### PR TITLE
Allow removing any listing (delete added, hide built-in)

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,6 +209,11 @@ header { background: var(--green); color: white; padding: 14px 16px 12px; displa
 .share-action.share-primary { width: 100%; flex: 1 1 100%; background: var(--orange); border-color: var(--orange); color: #fff; }
 .share-action.share-primary:hover { filter: brightness(1.05); }
 
+/* ── RESTORE HIDDEN ── */
+.restore-banner { margin: 6px 0 14px; padding: 12px 14px; text-align: center; background: white; border: 1.5px dashed var(--border); border-radius: 12px; font-size: 13px; color: var(--muted); cursor: pointer; }
+.restore-banner strong { color: var(--orange); }
+.restore-banner:hover { border-color: var(--orange); }
+
 /* ── USER LOCATION ── */
 .user-loc-dot { width: 16px; height: 16px; border-radius: 50%; background: #2471a3; border: 3px solid #fff; box-shadow: 0 1px 4px rgba(0,0,0,0.45); position: relative; }
 .user-loc-dot::after { content: ''; position: absolute; top: 50%; left: 50%; width: 16px; height: 16px; border-radius: 50%; background: rgba(36,113,163,0.45); transform: translate(-50%,-50%); animation: locpulse 2s ease-out infinite; }
@@ -299,6 +304,10 @@ header { background: var(--green); color: white; padding: 14px 16px 12px; displa
     <div class="help-section">
       <h3>✅ Visited</h3>
       <p>Tap the big green <strong>"Mark as Visited"</strong> button inside any store. It turns into a checkmark and the card gets a green border in the list.</p>
+    </div>
+    <div class="help-section">
+      <h3>✏️ Edit or remove a store</h3>
+      <p>Open any store and tap <strong>Edit Store</strong> to fix its details, or <strong>🗑️ Remove this store</strong> at the bottom. Stores <em>you</em> added are deleted; built-in stores are just hidden on your device — a <strong>"Restore all"</strong> link appears at the bottom of the list so you can bring them back anytime.</p>
     </div>
     <div class="help-section">
       <h3>⚖️ KG vs Itemized</h3>
@@ -411,7 +420,8 @@ header { background: var(--green); color: white; padding: 14px 16px 12px; displa
     <button class="sheet-cancel" onclick="document.getElementById('edit-overlay').classList.add('hidden')">Cancel</button>
     <div id="edit-delete-wrap" style="display:none;margin-top:16px;">
       <hr style="border:none;border-top:1px solid var(--border);margin-bottom:16px;">
-      <button id="edit-delete-btn" onclick="confirmDeleteCustomStore()" style="width:100%;padding:14px;background:none;border:2px solid #dc2626;color:#dc2626;border-radius:14px;font-size:15px;font-weight:700;cursor:pointer;">🗑️ Remove this store</button>
+      <button id="edit-delete-btn" onclick="confirmRemoveStore()" style="width:100%;padding:14px;background:none;border:2px solid #dc2626;color:#dc2626;border-radius:14px;font-size:15px;font-weight:700;cursor:pointer;">🗑️ Remove this store</button>
+      <p id="edit-delete-hint" style="font-size:12px;color:var(--muted);margin-top:8px;text-align:center;"></p>
     </div>
   </div>
 </div>
@@ -530,8 +540,8 @@ header { background: var(--green); color: white; padding: 14px 16px 12px; displa
 // ─────────────────────────────────────────────
 let lang = localStorage.getItem('lviv_sh_lang') || 'en';
 const TR = {
-  en:{tabList:'List',tabMap:'Map',fAll:'All Stores',fKg:'⚖️ By KG',fItem:'🏷️ Itemized',fVisited:'✅ Visited',fUnvisited:'🔲 Not Yet',tipStrong:'👋 Tap any store to see full details, hours, and the inventory tracker.',tipSub:"Use the filter buttons above to find exactly what you're looking for. Scroll the filters sideways to see all options.",statsVisited:'stores visited',statsAdded:'added by you',backBtn:'← Back to list',step1:'📍 Step 1 — Have you visited this store?',step2:'📦 Step 2 — Inventory & Price Tracker',markVisited:'📍 Mark as Visited',unmarkVisited:'✅ Visited — tap to unmark',visitSaved:'Your visit history is saved automatically on this device.',setDel:'📅 Set Last Delivery Date',updDel:'🔄 Update Delivery Date',noDelivery:'No delivery date set yet for this store.',storeInfo:'ℹ️ Store Information',addrLbl:'Address',phoneLbl:'Phone',notesLbl:'Notes',hoursLbl:'Opening Hours',removeStore:'🗑️ Remove this store',addedByYou:'📍 Added by you',byKg:'⚖️ By KG',byWeight:'⚖️ By Weight',itemized:'🏷️ Itemized pricing',closedToday:'🔒 Closed today',closedDay:'🔒 Closed',viewDetails:'View Details →',freshToday:'🎉 Fresh today! New stock just arrived',freshLabel:'✅ Fresh stock — prices still high',midLabel:'🟡 Mid-cycle — good selection',oldLabel:'🔥 Late cycle — BEST deals now!',dayLabel:'Day',delivery:'📦 Delivery',endCycle:'🏷️ End of cycle',todayPrice:"Today's price per KG",estDiscount:'Estimated discount vs. delivery day',cycleDay:'-day cycle · prices drop daily',off:'off',inventory:'Inventory cycle',humanaTag:'HUMANA',visitedTag:'Visited',editStore:'Edit Store',saveEdit:'Save Changes',editName:'Store name',editAddrEn:'Address (English)',editAddrUa:'Address (Ukrainian)',editPhone:'Phone',editPricing:'Pricing type',editCycle:'Inventory cycle',editNotes:'Notes',shareTitle:'Share & Contribute',shareIntro:'Stores you add or edit are saved on this device. Share them with friends, or contribute them to the official map so everyone gets them.',shareYoursHdr:'📤 Share your map',shareYoursHint:'Send your added & edited stores to anyone. They open the link (or import the file) and your stores appear on their map.',shareCopyLink:'🔗 Copy share link',shareDownload:'💾 Download file',shareShowCode:'🔡 Show code',shareContribHdr:'🌍 Contribute to the official map',shareContribHint:'Submit your additions & corrections so the maintainer can merge them into the map everyone downloads. Opens a pre-filled GitHub form (a free GitHub account is required to post).',shareContribBtn:'🚀 Submit on GitHub',shareImportHdr:'📥 Import from others',shareImportHint:'Got a share link, code, or file from someone? Paste the code below or load their file — their stores merge into yours (duplicates are skipped).',shareImportBtn:'📥 Import code',shareLoadFile:'📂 Load file…',sharePastePlaceholder:'Paste a share code here…',shareDone:'Done',shareNothing:"You haven't added or edited any stores yet. Add a store from the Map tab, then come back here to share it.",shareYouHave:'You have {added} store(s) added and {edited} correction(s) to share.',shareLinkCopied:'Share link copied to clipboard! Send it to anyone — opening it adds your stores to their map.',shareImportError:"Sorry, that doesn't look like a valid Lviv Second Hand share code or file.",shareImportDone:'Import complete!\n\n➕ {added} store(s) added\n✏️ {edited} correction(s) applied\n⏭️ {skipped} skipped (duplicates or already edited)',shareIncoming:'This link contains a shared map: {added} store(s) added and {edited} correction(s).\n\nImport them onto your map?',locYouAreHere:'📍 You are here',locDenied:'Location access is blocked. To see yourself on the map, allow location for this site in your browser settings, then tap 📍 again.',locUnavailable:"Couldn't get your location. Make sure location services are on and try again.",locUnsupported:'Your browser does not support location.',locStart:'Show my location',locStop:'Turn off location'},
-  ua:{tabList:'Список',tabMap:'Карта',fAll:'Всі магазини',fKg:'⚖️ На вагу',fItem:'🏷️ По штуці',fVisited:'✅ Відвідані',fUnvisited:'🔲 Ще ні',tipStrong:'👋 Натисніть на магазин, щоб побачити деталі, години та трекер.',tipSub:'Використовуйте кнопки фільтрів. Проведіть пальцем, щоб побачити всі.',statsVisited:'магазинів відвідано',statsAdded:'додано вами',backBtn:'← Назад',step1:'📍 Крок 1 — Ви відвідали цей магазин?',step2:'📦 Крок 2 — Трекер товарів і цін',markVisited:'📍 Відмітити як відвідане',unmarkVisited:'✅ Відвідано — натисніть, щоб зняти',visitSaved:'Історія відвідувань зберігається на цьому пристрої.',setDel:'📅 Встановити дату поставки',updDel:'🔄 Оновити дату поставки',noDelivery:'Дата поставки ще не вказана.',storeInfo:'ℹ️ Інформація про магазин',addrLbl:'Адреса',phoneLbl:'Телефон',notesLbl:'Примітки',hoursLbl:'Години роботи',removeStore:'🗑️ Видалити магазин',addedByYou:'📍 Додано вами',byKg:'⚖️ На вагу',byWeight:'⚖️ На вагу',itemized:'🏷️ По штуці',closedToday:'🔒 Зачинено сьогодні',closedDay:'🔒 Зачинено',viewDetails:'Деталі →',freshToday:'🎉 Щойно! Нові товари сьогодні',freshLabel:'✅ Свіжі товари — ціни ще високі',midLabel:'🟡 Середина циклу — хороший вибір',oldLabel:'🔥 Кінець циклу — НАЙКРАЩІ ціни!',dayLabel:'День',delivery:'📦 Поставка',endCycle:'🏷️ Кінець циклу',todayPrice:'Ціна сьогодні за кг',estDiscount:'Орієнтовна знижка від поставки',cycleDay:'-денний цикл · ціни знижуються щодня',off:'знижки',inventory:'Цикл поставок',humanaTag:'HUMANA',visitedTag:'Відвідано',editStore:'Редагувати',saveEdit:'Зберегти зміни',editName:'Назва магазину',editAddrEn:'Адреса (англ.)',editAddrUa:'Адреса (укр.)',editPhone:'Телефон',editPricing:'Тип цін',editCycle:'Цикл поставок',editNotes:'Нотатки',shareTitle:'Поділитися та зробити внесок',shareIntro:'Магазини, які ви додали чи відредагували, зберігаються на цьому пристрої. Поділіться ними з друзями або внесіть їх до офіційної карти, щоб їх отримали всі.',shareYoursHdr:'📤 Поділитися картою',shareYoursHint:'Надішліть свої додані та змінені магазини будь-кому. Вони відкривають посилання (або імпортують файл) — і ваші магазини з’являються на їхній карті.',shareCopyLink:'🔗 Копіювати посилання',shareDownload:'💾 Завантажити файл',shareShowCode:'🔡 Показати код',shareContribHdr:'🌍 Внести до офіційної карти',shareContribHint:'Надішліть свої доповнення та виправлення, щоб супровідник додав їх до карти, яку завантажують усі. Відкриється попередньо заповнена форма GitHub (для публікації потрібен безкоштовний акаунт GitHub).',shareContribBtn:'🚀 Надіслати на GitHub',shareImportHdr:'📥 Імпорт від інших',shareImportHint:'Отримали посилання, код чи файл від когось? Вставте код нижче або завантажте файл — їхні магазини додадуться до ваших (дублікати пропускаються).',shareImportBtn:'📥 Імпортувати код',shareLoadFile:'📂 Завантажити файл…',sharePastePlaceholder:'Вставте код для обміну сюди…',shareDone:'Готово',shareNothing:'Ви ще не додали й не редагували жодного магазину. Додайте магазин на вкладці «Карта», а потім поверніться сюди, щоб поділитися.',shareYouHave:'У вас є {added} доданих магазинів і {edited} виправлень для обміну.',shareLinkCopied:'Посилання скопійовано! Надішліть його будь-кому — відкривши його, вони додадуть ваші магазини на свою карту.',shareImportError:'Вибачте, це не схоже на дійсний код або файл Lviv Second Hand.',shareImportDone:'Імпорт завершено!\n\n➕ Додано магазинів: {added}\n✏️ Застосовано виправлень: {edited}\n⏭️ Пропущено: {skipped} (дублікати або вже змінені)',shareIncoming:'Це посилання містить спільну карту: {added} доданих магазинів і {edited} виправлень.\n\nІмпортувати їх на вашу карту?',locYouAreHere:'📍 Ви тут',locDenied:'Доступ до місцезнаходження заблоковано. Щоб побачити себе на карті, дозвольте доступ до геолокації для цього сайту в налаштуваннях браузера, а потім знову натисніть 📍.',locUnavailable:'Не вдалося визначити місцезнаходження. Переконайтеся, що геолокацію ввімкнено, і спробуйте ще раз.',locUnsupported:'Ваш браузер не підтримує геолокацію.',locStart:'Показати моє місцезнаходження',locStop:'Вимкнути геолокацію'}
+  en:{tabList:'List',tabMap:'Map',fAll:'All Stores',fKg:'⚖️ By KG',fItem:'🏷️ Itemized',fVisited:'✅ Visited',fUnvisited:'🔲 Not Yet',tipStrong:'👋 Tap any store to see full details, hours, and the inventory tracker.',tipSub:"Use the filter buttons above to find exactly what you're looking for. Scroll the filters sideways to see all options.",statsVisited:'stores visited',statsAdded:'added by you',backBtn:'← Back to list',step1:'📍 Step 1 — Have you visited this store?',step2:'📦 Step 2 — Inventory & Price Tracker',markVisited:'📍 Mark as Visited',unmarkVisited:'✅ Visited — tap to unmark',visitSaved:'Your visit history is saved automatically on this device.',setDel:'📅 Set Last Delivery Date',updDel:'🔄 Update Delivery Date',noDelivery:'No delivery date set yet for this store.',storeInfo:'ℹ️ Store Information',addrLbl:'Address',phoneLbl:'Phone',notesLbl:'Notes',hoursLbl:'Opening Hours',removeStore:'🗑️ Remove this store',addedByYou:'📍 Added by you',byKg:'⚖️ By KG',byWeight:'⚖️ By Weight',itemized:'🏷️ Itemized pricing',closedToday:'🔒 Closed today',closedDay:'🔒 Closed',viewDetails:'View Details →',freshToday:'🎉 Fresh today! New stock just arrived',freshLabel:'✅ Fresh stock — prices still high',midLabel:'🟡 Mid-cycle — good selection',oldLabel:'🔥 Late cycle — BEST deals now!',dayLabel:'Day',delivery:'📦 Delivery',endCycle:'🏷️ End of cycle',todayPrice:"Today's price per KG",estDiscount:'Estimated discount vs. delivery day',cycleDay:'-day cycle · prices drop daily',off:'off',inventory:'Inventory cycle',humanaTag:'HUMANA',visitedTag:'Visited',editStore:'Edit Store',saveEdit:'Save Changes',editName:'Store name',editAddrEn:'Address (English)',editAddrUa:'Address (Ukrainian)',editPhone:'Phone',editPricing:'Pricing type',editCycle:'Inventory cycle',editNotes:'Notes',shareTitle:'Share & Contribute',shareIntro:'Stores you add or edit are saved on this device. Share them with friends, or contribute them to the official map so everyone gets them.',shareYoursHdr:'📤 Share your map',shareYoursHint:'Send your added & edited stores to anyone. They open the link (or import the file) and your stores appear on their map.',shareCopyLink:'🔗 Copy share link',shareDownload:'💾 Download file',shareShowCode:'🔡 Show code',shareContribHdr:'🌍 Contribute to the official map',shareContribHint:'Submit your additions & corrections so the maintainer can merge them into the map everyone downloads. Opens a pre-filled GitHub form (a free GitHub account is required to post).',shareContribBtn:'🚀 Submit on GitHub',shareImportHdr:'📥 Import from others',shareImportHint:'Got a share link, code, or file from someone? Paste the code below or load their file — their stores merge into yours (duplicates are skipped).',shareImportBtn:'📥 Import code',shareLoadFile:'📂 Load file…',sharePastePlaceholder:'Paste a share code here…',shareDone:'Done',shareNothing:"You haven't added or edited any stores yet. Add a store from the Map tab, then come back here to share it.",shareYouHave:'You have {added} store(s) added and {edited} correction(s) to share.',shareLinkCopied:'Share link copied to clipboard! Send it to anyone — opening it adds your stores to their map.',shareImportError:"Sorry, that doesn't look like a valid Lviv Second Hand share code or file.",shareImportDone:'Import complete!\n\n➕ {added} store(s) added\n✏️ {edited} correction(s) applied\n⏭️ {skipped} skipped (duplicates or already edited)',shareIncoming:'This link contains a shared map: {added} store(s) added and {edited} correction(s).\n\nImport them onto your map?',locYouAreHere:'📍 You are here',locDenied:'Location access is blocked. To see yourself on the map, allow location for this site in your browser settings, then tap 📍 again.',locUnavailable:"Couldn't get your location. Make sure location services are on and try again.",locUnsupported:'Your browser does not support location.',locStart:'Show my location',locStop:'Turn off location',removeHintCustom:'This deletes the store you added.',removeHintBuiltin:'This hides the store on this device only. You can restore it anytime.',confirmRemoveCustom:'Remove this store from your list?',confirmHideBuiltin:'Hide this store from your map? It only affects this device — you can restore it anytime from the bottom of the list.',hiddenCount:'{n} store(s) hidden',restoreHidden:'Restore all'},
+  ua:{tabList:'Список',tabMap:'Карта',fAll:'Всі магазини',fKg:'⚖️ На вагу',fItem:'🏷️ По штуці',fVisited:'✅ Відвідані',fUnvisited:'🔲 Ще ні',tipStrong:'👋 Натисніть на магазин, щоб побачити деталі, години та трекер.',tipSub:'Використовуйте кнопки фільтрів. Проведіть пальцем, щоб побачити всі.',statsVisited:'магазинів відвідано',statsAdded:'додано вами',backBtn:'← Назад',step1:'📍 Крок 1 — Ви відвідали цей магазин?',step2:'📦 Крок 2 — Трекер товарів і цін',markVisited:'📍 Відмітити як відвідане',unmarkVisited:'✅ Відвідано — натисніть, щоб зняти',visitSaved:'Історія відвідувань зберігається на цьому пристрої.',setDel:'📅 Встановити дату поставки',updDel:'🔄 Оновити дату поставки',noDelivery:'Дата поставки ще не вказана.',storeInfo:'ℹ️ Інформація про магазин',addrLbl:'Адреса',phoneLbl:'Телефон',notesLbl:'Примітки',hoursLbl:'Години роботи',removeStore:'🗑️ Видалити магазин',addedByYou:'📍 Додано вами',byKg:'⚖️ На вагу',byWeight:'⚖️ На вагу',itemized:'🏷️ По штуці',closedToday:'🔒 Зачинено сьогодні',closedDay:'🔒 Зачинено',viewDetails:'Деталі →',freshToday:'🎉 Щойно! Нові товари сьогодні',freshLabel:'✅ Свіжі товари — ціни ще високі',midLabel:'🟡 Середина циклу — хороший вибір',oldLabel:'🔥 Кінець циклу — НАЙКРАЩІ ціни!',dayLabel:'День',delivery:'📦 Поставка',endCycle:'🏷️ Кінець циклу',todayPrice:'Ціна сьогодні за кг',estDiscount:'Орієнтовна знижка від поставки',cycleDay:'-денний цикл · ціни знижуються щодня',off:'знижки',inventory:'Цикл поставок',humanaTag:'HUMANA',visitedTag:'Відвідано',editStore:'Редагувати',saveEdit:'Зберегти зміни',editName:'Назва магазину',editAddrEn:'Адреса (англ.)',editAddrUa:'Адреса (укр.)',editPhone:'Телефон',editPricing:'Тип цін',editCycle:'Цикл поставок',editNotes:'Нотатки',shareTitle:'Поділитися та зробити внесок',shareIntro:'Магазини, які ви додали чи відредагували, зберігаються на цьому пристрої. Поділіться ними з друзями або внесіть їх до офіційної карти, щоб їх отримали всі.',shareYoursHdr:'📤 Поділитися картою',shareYoursHint:'Надішліть свої додані та змінені магазини будь-кому. Вони відкривають посилання (або імпортують файл) — і ваші магазини з’являються на їхній карті.',shareCopyLink:'🔗 Копіювати посилання',shareDownload:'💾 Завантажити файл',shareShowCode:'🔡 Показати код',shareContribHdr:'🌍 Внести до офіційної карти',shareContribHint:'Надішліть свої доповнення та виправлення, щоб супровідник додав їх до карти, яку завантажують усі. Відкриється попередньо заповнена форма GitHub (для публікації потрібен безкоштовний акаунт GitHub).',shareContribBtn:'🚀 Надіслати на GitHub',shareImportHdr:'📥 Імпорт від інших',shareImportHint:'Отримали посилання, код чи файл від когось? Вставте код нижче або завантажте файл — їхні магазини додадуться до ваших (дублікати пропускаються).',shareImportBtn:'📥 Імпортувати код',shareLoadFile:'📂 Завантажити файл…',sharePastePlaceholder:'Вставте код для обміну сюди…',shareDone:'Готово',shareNothing:'Ви ще не додали й не редагували жодного магазину. Додайте магазин на вкладці «Карта», а потім поверніться сюди, щоб поділитися.',shareYouHave:'У вас є {added} доданих магазинів і {edited} виправлень для обміну.',shareLinkCopied:'Посилання скопійовано! Надішліть його будь-кому — відкривши його, вони додадуть ваші магазини на свою карту.',shareImportError:'Вибачте, це не схоже на дійсний код або файл Lviv Second Hand.',shareImportDone:'Імпорт завершено!\n\n➕ Додано магазинів: {added}\n✏️ Застосовано виправлень: {edited}\n⏭️ Пропущено: {skipped} (дублікати або вже змінені)',shareIncoming:'Це посилання містить спільну карту: {added} доданих магазинів і {edited} виправлень.\n\nІмпортувати їх на вашу карту?',locYouAreHere:'📍 Ви тут',locDenied:'Доступ до місцезнаходження заблоковано. Щоб побачити себе на карті, дозвольте доступ до геолокації для цього сайту в налаштуваннях браузера, а потім знову натисніть 📍.',locUnavailable:'Не вдалося визначити місцезнаходження. Переконайтеся, що геолокацію ввімкнено, і спробуйте ще раз.',locUnsupported:'Ваш браузер не підтримує геолокацію.',locStart:'Показати моє місцезнаходження',locStop:'Вимкнути геолокацію',removeHintCustom:'Це видалить доданий вами магазин.',removeHintBuiltin:'Це приховає магазин лише на цьому пристрої. Ви можете відновити його будь-коли.',confirmRemoveCustom:'Видалити цей магазин зі списку?',confirmHideBuiltin:'Приховати цей магазин з вашої карти? Це стосується лише цього пристрою — ви можете відновити його будь-коли внизу списку.',hiddenCount:'Приховано магазинів: {n}',restoreHidden:'Відновити всі'}
 };
 function t(k){return(TR[lang]||TR.en)[k]||k;}
 function setLang(l){
@@ -636,7 +646,9 @@ function setFilter(f, btn) {
 function allStores() { return [...STORES, ...getCustomStores()]; }
 
 function filtered() {
+  const hidden = new Set(getHiddenStores());
   return allStores().filter(s => {
+    if (hidden.has(s.id)) return false;
     const sd = getSD(s.id);
     if (currentFilter === 'humana') return s.type === 'humana';
     if (currentFilter === 'kg') return s.pricing === 'kg';
@@ -653,8 +665,10 @@ function filtered() {
 function renderList() {
   const stores = filtered();
   const el = document.getElementById('store-list');
+  const hiddenCount = getHiddenStores().length;
+  const restoreBanner = hiddenCount ? `<div class="restore-banner" onclick="restoreAllHidden()">🙈 ${t('hiddenCount').replace('{n}', hiddenCount)} · <strong>${t('restoreHidden')}</strong></div>` : '';
   if (!stores.length) {
-    el.innerHTML = `<div class="empty"><div class="empty-icon">🔍</div><div class="empty-title">No stores match</div><div class="empty-sub">Try a different filter</div></div>`;
+    el.innerHTML = `<div class="empty"><div class="empty-icon">🔍</div><div class="empty-title">No stores match</div><div class="empty-sub">Try a different filter</div></div>` + restoreBanner;
     return;
   }
   el.innerHTML = stores.map(raw => {
@@ -690,7 +704,7 @@ function renderList() {
       </div>
       ${cycleHtml}
     </div>`;
-  }).join('');
+  }).join('') + restoreBanner;
 }
 
 // ─────────────────────────────────────────────
@@ -1012,7 +1026,8 @@ function renderPins() {
 // ─────────────────────────────────────────────
 function exportKML() {
   function esc(s){ return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
-  const stores = [...STORES, ...getCustomStores()];
+  const hidden = new Set(getHiddenStores());
+  const stores = [...STORES, ...getCustomStores()].filter(s => !hidden.has(s.id));
   const marks = stores.map(s => {
     const hrs = s.hours ? Object.entries(s.hours).map(([d,h])=>d+':'+h).join(', ') : '';
     const desc = [s.addressEn||s.address||'', s.phone||'', s.pricing==='kg'?'By KG':'Itemized', (s.cycle||7)+'-day cycle', hrs, s.note||''].filter(Boolean).join('\n');
@@ -1046,6 +1061,23 @@ function saveStoreOverrides(obj){ localStorage.setItem('lviv_sh_overrides',JSON.
 function getStoreData(s){
   const ov = getStoreOverrides()[s.id]||{};
   return Object.assign({},s,ov);
+}
+
+// ─────────────────────────────────────────────
+// HIDDEN STORES (removed from this device's view)
+// ─────────────────────────────────────────────
+function getHiddenStores(){
+  try{ return JSON.parse(localStorage.getItem('lviv_sh_hidden')||'[]'); }catch(e){ return []; }
+}
+function saveHiddenStores(arr){ localStorage.setItem('lviv_sh_hidden',JSON.stringify(arr)); }
+function hideStore(id){
+  const arr = getHiddenStores();
+  if(!arr.includes(id)){ arr.push(id); saveHiddenStores(arr); }
+}
+function restoreAllHidden(){
+  saveHiddenStores([]);
+  renderList(); updateStats();
+  if(mapInst) renderPins();
 }
 
 function openAddStoreModal(lat,lng){
@@ -1088,11 +1120,6 @@ function saveCustomStore(){
   alert('Store added!');
 }
 
-function deleteCustomStore(id){
-  if(!confirm('Remove this store from your list?')) return;
-  saveCustomStores(getCustomStores().filter(s=>s.id!==id));
-  closeDetail();
-}
 
 // ─────────────────────────────────────────────
 // EDIT STORE MODAL
@@ -1111,8 +1138,10 @@ function openEditModal(id){
   document.getElementById('edit-pricing').value = s.pricing||'item';
   document.getElementById('edit-cycle').value = String(s.cycle||7);
   document.getElementById('edit-note').value = s.note||'';
-  // Show delete button only for custom stores
-  document.getElementById('edit-delete-wrap').style.display = raw.custom ? 'block' : 'none';
+  // Remove/hide button — available for every store
+  document.getElementById('edit-delete-wrap').style.display = 'block';
+  document.getElementById('edit-delete-btn').textContent = t('removeStore');
+  document.getElementById('edit-delete-hint').textContent = raw.custom ? t('removeHintCustom') : t('removeHintBuiltin');
   // Update labels with current language
   document.getElementById('edit-title').textContent = '✏️ '+t('editStore');
   document.getElementById('edit-lbl-name').textContent = t('editName');
@@ -1154,11 +1183,17 @@ function saveEdit(){
   openDetail(editStoreId);
 }
 
-function confirmDeleteCustomStore(){
+function confirmRemoveStore(){
   if(!editStoreId) return;
-  if(!confirm('Remove this store from your list?')) return;
+  const raw = allStores().find(x => x.id === editStoreId);
+  const isCustom = raw && raw.custom;
+  if(!confirm(isCustom ? t('confirmRemoveCustom') : t('confirmHideBuiltin'))) return;
   document.getElementById('edit-overlay').classList.add('hidden');
-  saveCustomStores(getCustomStores().filter(s=>s.id!==editStoreId));
+  if(isCustom){
+    saveCustomStores(getCustomStores().filter(s=>s.id!==editStoreId));
+  } else {
+    hideStore(editStoreId);
+  }
   closeDetail();
 }
 


### PR DESCRIPTION
## What & why

Reported: there's no way to delete listings. Only user-added stores could be removed — the built-in and community stores had no remove option. This makes the **"Remove this store"** button (in the Edit sheet) work for **every** listing.

## Behavior
- **Stores you added** → deleted, exactly as before.
- **Built-in / community stores** → **hidden on this device** (stored in `lviv_sh_hidden`) rather than deleted, since they ship inside the app and can't be removed per-device any other way.
- Hidden stores are excluded from the **list**, the **map pins**, and the **KML export**.
- Whenever anything is hidden, a **"🙈 N store(s) hidden · Restore all"** banner appears at the bottom of the list, so it's fully reversible with one tap.
- Confirm dialogs use clear, distinct wording for "delete" vs "hide", and explain that hiding is local and reversible.

## Details
- `getHiddenStores` / `saveHiddenStores` / `hideStore` / `restoreAllHidden` helpers, mirroring the existing overrides pattern.
- `filtered()` and `exportKML()` skip hidden IDs.
- Edit sheet always shows the remove button now, with a hint that adapts to custom vs built-in.
- New EN/UA strings; a Help section ("✏️ Edit or remove a store"); removed the now-unused `deleteCustomStore`.

## Testing
- JS syntax-checked.
- Headless-browser test: hiding a built-in store removes it from `filtered()` and shows the restore banner; deleting a custom store removes it from the custom list (and does not add it to hidden); "Restore all" brings hidden stores back and clears the banner; KML export excludes a hidden store. No JS errors.
- Note: live Leaflet map render isn't exercisable in the sandbox (CDN blocked), but pin rendering uses the same `filtered()` that the test covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_