### PR TITLE
Shorten home-screen app name to "LSH"

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-<meta name="apple-mobile-web-app-title" content="Second Hand">
+<meta name="apple-mobile-web-app-title" content="LSH">
 <title>Lviv Second Hand</title>
 <link rel="manifest" href="manifest.webmanifest">
 <link rel="icon" href="favicon.svg" type="image/svg+xml">

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
   "name": "Lviv Second Hand",
-  "short_name": "Second Hand",
+  "short_name": "LSH",
   "description": "Find and track second-hand clothing stores in Lviv — map, inventory cycle tracker, and price estimates.",
   "lang": "en",
   "dir": "ltr",


### PR DESCRIPTION
## What & why

On the home screen the app label was truncating to "Second H…" because "Second Hand" is too long for the space under the icon. This sets the short label to the initials **LSH** (Lviv Second Hand).

## Changes
- `manifest.webmanifest` — `short_name` changed from `"Second Hand"` to `"LSH"` (controls the Android home-screen label).
- `index.html` — `apple-mobile-web-app-title` meta changed from `"Second Hand"` to `"LSH"` (controls the iOS home-screen label).

The full **"Lviv Second Hand"** name is unchanged in the `<title>` and the manifest `name`, so the browser tab and Android install prompt still show the full name.

## Notes
- Assets/metadata only; no logic changes.
- Existing home-screen installs may keep the old label until the shortcut is removed and re-added (the OS caches the manifest at install time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_