### PR TITLE
Fix mobile viewport clipping (100dvh + safe-area)

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,10 +33,10 @@
   --border: #e5e7eb;
 }
 * { box-sizing: border-box; margin: 0; padding: 0; -webkit-tap-highlight-color: transparent; }
-body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg); color: var(--text); height: 100vh; display: flex; flex-direction: column; overflow: hidden; font-size: 15px; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg); color: var(--text); height: 100vh; height: 100dvh; display: flex; flex-direction: column; overflow: hidden; font-size: 15px; }
 
 /* ── HEADER ── */
-header { background: var(--green); color: white; padding: 14px 16px 12px; display: flex; align-items: center; justify-content: space-between; flex-shrink: 0; }
+header { background: var(--green); color: white; padding: calc(14px + env(safe-area-inset-top, 0px)) 16px 12px; display: flex; align-items: center; justify-content: space-between; flex-shrink: 0; }
 .hdr-left h1 { font-size: 19px; font-weight: 800; }
 .hdr-left p { font-size: 12px; opacity: 0.75; margin-top: 1px; }
 .help-btn { background: rgba(255,255,255,0.2); border: none; color: white; width: 36px; height: 36px; border-radius: 50%; font-size: 18px; cursor: pointer; display: flex; align-items: center; justify-content: center; }
@@ -99,7 +99,7 @@ header { background: var(--green); color: white; padding: 14px 16px 12px; displa
 .back-btn { background: none; border: none; color: rgba(255,255,255,0.85); font-size: 15px; cursor: pointer; padding: 0 0 10px 0; display: flex; align-items: center; gap: 5px; }
 .det-name { font-size: 22px; font-weight: 800; line-height: 1.2; }
 .det-sub { font-size: 13px; opacity: 0.8; margin-top: 4px; }
-.det-body { padding: 14px; }
+.det-body { padding: 14px 14px calc(28px + env(safe-area-inset-bottom, 0px)); }
 
 /* ── VISIT BUTTON ── */
 .visit-btn { width: 100%; padding: 16px; border-radius: 14px; font-size: 17px; font-weight: 800; cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 9px; transition: all 0.2s; margin-bottom: 14px; border: none; }
@@ -165,7 +165,7 @@ header { background: var(--green); color: white; padding: 14px 16px 12px; displa
 /* ── MODALS ── */
 .overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.55); z-index: 900; display: flex; align-items: flex-end; }
 .overlay.hidden { display: none; }
-.sheet { background: white; border-radius: 22px 22px 0 0; padding: 22px 20px 32px; width: 100%; }
+.sheet { background: white; border-radius: 22px 22px 0 0; padding: 22px 20px calc(32px + env(safe-area-inset-bottom, 0px)); width: 100%; }
 .sheet-handle { width: 40px; height: 4px; background: var(--border); border-radius: 2px; margin: 0 auto 18px; }
 .sheet h2 { font-size: 20px; font-weight: 800; margin-bottom: 6px; }
 .sheet p { font-size: 14px; color: var(--muted); margin-bottom: 18px; line-height: 1.5; }
