### PR TITLE
Add a privacy policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ You can export every store on the map as a `.kml` file and import it straight in
 3. Select the downloaded `.kml` file
 4. All stores now appear as bookmarks on your Maps.me map, even offline
 
+## 🔒 Privacy
+
+No accounts, no ads, no tracking. Everything you do stays in your own browser on your own device — it's never sent to a server, and nothing leaves your phone unless you choose to share it. Full details: **[Privacy Policy](https://anonymouspartner.github.io/lviv-secondhand/privacy.html)** (also linked from the in-app **?** Help panel).
+
 ---
 
 # 🇺🇦 Lviv Second Hand — Пошук секонд-хендів
@@ -125,3 +129,7 @@ PWA (прогресивний веб-додаток) для пошуку та в
 2. Відкрийте Maps.me → **Закладки** → **Імпорт**
 3. Виберіть завантажений файл `.kml`
 4. Усі магазини з'являться як закладки на вашій карті Maps.me, навіть офлайн
+
+## 🔒 Конфіденційність
+
+Без облікових записів, реклами та стеження. Усе, що ви робите, залишається у вашому браузері на вашому пристрої — воно ніколи не надсилається на сервер і не залишає ваш телефон, доки ви самі не вирішите поділитися. Докладніше: **[Політика конфіденційності](https://anonymouspartner.github.io/lviv-secondhand/privacy.html)** (також доступна з панелі довідки **?** у застосунку).

--- a/index.html
+++ b/index.html
@@ -306,6 +306,9 @@ header { background: var(--green); color: white; padding: 14px 16px 12px; displa
       <p>Tap the <strong>📤</strong> button in the top-right to download a KML file with all store locations. In Maps.me: tap ☰ → Bookmarks → ⋮ → Import → select the file. All stores appear as bookmarks. Inside any store, tap <strong>📍 Maps.me</strong> to jump straight to that store on the Maps.me map. To add a new store you discover, long-press on the spot in Maps.me to drop a pin, then bookmark it.</p>
     </div>
     <button class="sheet-btn" onclick="document.getElementById('help-overlay').classList.add('hidden')">Got it!</button>
+    <p style="text-align:center;margin-top:14px;font-size:13px;color:var(--muted);">
+      <a href="privacy.html" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:underline;">🔒 Privacy Policy · Політика конфіденційності</a>
+    </p>
   </div>
 </div>
 

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="theme-color" content="#1b5e38">
+<title>Privacy Policy — Lviv Second Hand</title>
+<link rel="icon" href="favicon.svg" type="image/svg+xml">
+<link rel="icon" href="favicon-32.png" sizes="32x32" type="image/png">
+<link rel="apple-touch-icon" href="apple-touch-icon.png">
+<style>
+  :root{
+    --green:#1b5e38; --green2:#2d8653; --orange:#e86c2a;
+    --bg:#f2f4f6; --card:#ffffff; --text:#1a1a2e; --muted:#6b7280; --border:#e5e7eb;
+  }
+  *{box-sizing:border-box;margin:0;padding:0;}
+  body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:var(--bg);color:var(--text);font-size:16px;line-height:1.65;}
+  header{background:var(--green);color:#fff;padding:20px 20px 18px;}
+  header .wrap{max-width:760px;margin:0 auto;display:flex;align-items:center;gap:12px;}
+  header img{width:40px;height:40px;border-radius:10px;}
+  header h1{font-size:20px;font-weight:800;line-height:1.2;}
+  header a.back{color:#fff;opacity:.85;text-decoration:none;font-size:13px;font-weight:600;display:inline-block;margin-top:2px;}
+  header a.back:hover{opacity:1;text-decoration:underline;}
+  main{max-width:760px;margin:0 auto;padding:26px 20px 60px;}
+  .card{background:var(--card);border:1px solid var(--border);border-radius:16px;padding:22px 22px 8px;margin-bottom:22px;}
+  h2{font-size:20px;font-weight:800;color:var(--green);margin:26px 0 12px;padding-bottom:8px;border-bottom:2px solid var(--border);}
+  h2:first-child{margin-top:6px;}
+  h3{font-size:16px;font-weight:700;margin:18px 0 6px;}
+  p{margin:0 0 14px;}
+  ul{margin:0 0 14px 22px;}
+  li{margin-bottom:7px;}
+  strong{font-weight:700;}
+  a{color:var(--orange);font-weight:600;}
+  .tldr{background:var(--green);color:#fff;border-radius:16px;padding:20px 22px;margin-bottom:24px;}
+  .tldr h2{color:#fff;border:none;margin:0 0 8px;padding:0;font-size:18px;}
+  .tldr p{margin-bottom:0;opacity:.95;}
+  .meta{color:var(--muted);font-size:13px;margin-bottom:20px;}
+  .lang-divider{text-align:center;color:var(--muted);font-size:13px;font-weight:700;letter-spacing:1px;text-transform:uppercase;margin:38px 0 8px;}
+  footer{max-width:760px;margin:0 auto;padding:0 20px 50px;color:var(--muted);font-size:13px;text-align:center;}
+</style>
+</head>
+<body>
+<header>
+  <div class="wrap">
+    <img src="icon-192.png" alt="Lviv Second Hand icon">
+    <div>
+      <h1>Privacy Policy</h1>
+      <a class="back" href="./">← Back to the app</a>
+    </div>
+  </div>
+</header>
+
+<main>
+  <!-- ══════════ ENGLISH ══════════ -->
+  <p class="meta">Lviv Second Hand · Last updated: 19 July 2026</p>
+
+  <div class="tldr">
+    <h2>The short version</h2>
+    <p>Lviv Second Hand has no accounts, no ads, and no tracking. Everything you do — the stores you add, the edits you make, the places you mark as visited — is stored only in your own browser on your own device. We never see it, and it never leaves your phone unless <em>you</em> choose to share it.</p>
+  </div>
+
+  <div class="card">
+    <h2>1. Who we are</h2>
+    <p>Lviv Second Hand is a free, open-source Progressive Web App (PWA) for finding and tracking second-hand clothing stores in Lviv, Ukraine. It is a static website with no back-end server and no database. The app runs entirely inside your web browser.</p>
+
+    <h2>2. What data we collect</h2>
+    <p><strong>We do not collect any personal data.</strong> There is no sign-up, no login, and no analytics. We do not use cookies for tracking.</p>
+    <p>The app saves the following on your device only, using your browser's <strong>local storage</strong>:</p>
+    <ul>
+      <li>Stores you mark as <strong>visited</strong>, and the delivery dates you record for the inventory tracker</li>
+      <li>Stores you <strong>add</strong> to the map, and any <strong>edits</strong> you make to existing stores</li>
+      <li>Your <strong>language</strong> preference (English or Ukrainian) and whether you've seen the welcome screen</li>
+    </ul>
+    <p>This information stays in your browser. It is not transmitted to us or anyone else, and we have no way to read it.</p>
+
+    <h2>3. How your data is used</h2>
+    <p>Your saved data is used only to make the app work for you — to remember your visits, your added stores, and your settings the next time you open the app. That's it.</p>
+
+    <h2>4. Sharing features</h2>
+    <p>The app lets you share the stores you've added or edited. These features are entirely optional and only ever run when you choose them:</p>
+    <ul>
+      <li><strong>Share link / file / code</strong> — creates a link, file, or code containing the stores you added and edited. If you send it to someone, you are choosing to share that information with them. Nothing is uploaded to us; the data travels only through whatever channel you use to send it.</li>
+      <li><strong>Contribute to the official map</strong> — opens GitHub with a pre-filled submission so a maintainer can add your stores to the shared map. Anything you post there becomes public and is governed by <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener">GitHub's privacy statement</a>. Only submit information you're comfortable making public.</li>
+      <li><strong>Export to Maps.me (KML)</strong> — generates a file on your device that you can import into the Maps.me app. The file is created locally; we don't receive it.</li>
+    </ul>
+
+    <h2>5. Third-party services</h2>
+    <p>To display the app and its map, your browser connects to a few third parties. Like any website visit, these connections reveal your device's IP address and basic technical details to those providers. We do not control their data practices:</p>
+    <ul>
+      <li><strong>GitHub Pages</strong> — hosts the website. See <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener">GitHub's privacy statement</a>.</li>
+      <li><strong>OpenStreetMap</strong> — provides the map tiles shown on the Map tab. See the <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy" target="_blank" rel="noopener">OpenStreetMap Foundation privacy policy</a>.</li>
+      <li><strong>unpkg</strong> — a content-delivery network that serves the Leaflet mapping library used to draw the map.</li>
+    </ul>
+    <p>No advertising, analytics, or tracking services are used.</p>
+
+    <h2>6. Your control over your data</h2>
+    <p>Because your data lives in your browser, you are always in full control of it:</p>
+    <ul>
+      <li>Remove individual added stores, or unmark visits, directly in the app.</li>
+      <li>Clear everything at any time by clearing this site's data in your browser settings, or by uninstalling the app from your home screen.</li>
+    </ul>
+    <p>Once cleared, the data is gone — we keep no copy.</p>
+
+    <h2>7. Children's privacy</h2>
+    <p>The app is a general-audience utility and does not knowingly collect any information from anyone, including children.</p>
+
+    <h2>8. Changes to this policy</h2>
+    <p>If this policy changes, the "Last updated" date at the top will change with it. Significant changes will be reflected in the app and in the project's public repository.</p>
+
+    <h2>9. Contact</h2>
+    <p>Questions about privacy? Please open an issue on our GitHub repository:<br>
+    <a href="https://github.com/anonymouspartner/lviv-secondhand/issues" target="_blank" rel="noopener">github.com/anonymouspartner/lviv-secondhand/issues</a></p>
+  </div>
+
+  <!-- ══════════ УКРАЇНСЬКА ══════════ -->
+  <div class="lang-divider">— Українською —</div>
+  <p class="meta">Lviv Second Hand · Останнє оновлення: 19 липня 2026</p>
+
+  <div class="tldr">
+    <h2>Коротко</h2>
+    <p>Lviv Second Hand не має облікових записів, реклами чи стеження. Усе, що ви робите — магазини, які додаєте, зміни, які вносите, місця, які позначаєте як відвідані — зберігається лише у вашому браузері на вашому пристрої. Ми цього не бачимо, і воно не залишає ваш телефон, доки <em>ви</em> самі не вирішите поділитися.</p>
+  </div>
+
+  <div class="card">
+    <h2>1. Хто ми</h2>
+    <p>Lviv Second Hand — це безкоштовний прогресивний веб-додаток (PWA) з відкритим кодом для пошуку та відстеження магазинів секонд-хенду у Львові. Це статичний сайт без сервера та без бази даних. Додаток працює повністю у вашому браузері.</p>
+
+    <h2>2. Які дані ми збираємо</h2>
+    <p><strong>Ми не збираємо жодних персональних даних.</strong> Немає реєстрації, входу чи аналітики. Ми не використовуємо файли cookie для стеження.</p>
+    <p>Додаток зберігає наведене нижче лише на вашому пристрої, у <strong>локальному сховищі</strong> браузера:</p>
+    <ul>
+      <li>Магазини, які ви позначили як <strong>відвідані</strong>, та дати поставок, які ви вказали для трекера товарів</li>
+      <li>Магазини, які ви <strong>додали</strong> на карту, та будь-які <strong>зміни</strong> до наявних магазинів</li>
+      <li>Вашу <strong>мову</strong> (англійська чи українська) та чи бачили ви вітальний екран</li>
+    </ul>
+    <p>Ця інформація залишається у вашому браузері. Вона не передається ні нам, ні комусь іншому, і ми не маємо доступу до неї.</p>
+
+    <h2>3. Як використовуються ваші дані</h2>
+    <p>Ваші збережені дані використовуються лише для роботи додатка — щоб запам'ятати ваші відвідування, додані магазини та налаштування наступного разу, коли ви відкриєте додаток. Це все.</p>
+
+    <h2>4. Функції обміну</h2>
+    <p>Додаток дозволяє поділитися магазинами, які ви додали чи змінили. Ці функції повністю необов'язкові й виконуються лише тоді, коли ви їх обираєте:</p>
+    <ul>
+      <li><strong>Посилання / файл / код для обміну</strong> — створює посилання, файл або код із магазинами, які ви додали та змінили. Якщо ви надішлете його комусь, ви самі вирішуєте поділитися цією інформацією. Нічого не завантажується до нас; дані йдуть лише через той канал, який ви оберете.</li>
+      <li><strong>Внесок до офіційної карти</strong> — відкриває GitHub із попередньо заповненою формою, щоб супровідник додав ваші магазини до спільної карти. Усе, що ви там публікуєте, стає публічним і регулюється <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener">заявою про конфіденційність GitHub</a>. Надсилайте лише ту інформацію, яку готові зробити публічною.</li>
+      <li><strong>Експорт у Maps.me (KML)</strong> — створює файл на вашому пристрої, який можна імпортувати в додаток Maps.me. Файл створюється локально; ми його не отримуємо.</li>
+    </ul>
+
+    <h2>5. Сторонні сервіси</h2>
+    <p>Щоб показати додаток і карту, ваш браузер з'єднується з кількома сторонніми сервісами. Як і за будь-якого відвідування сайту, ці з'єднання розкривають IP-адресу вашого пристрою та базові технічні дані цим постачальникам. Ми не контролюємо їхні практики щодо даних:</p>
+    <ul>
+      <li><strong>GitHub Pages</strong> — хостинг сайту. Див. <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener">заяву про конфіденційність GitHub</a>.</li>
+      <li><strong>OpenStreetMap</strong> — надає плитки карти на вкладці «Карта». Див. <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy" target="_blank" rel="noopener">політику конфіденційності OpenStreetMap Foundation</a>.</li>
+      <li><strong>unpkg</strong> — мережа доставки вмісту (CDN), що надає бібліотеку карт Leaflet.</li>
+    </ul>
+    <p>Жодні рекламні сервіси, аналітика чи інструменти стеження не використовуються.</p>
+
+    <h2>6. Ваш контроль над даними</h2>
+    <p>Оскільки ваші дані зберігаються у вашому браузері, ви завжди повністю ними керуєте:</p>
+    <ul>
+      <li>Видаляйте окремі додані магазини або знімайте позначки відвідування прямо в додатку.</li>
+      <li>Очистіть усе будь-коли, видаливши дані цього сайту в налаштуваннях браузера або видаливши додаток з головного екрана.</li>
+    </ul>
+    <p>Після очищення дані зникають — ми не зберігаємо жодної копії.</p>
+
+    <h2>7. Конфіденційність дітей</h2>
+    <p>Додаток є утилітою для широкої аудиторії й свідомо не збирає жодної інформації ні від кого, зокрема від дітей.</p>
+
+    <h2>8. Зміни до цієї політики</h2>
+    <p>Якщо ця політика зміниться, дата «Останнє оновлення» вгорі також зміниться. Суттєві зміни буде відображено в додатку та в публічному репозиторії проєкту.</p>
+
+    <h2>9. Контакти</h2>
+    <p>Питання щодо конфіденційності? Будь ласка, створіть звернення в нашому репозиторії GitHub:<br>
+    <a href="https://github.com/anonymouspartner/lviv-secondhand/issues" target="_blank" rel="noopener">github.com/anonymouspartner/lviv-secondhand/issues</a></p>
+  </div>
+</main>
+
+<footer>
+  🧥 Lviv Second Hand — a free, open-source community project.
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## What & why

The app had no privacy policy. This adds a clear, honest one that matches how the app actually behaves — no accounts, no tracking, no analytics, everything stored locally in the browser.

## Changes
- **`privacy.html`** — a standalone, bilingual (EN/UA) policy page styled to match the app (green header, hanger icon, "short version" summary). It covers:
  - No personal data collected; no sign-up, cookies, or analytics
  - Exactly what's kept in local storage (visits, delivery dates, added/edited stores, language/welcome flags) and that it never leaves the device
  - The optional sharing features (share link/file/code, GitHub contribution, Maps.me export) and what disclosing each one means
  - Third parties a page load necessarily contacts — GitHub Pages (hosting), OpenStreetMap (map tiles), unpkg (Leaflet CDN) — with links to their policies
  - How users can clear their data, children's privacy, policy changes
  - Contact via the repo's **GitHub Issues**
- **`index.html`** — a "🔒 Privacy Policy · Політика конфіденційності" link added to the bottom of the in-app **?** Help panel (opens in a new tab).
- **`README.md`** — a short Privacy section (EN + UA) linking to the policy.

## Notes
- All paths are relative, so the page and its icons resolve under the GitHub Pages subpath.
- Contact is the GitHub issue tracker (no personal email published), per the choice made when requesting this.
- Verified with a local server + headless browser: `privacy.html` loads `200` with both language sections and the contact link, the in-app Help link points to it, header icon loads, and no JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_