### PR TITLE
Add "show my location" button to the map

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,6 +209,12 @@ header { background: var(--green); color: white; padding: 14px 16px 12px; displa
 .share-action.share-primary { width: 100%; flex: 1 1 100%; background: var(--orange); border-color: var(--orange); color: #fff; }
 .share-action.share-primary:hover { filter: brightness(1.05); }
 
+/* ── USER LOCATION ── */
+.user-loc-dot { width: 16px; height: 16px; border-radius: 50%; background: #2471a3; border: 3px solid #fff; box-shadow: 0 1px 4px rgba(0,0,0,0.45); position: relative; }
+.user-loc-dot::after { content: ''; position: absolute; top: 50%; left: 50%; width: 16px; height: 16px; border-radius: 50%; background: rgba(36,113,163,0.45); transform: translate(-50%,-50%); animation: locpulse 2s ease-out infinite; }
+@keyframes locpulse { 0% { transform: translate(-50%,-50%) scale(1); opacity: 0.6; } 100% { transform: translate(-50%,-50%) scale(3.6); opacity: 0; } }
+#map-locate-btn:disabled { opacity: 0.7; cursor: default; }
+
 /* ── POPUP ── */
 .leaflet-popup-content-wrapper { border-radius: 14px; }
 .popup-name { font-weight: 800; font-size: 14px; margin-bottom: 4px; }
@@ -277,6 +283,7 @@ header { background: var(--green); color: white; padding: 14px 16px 12px; displa
     <div class="help-section">
       <h3>🗺️ The Map</h3>
       <p>Shows all store locations as pins. <strong>Red pins</strong> = HUMANA. <strong>Blue pins</strong> = others. A ✓ on a pin means you've visited. Tap any pin to see a summary, then tap "View Details".</p>
+      <p style="margin-top:8px;">Tap the <strong>📍</strong> button (bottom-right) to show <strong>your location</strong> on the map as a blue dot. Your browser will ask for permission the first time.</p>
     </div>
     <div class="help-section">
       <h3>📦 Inventory Tracker</h3>
@@ -505,6 +512,7 @@ header { background: var(--green); color: white; padding: 14px 16px 12px; displa
 
   <div class="view hidden" id="map-view" style="overflow:hidden;">
     <div id="map"></div>
+    <button onclick="locateUser()" id="map-locate-btn" style="position:fixed;bottom:84px;right:16px;z-index:999;width:54px;height:54px;border-radius:50%;background:white;color:var(--green);border:none;font-size:24px;box-shadow:0 4px 14px rgba(0,0,0,0.3);cursor:pointer;align-items:center;justify-content:center;line-height:1;" title="Show my location">📍</button>
     <button onclick="startAddPin()" id="map-add-btn" style="position:fixed;bottom:20px;right:16px;z-index:999;width:54px;height:54px;border-radius:50%;background:var(--orange);color:white;border:none;font-size:28px;font-weight:900;box-shadow:0 4px 14px rgba(0,0,0,0.3);cursor:pointer;align-items:center;justify-content:center;line-height:1;" title="Add a new store — tap the map to pin location">+</button>
     <div id="map-tap-hint" style="position:fixed;top:120px;left:50%;transform:translateX(-50%);background:rgba(0,0,0,0.72);color:white;padding:7px 14px;border-radius:20px;font-size:13px;font-weight:600;z-index:999;display:none;pointer-events:none;">📍 Tap map to set location</div>
   </div>
@@ -521,8 +529,8 @@ header { background: var(--green); color: white; padding: 14px 16px 12px; displa
 // ─────────────────────────────────────────────
 let lang = localStorage.getItem('lviv_sh_lang') || 'en';
 const TR = {
-  en:{tabList:'List',tabMap:'Map',fAll:'All Stores',fKg:'⚖️ By KG',fItem:'🏷️ Itemized',fVisited:'✅ Visited',fUnvisited:'🔲 Not Yet',tipStrong:'👋 Tap any store to see full details, hours, and the inventory tracker.',tipSub:"Use the filter buttons above to find exactly what you're looking for. Scroll the filters sideways to see all options.",statsVisited:'stores visited',statsAdded:'added by you',backBtn:'← Back to list',step1:'📍 Step 1 — Have you visited this store?',step2:'📦 Step 2 — Inventory & Price Tracker',markVisited:'📍 Mark as Visited',unmarkVisited:'✅ Visited — tap to unmark',visitSaved:'Your visit history is saved automatically on this device.',setDel:'📅 Set Last Delivery Date',updDel:'🔄 Update Delivery Date',noDelivery:'No delivery date set yet for this store.',storeInfo:'ℹ️ Store Information',addrLbl:'Address',phoneLbl:'Phone',notesLbl:'Notes',hoursLbl:'Opening Hours',removeStore:'🗑️ Remove this store',addedByYou:'📍 Added by you',byKg:'⚖️ By KG',byWeight:'⚖️ By Weight',itemized:'🏷️ Itemized pricing',closedToday:'🔒 Closed today',closedDay:'🔒 Closed',viewDetails:'View Details →',freshToday:'🎉 Fresh today! New stock just arrived',freshLabel:'✅ Fresh stock — prices still high',midLabel:'🟡 Mid-cycle — good selection',oldLabel:'🔥 Late cycle — BEST deals now!',dayLabel:'Day',delivery:'📦 Delivery',endCycle:'🏷️ End of cycle',todayPrice:"Today's price per KG",estDiscount:'Estimated discount vs. delivery day',cycleDay:'-day cycle · prices drop daily',off:'off',inventory:'Inventory cycle',humanaTag:'HUMANA',visitedTag:'Visited',editStore:'Edit Store',saveEdit:'Save Changes',editName:'Store name',editAddrEn:'Address (English)',editAddrUa:'Address (Ukrainian)',editPhone:'Phone',editPricing:'Pricing type',editCycle:'Inventory cycle',editNotes:'Notes',shareTitle:'Share & Contribute',shareIntro:'Stores you add or edit are saved on this device. Share them with friends, or contribute them to the official map so everyone gets them.',shareYoursHdr:'📤 Share your map',shareYoursHint:'Send your added & edited stores to anyone. They open the link (or import the file) and your stores appear on their map.',shareCopyLink:'🔗 Copy share link',shareDownload:'💾 Download file',shareShowCode:'🔡 Show code',shareContribHdr:'🌍 Contribute to the official map',shareContribHint:'Submit your additions & corrections so the maintainer can merge them into the map everyone downloads. Opens a pre-filled GitHub form (a free GitHub account is required to post).',shareContribBtn:'🚀 Submit on GitHub',shareImportHdr:'📥 Import from others',shareImportHint:'Got a share link, code, or file from someone? Paste the code below or load their file — their stores merge into yours (duplicates are skipped).',shareImportBtn:'📥 Import code',shareLoadFile:'📂 Load file…',sharePastePlaceholder:'Paste a share code here…',shareDone:'Done',shareNothing:"You haven't added or edited any stores yet. Add a store from the Map tab, then come back here to share it.",shareYouHave:'You have {added} store(s) added and {edited} correction(s) to share.',shareLinkCopied:'Share link copied to clipboard! Send it to anyone — opening it adds your stores to their map.',shareImportError:"Sorry, that doesn't look like a valid Lviv Second Hand share code or file.",shareImportDone:'Import complete!\n\n➕ {added} store(s) added\n✏️ {edited} correction(s) applied\n⏭️ {skipped} skipped (duplicates or already edited)',shareIncoming:'This link contains a shared map: {added} store(s) added and {edited} correction(s).\n\nImport them onto your map?'},
-  ua:{tabList:'Список',tabMap:'Карта',fAll:'Всі магазини',fKg:'⚖️ На вагу',fItem:'🏷️ По штуці',fVisited:'✅ Відвідані',fUnvisited:'🔲 Ще ні',tipStrong:'👋 Натисніть на магазин, щоб побачити деталі, години та трекер.',tipSub:'Використовуйте кнопки фільтрів. Проведіть пальцем, щоб побачити всі.',statsVisited:'магазинів відвідано',statsAdded:'додано вами',backBtn:'← Назад',step1:'📍 Крок 1 — Ви відвідали цей магазин?',step2:'📦 Крок 2 — Трекер товарів і цін',markVisited:'📍 Відмітити як відвідане',unmarkVisited:'✅ Відвідано — натисніть, щоб зняти',visitSaved:'Історія відвідувань зберігається на цьому пристрої.',setDel:'📅 Встановити дату поставки',updDel:'🔄 Оновити дату поставки',noDelivery:'Дата поставки ще не вказана.',storeInfo:'ℹ️ Інформація про магазин',addrLbl:'Адреса',phoneLbl:'Телефон',notesLbl:'Примітки',hoursLbl:'Години роботи',removeStore:'🗑️ Видалити магазин',addedByYou:'📍 Додано вами',byKg:'⚖️ На вагу',byWeight:'⚖️ На вагу',itemized:'🏷️ По штуці',closedToday:'🔒 Зачинено сьогодні',closedDay:'🔒 Зачинено',viewDetails:'Деталі →',freshToday:'🎉 Щойно! Нові товари сьогодні',freshLabel:'✅ Свіжі товари — ціни ще високі',midLabel:'🟡 Середина циклу — хороший вибір',oldLabel:'🔥 Кінець циклу — НАЙКРАЩІ ціни!',dayLabel:'День',delivery:'📦 Поставка',endCycle:'🏷️ Кінець циклу',todayPrice:'Ціна сьогодні за кг',estDiscount:'Орієнтовна знижка від поставки',cycleDay:'-денний цикл · ціни знижуються щодня',off:'знижки',inventory:'Цикл поставок',humanaTag:'HUMANA',visitedTag:'Відвідано',editStore:'Редагувати',saveEdit:'Зберегти зміни',editName:'Назва магазину',editAddrEn:'Адреса (англ.)',editAddrUa:'Адреса (укр.)',editPhone:'Телефон',editPricing:'Тип цін',editCycle:'Цикл поставок',editNotes:'Нотатки',shareTitle:'Поділитися та зробити внесок',shareIntro:'Магазини, які ви додали чи відредагували, зберігаються на цьому пристрої. Поділіться ними з друзями або внесіть їх до офіційної карти, щоб їх отримали всі.',shareYoursHdr:'📤 Поділитися картою',shareYoursHint:'Надішліть свої додані та змінені магазини будь-кому. Вони відкривають посилання (або імпортують файл) — і ваші магазини з’являються на їхній карті.',shareCopyLink:'🔗 Копіювати посилання',shareDownload:'💾 Завантажити файл',shareShowCode:'🔡 Показати код',shareContribHdr:'🌍 Внести до офіційної карти',shareContribHint:'Надішліть свої доповнення та виправлення, щоб супровідник додав їх до карти, яку завантажують усі. Відкриється попередньо заповнена форма GitHub (для публікації потрібен безкоштовний акаунт GitHub).',shareContribBtn:'🚀 Надіслати на GitHub',shareImportHdr:'📥 Імпорт від інших',shareImportHint:'Отримали посилання, код чи файл від когось? Вставте код нижче або завантажте файл — їхні магазини додадуться до ваших (дублікати пропускаються).',shareImportBtn:'📥 Імпортувати код',shareLoadFile:'📂 Завантажити файл…',sharePastePlaceholder:'Вставте код для обміну сюди…',shareDone:'Готово',shareNothing:'Ви ще не додали й не редагували жодного магазину. Додайте магазин на вкладці «Карта», а потім поверніться сюди, щоб поділитися.',shareYouHave:'У вас є {added} доданих магазинів і {edited} виправлень для обміну.',shareLinkCopied:'Посилання скопійовано! Надішліть його будь-кому — відкривши його, вони додадуть ваші магазини на свою карту.',shareImportError:'Вибачте, це не схоже на дійсний код або файл Lviv Second Hand.',shareImportDone:'Імпорт завершено!\n\n➕ Додано магазинів: {added}\n✏️ Застосовано виправлень: {edited}\n⏭️ Пропущено: {skipped} (дублікати або вже змінені)',shareIncoming:'Це посилання містить спільну карту: {added} доданих магазинів і {edited} виправлень.\n\nІмпортувати їх на вашу карту?'}
+  en:{tabList:'List',tabMap:'Map',fAll:'All Stores',fKg:'⚖️ By KG',fItem:'🏷️ Itemized',fVisited:'✅ Visited',fUnvisited:'🔲 Not Yet',tipStrong:'👋 Tap any store to see full details, hours, and the inventory tracker.',tipSub:"Use the filter buttons above to find exactly what you're looking for. Scroll the filters sideways to see all options.",statsVisited:'stores visited',statsAdded:'added by you',backBtn:'← Back to list',step1:'📍 Step 1 — Have you visited this store?',step2:'📦 Step 2 — Inventory & Price Tracker',markVisited:'📍 Mark as Visited',unmarkVisited:'✅ Visited — tap to unmark',visitSaved:'Your visit history is saved automatically on this device.',setDel:'📅 Set Last Delivery Date',updDel:'🔄 Update Delivery Date',noDelivery:'No delivery date set yet for this store.',storeInfo:'ℹ️ Store Information',addrLbl:'Address',phoneLbl:'Phone',notesLbl:'Notes',hoursLbl:'Opening Hours',removeStore:'🗑️ Remove this store',addedByYou:'📍 Added by you',byKg:'⚖️ By KG',byWeight:'⚖️ By Weight',itemized:'🏷️ Itemized pricing',closedToday:'🔒 Closed today',closedDay:'🔒 Closed',viewDetails:'View Details →',freshToday:'🎉 Fresh today! New stock just arrived',freshLabel:'✅ Fresh stock — prices still high',midLabel:'🟡 Mid-cycle — good selection',oldLabel:'🔥 Late cycle — BEST deals now!',dayLabel:'Day',delivery:'📦 Delivery',endCycle:'🏷️ End of cycle',todayPrice:"Today's price per KG",estDiscount:'Estimated discount vs. delivery day',cycleDay:'-day cycle · prices drop daily',off:'off',inventory:'Inventory cycle',humanaTag:'HUMANA',visitedTag:'Visited',editStore:'Edit Store',saveEdit:'Save Changes',editName:'Store name',editAddrEn:'Address (English)',editAddrUa:'Address (Ukrainian)',editPhone:'Phone',editPricing:'Pricing type',editCycle:'Inventory cycle',editNotes:'Notes',shareTitle:'Share & Contribute',shareIntro:'Stores you add or edit are saved on this device. Share them with friends, or contribute them to the official map so everyone gets them.',shareYoursHdr:'📤 Share your map',shareYoursHint:'Send your added & edited stores to anyone. They open the link (or import the file) and your stores appear on their map.',shareCopyLink:'🔗 Copy share link',shareDownload:'💾 Download file',shareShowCode:'🔡 Show code',shareContribHdr:'🌍 Contribute to the official map',shareContribHint:'Submit your additions & corrections so the maintainer can merge them into the map everyone downloads. Opens a pre-filled GitHub form (a free GitHub account is required to post).',shareContribBtn:'🚀 Submit on GitHub',shareImportHdr:'📥 Import from others',shareImportHint:'Got a share link, code, or file from someone? Paste the code below or load their file — their stores merge into yours (duplicates are skipped).',shareImportBtn:'📥 Import code',shareLoadFile:'📂 Load file…',sharePastePlaceholder:'Paste a share code here…',shareDone:'Done',shareNothing:"You haven't added or edited any stores yet. Add a store from the Map tab, then come back here to share it.",shareYouHave:'You have {added} store(s) added and {edited} correction(s) to share.',shareLinkCopied:'Share link copied to clipboard! Send it to anyone — opening it adds your stores to their map.',shareImportError:"Sorry, that doesn't look like a valid Lviv Second Hand share code or file.",shareImportDone:'Import complete!\n\n➕ {added} store(s) added\n✏️ {edited} correction(s) applied\n⏭️ {skipped} skipped (duplicates or already edited)',shareIncoming:'This link contains a shared map: {added} store(s) added and {edited} correction(s).\n\nImport them onto your map?',locYouAreHere:'📍 You are here',locDenied:'Location access is blocked. To see yourself on the map, allow location for this site in your browser settings, then tap 📍 again.',locUnavailable:"Couldn't get your location. Make sure location services are on and try again.",locUnsupported:'Your browser does not support location.'},
+  ua:{tabList:'Список',tabMap:'Карта',fAll:'Всі магазини',fKg:'⚖️ На вагу',fItem:'🏷️ По штуці',fVisited:'✅ Відвідані',fUnvisited:'🔲 Ще ні',tipStrong:'👋 Натисніть на магазин, щоб побачити деталі, години та трекер.',tipSub:'Використовуйте кнопки фільтрів. Проведіть пальцем, щоб побачити всі.',statsVisited:'магазинів відвідано',statsAdded:'додано вами',backBtn:'← Назад',step1:'📍 Крок 1 — Ви відвідали цей магазин?',step2:'📦 Крок 2 — Трекер товарів і цін',markVisited:'📍 Відмітити як відвідане',unmarkVisited:'✅ Відвідано — натисніть, щоб зняти',visitSaved:'Історія відвідувань зберігається на цьому пристрої.',setDel:'📅 Встановити дату поставки',updDel:'🔄 Оновити дату поставки',noDelivery:'Дата поставки ще не вказана.',storeInfo:'ℹ️ Інформація про магазин',addrLbl:'Адреса',phoneLbl:'Телефон',notesLbl:'Примітки',hoursLbl:'Години роботи',removeStore:'🗑️ Видалити магазин',addedByYou:'📍 Додано вами',byKg:'⚖️ На вагу',byWeight:'⚖️ На вагу',itemized:'🏷️ По штуці',closedToday:'🔒 Зачинено сьогодні',closedDay:'🔒 Зачинено',viewDetails:'Деталі →',freshToday:'🎉 Щойно! Нові товари сьогодні',freshLabel:'✅ Свіжі товари — ціни ще високі',midLabel:'🟡 Середина циклу — хороший вибір',oldLabel:'🔥 Кінець циклу — НАЙКРАЩІ ціни!',dayLabel:'День',delivery:'📦 Поставка',endCycle:'🏷️ Кінець циклу',todayPrice:'Ціна сьогодні за кг',estDiscount:'Орієнтовна знижка від поставки',cycleDay:'-денний цикл · ціни знижуються щодня',off:'знижки',inventory:'Цикл поставок',humanaTag:'HUMANA',visitedTag:'Відвідано',editStore:'Редагувати',saveEdit:'Зберегти зміни',editName:'Назва магазину',editAddrEn:'Адреса (англ.)',editAddrUa:'Адреса (укр.)',editPhone:'Телефон',editPricing:'Тип цін',editCycle:'Цикл поставок',editNotes:'Нотатки',shareTitle:'Поділитися та зробити внесок',shareIntro:'Магазини, які ви додали чи відредагували, зберігаються на цьому пристрої. Поділіться ними з друзями або внесіть їх до офіційної карти, щоб їх отримали всі.',shareYoursHdr:'📤 Поділитися картою',shareYoursHint:'Надішліть свої додані та змінені магазини будь-кому. Вони відкривають посилання (або імпортують файл) — і ваші магазини з’являються на їхній карті.',shareCopyLink:'🔗 Копіювати посилання',shareDownload:'💾 Завантажити файл',shareShowCode:'🔡 Показати код',shareContribHdr:'🌍 Внести до офіційної карти',shareContribHint:'Надішліть свої доповнення та виправлення, щоб супровідник додав їх до карти, яку завантажують усі. Відкриється попередньо заповнена форма GitHub (для публікації потрібен безкоштовний акаунт GitHub).',shareContribBtn:'🚀 Надіслати на GitHub',shareImportHdr:'📥 Імпорт від інших',shareImportHint:'Отримали посилання, код чи файл від когось? Вставте код нижче або завантажте файл — їхні магазини додадуться до ваших (дублікати пропускаються).',shareImportBtn:'📥 Імпортувати код',shareLoadFile:'📂 Завантажити файл…',sharePastePlaceholder:'Вставте код для обміну сюди…',shareDone:'Готово',shareNothing:'Ви ще не додали й не редагували жодного магазину. Додайте магазин на вкладці «Карта», а потім поверніться сюди, щоб поділитися.',shareYouHave:'У вас є {added} доданих магазинів і {edited} виправлень для обміну.',shareLinkCopied:'Посилання скопійовано! Надішліть його будь-кому — відкривши його, вони додадуть ваші магазини на свою карту.',shareImportError:'Вибачте, це не схоже на дійсний код або файл Lviv Second Hand.',shareImportDone:'Імпорт завершено!\n\n➕ Додано магазинів: {added}\n✏️ Застосовано виправлень: {edited}\n⏭️ Пропущено: {skipped} (дублікати або вже змінені)',shareIncoming:'Це посилання містить спільну карту: {added} доданих магазинів і {edited} виправлень.\n\nІмпортувати їх на вашу карту?',locYouAreHere:'📍 Ви тут',locDenied:'Доступ до місцезнаходження заблоковано. Щоб побачити себе на карті, дозвольте доступ до геолокації для цього сайту в налаштуваннях браузера, а потім знову натисніть 📍.',locUnavailable:'Не вдалося визначити місцезнаходження. Переконайтеся, що геолокацію ввімкнено, і спробуйте ще раз.',locUnsupported:'Ваш браузер не підтримує геолокацію.'}
 };
 function t(k){return(TR[lang]||TR.en)[k]||k;}
 function setLang(l){
@@ -877,6 +885,8 @@ function switchTab(tab) {
   document.getElementById(`${tab}-view`).classList.remove('hidden');
   const fab = document.getElementById('map-add-btn');
   if (fab) fab.style.display = tab === 'map' ? 'flex' : 'none';
+  const locBtn = document.getElementById('map-locate-btn');
+  if (locBtn) locBtn.style.display = tab === 'map' ? 'flex' : 'none';
   if (tab === 'map' && !mapInst) initMap();
   if (tab === 'map' && mapInst) { setTimeout(()=>mapInst.invalidateSize(),150); renderPins(); }
 }
@@ -886,6 +896,9 @@ function switchTab(tab) {
 // ─────────────────────────────────────────────
 let addingPin = false;
 let tempMarker = null;
+let userLocMarker = null;
+let userLocCircle = null;
+let locating = false;
 
 function initMap() {
   mapInst = L.map('map').setView([49.835, 24.025], 13);
@@ -900,7 +913,49 @@ function initMap() {
     tempMarker = L.marker([e.latlng.lat, e.latlng.lng]).addTo(mapInst).bindPopup('New store location').openPopup();
     openAddStoreModal(e.latlng.lat, e.latlng.lng);
   });
+
+  // Geolocation ("show my location")
+  mapInst.on('locationfound', onLocationFound);
+  mapInst.on('locationerror', onLocationError);
+
   renderPins();
+}
+
+function locateUser() {
+  if (!mapInst) return;
+  if (!('geolocation' in navigator)) { alert(t('locUnsupported')); return; }
+  const btn = document.getElementById('map-locate-btn');
+  if (locating) return;
+  locating = true;
+  if (btn) { btn.textContent = '⏳'; btn.disabled = true; }
+  mapInst.locate({ setView: true, maxZoom: 16, enableHighAccuracy: true, timeout: 10000 });
+}
+
+function resetLocateBtn() {
+  locating = false;
+  const btn = document.getElementById('map-locate-btn');
+  if (btn) { btn.textContent = '📍'; btn.disabled = false; }
+}
+
+function onLocationFound(e) {
+  resetLocateBtn();
+  const radius = Math.max(e.accuracy || 0, 5);
+  const dot = L.divIcon({
+    className: '',
+    html: '<div class="user-loc-dot"></div>',
+    iconSize: [22, 22], iconAnchor: [11, 11]
+  });
+  if (userLocMarker) userLocMarker.setLatLng(e.latlng); else userLocMarker = L.marker(e.latlng, { icon: dot, zIndexOffset: 1000, interactive: true }).addTo(mapInst);
+  userLocMarker.bindPopup(t('locYouAreHere'));
+  if (userLocCircle) userLocCircle.setLatLng(e.latlng).setRadius(radius);
+  else userLocCircle = L.circle(e.latlng, { radius: radius, color: '#2471a3', fillColor: '#2471a3', fillOpacity: 0.12, weight: 1 }).addTo(mapInst);
+}
+
+function onLocationError(e) {
+  resetLocateBtn();
+  // code 1 = permission denied; others = position unavailable / timeout
+  const denied = e && (e.code === 1 || /denied|permission/i.test(e.message || ''));
+  alert(denied ? t('locDenied') : t('locUnavailable'));
 }
 
 function startAddPin() {


### PR DESCRIPTION
## What & why

Requested feature: let users see where they are on the map. Adds a **📍 button** on the Map tab that finds the user's current position and shows it.

## How it works
- New round **📍 button** above the existing **+** button (bottom-right of the Map tab). Shown/hidden together with the Map tab.
- Tapping it uses Leaflet's geolocation (`map.locate`) to center + zoom the map on the user and drop a **pulsing blue "you are here" dot** with a translucent **accuracy circle**. Re-tapping updates the position.
- While locating, the button shows a ⏳ state and is disabled; it resets to 📍 when done.
- The browser asks for location permission the first time (nothing is stored or sent anywhere — the position stays in the page).

## Error handling
- **Permission denied** → a clear message explaining how to re-enable location, rather than failing silently.
- **Position unavailable / timeout** (10s) → a "couldn't get your location" message.
- **Unsupported browser** → a graceful notice.

## i18n & docs
- EN/UA strings for the "you are here" popup and all three error cases, matching the existing translation system.
- Added a note to the **?** Help panel's Map section.

## Testing
- JS syntax-checked.
- Headless-browser tests with a geolocation-mocked context: granted case places the marker + accuracy circle at the correct coordinates and resets the button; the denied (code 1) and unavailable (code 2) cases show the right EN/UA messages and reset the button. No JS errors.
- Note: the live Leaflet map render couldn't be exercised in the sandbox (the unpkg CDN is network-blocked here), but the feature uses standard, documented Leaflet geolocation APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_