@@ -278,7 +278,7 @@ header { background: var(--green); color: white; padding: 14px 16px 12px; displa
 <!-- HELP SHEET                                 -->
 <!-- ══════════════════════════════════════════ -->
 <div class="overlay hidden" id="help-overlay">
-  <div class="sheet" style="max-height:85vh;overflow-y:auto;">
+  <div class="sheet" style="max-height:85dvh;overflow-y:auto;">
     <div class="sheet-handle"></div>
     <h2>How to use this app</h2>
     <br>
@@ -354,7 +354,7 @@ header { background: var(--green); color: white; padding: 14px 16px 12px; displa
 <!-- ADD STORE MODAL                            -->
 <!-- ══════════════════════════════════════════ -->
 <div class="overlay hidden" id="add-overlay">
-  <div class="sheet" style="max-height:92vh;overflow-y:auto;">
+  <div class="sheet" style="max-height:92dvh;overflow-y:auto;">
     <div class="sheet-handle"></div>
     <h2>📍 Add a New Store</h2>
     <p>Found a store that's not on the map? Add it here. On the map tab, tap any location to auto-fill the coordinates.</p>
@@ -391,7 +391,7 @@ header { background: var(--green); color: white; padding: 14px 16px 12px; displa
 <!-- EDIT STORE MODAL                           -->
 <!-- ══════════════════════════════════════════ -->
 <div class="overlay hidden" id="edit-overlay">
-  <div class="sheet" style="max-height:92vh;overflow-y:auto;">
+  <div class="sheet" style="max-height:92dvh;overflow-y:auto;">
     <div class="sheet-handle"></div>
     <h2 id="edit-title">✏️ Edit Store</h2>
     <p style="font-size:13px;color:var(--muted);margin-bottom:16px;margin-top:4px;">Changes are saved on this device only.</p>
@@ -430,7 +430,7 @@ header { background: var(--green); color: white; padding: 14px 16px 12px; displa
 <!-- SHARE & CONTRIBUTE MODAL                    -->
 <!-- ══════════════════════════════════════════ -->
 <div class="overlay hidden" id="share-overlay">
-  <div class="sheet" style="max-height:92vh;overflow-y:auto;">
+  <div class="sheet" style="max-height:92dvh;overflow-y:auto;">
     <div class="sheet-handle"></div>
     <h2 id="share-title">🤝 Share &amp; Contribute</h2>
     <p id="share-intro" style="font-size:13px;color:var(--muted);margin-bottom:16px;margin-top:4px;">Stores you add or edit are saved on this device. Share them with friends, or contribute them to the official map so everyone gets them.</p>
@@ -523,8 +523,8 @@ header { background: var(--green); color: white; padding: 14px 16px 12px; displa
 
   <div class="view hidden" id="map-view" style="overflow:hidden;">
     <div id="map"></div>
-    <button onclick="locateUser()" id="map-locate-btn" style="position:fixed;bottom:84px;right:16px;z-index:999;width:54px;height:54px;border-radius:50%;background:white;color:var(--green);border:none;font-size:24px;box-shadow:0 4px 14px rgba(0,0,0,0.3);cursor:pointer;align-items:center;justify-content:center;line-height:1;" title="Show my location">📍</button>
-    <button onclick="startAddPin()" id="map-add-btn" style="position:fixed;bottom:20px;right:16px;z-index:999;width:54px;height:54px;border-radius:50%;background:var(--orange);color:white;border:none;font-size:28px;font-weight:900;box-shadow:0 4px 14px rgba(0,0,0,0.3);cursor:pointer;align-items:center;justify-content:center;line-height:1;" title="Add a new store — tap the map to pin location">+</button>
+    <button onclick="locateUser()" id="map-locate-btn" style="position:fixed;bottom:calc(84px + env(safe-area-inset-bottom, 0px));right:16px;z-index:999;width:54px;height:54px;border-radius:50%;background:white;color:var(--green);border:none;font-size:24px;box-shadow:0 4px 14px rgba(0,0,0,0.3);cursor:pointer;align-items:center;justify-content:center;line-height:1;" title="Show my location">📍</button>
+    <button onclick="startAddPin()" id="map-add-btn" style="position:fixed;bottom:calc(20px + env(safe-area-inset-bottom, 0px));right:16px;z-index:999;width:54px;height:54px;border-radius:50%;background:var(--orange);color:white;border:none;font-size:28px;font-weight:900;box-shadow:0 4px 14px rgba(0,0,0,0.3);cursor:pointer;align-items:center;justify-content:center;line-height:1;" title="Add a new store — tap the map to pin location">+</button>
     <div id="map-tap-hint" style="position:fixed;top:120px;left:50%;transform:translateX(-50%);background:rgba(0,0,0,0.72);color:white;padding:7px 14px;border-radius:20px;font-size:13px;font-weight:600;z-index:999;display:none;pointer-events:none;">📍 Tap map to set location</div>
   </div>
 


### PR DESCRIPTION
## What & why

On mobile, the bottom of the **store detail view** was cut off — the *Google Maps* / *Maps.me* buttons under "Edit Store" were unreachable (reported with a screenshot). Cause: `body { height: 100vh }`. On mobile browsers `100vh` is the *tall* viewport that sits behind the address bar and home-gesture bar, so the bottom of every scroll view is pushed off-screen. The list view already compensated with safe-area bottom padding; the detail body did not.

## Changes (CSS only)
- `body`: `height: 100vh` → `100vh; height: 100dvh;` (dynamic viewport with fallback).
- `.det-body`: adds `calc(28px + env(safe-area-inset-bottom))` bottom padding so the last buttons clear the gesture bar.
- Modal sheets: `max-height` → `dvh`, and `.sheet` bottom padding includes `env(safe-area-inset-bottom)`.
- `header`: `padding-top` includes `env(safe-area-inset-top)` for the iOS notch in standalone mode.
- Map FABs (📍 / +): `bottom` offsets include `env(safe-area-inset-bottom)`.

## Testing
- Headless browser at 390px: detail view scrolls fully, the Maps buttons are within the scrollable area and reachable, no horizontal overflow, no JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_