### PR TITLE
Security: prevent stored XSS from shared/imported data

### DIFF
--- a/index.html
+++ b/index.html
@@ -544,6 +544,8 @@ const TR = {
   ua:{tabList:'Список',tabMap:'Карта',fAll:'Всі магазини',fKg:'⚖️ На вагу',fItem:'🏷️ По штуці',fVisited:'✅ Відвідані',fUnvisited:'🔲 Ще ні',tipStrong:'👋 Натисніть на магазин, щоб побачити деталі, години та трекер.',tipSub:'Використовуйте кнопки фільтрів. Проведіть пальцем, щоб побачити всі.',statsVisited:'магазинів відвідано',statsAdded:'додано вами',backBtn:'← Назад',step1:'📍 Крок 1 — Ви відвідали цей магазин?',step2:'📦 Крок 2 — Трекер товарів і цін',markVisited:'📍 Відмітити як відвідане',unmarkVisited:'✅ Відвідано — натисніть, щоб зняти',visitSaved:'Історія відвідувань зберігається на цьому пристрої.',setDel:'📅 Встановити дату поставки',updDel:'🔄 Оновити дату поставки',noDelivery:'Дата поставки ще не вказана.',storeInfo:'ℹ️ Інформація про магазин',addrLbl:'Адреса',phoneLbl:'Телефон',notesLbl:'Примітки',hoursLbl:'Години роботи',removeStore:'🗑️ Видалити магазин',addedByYou:'📍 Додано вами',byKg:'⚖️ На вагу',byWeight:'⚖️ На вагу',itemized:'🏷️ По штуці',closedToday:'🔒 Зачинено сьогодні',closedDay:'🔒 Зачинено',viewDetails:'Деталі →',freshToday:'🎉 Щойно! Нові товари сьогодні',freshLabel:'✅ Свіжі товари — ціни ще високі',midLabel:'🟡 Середина циклу — хороший вибір',oldLabel:'🔥 Кінець циклу — НАЙКРАЩІ ціни!',dayLabel:'День',delivery:'📦 Поставка',endCycle:'🏷️ Кінець циклу',todayPrice:'Ціна сьогодні за кг',estDiscount:'Орієнтовна знижка від поставки',cycleDay:'-денний цикл · ціни знижуються щодня',off:'знижки',inventory:'Цикл поставок',humanaTag:'HUMANA',visitedTag:'Відвідано',editStore:'Редагувати',saveEdit:'Зберегти зміни',editName:'Назва магазину',editAddrEn:'Адреса (англ.)',editAddrUa:'Адреса (укр.)',editPhone:'Телефон',editPricing:'Тип цін',editCycle:'Цикл поставок',editNotes:'Нотатки',shareTitle:'Поділитися та зробити внесок',shareIntro:'Магазини, які ви додали чи відредагували, зберігаються на цьому пристрої. Поділіться ними з друзями або внесіть їх до офіційної карти, щоб їх отримали всі.',shareYoursHdr:'📤 Поділитися картою',shareYoursHint:'Надішліть свої додані та змінені магазини будь-кому. Вони відкривають посилання (або імпортують файл) — і ваші магазини з’являються на їхній карті.',shareCopyLink:'🔗 Копіювати посилання',shareDownload:'💾 Завантажити файл',shareShowCode:'🔡 Показати код',shareContribHdr:'🌍 Внести до офіційної карти',shareContribHint:'Надішліть свої доповнення та виправлення, щоб супровідник додав їх до карти, яку завантажують усі. Відкриється попередньо заповнена форма GitHub (для публікації потрібен безкоштовний акаунт GitHub).',shareContribBtn:'🚀 Надіслати на GitHub',shareImportHdr:'📥 Імпорт від інших',shareImportHint:'Отримали посилання, код чи файл від когось? Вставте код нижче або завантажте файл — їхні магазини додадуться до ваших (дублікати пропускаються).',shareImportBtn:'📥 Імпортувати код',shareLoadFile:'📂 Завантажити файл…',sharePastePlaceholder:'Вставте код для обміну сюди…',shareDone:'Готово',shareNothing:'Ви ще не додали й не редагували жодного магазину. Додайте магазин на вкладці «Карта», а потім поверніться сюди, щоб поділитися.',shareYouHave:'У вас є {added} доданих магазинів і {edited} виправлень для обміну.',shareLinkCopied:'Посилання скопійовано! Надішліть його будь-кому — відкривши його, вони додадуть ваші магазини на свою карту.',shareImportError:'Вибачте, це не схоже на дійсний код або файл Lviv Second Hand.',shareImportDone:'Імпорт завершено!\n\n➕ Додано магазинів: {added}\n✏️ Застосовано виправлень: {edited}\n⏭️ Пропущено: {skipped} (дублікати або вже змінені)',shareIncoming:'Це посилання містить спільну карту: {added} доданих магазинів і {edited} виправлень.\n\nІмпортувати їх на вашу карту?',locYouAreHere:'📍 Ви тут',locDenied:'Доступ до місцезнаходження заблоковано. Щоб побачити себе на карті, дозвольте доступ до геолокації для цього сайту в налаштуваннях браузера, а потім знову натисніть 📍.',locUnavailable:'Не вдалося визначити місцезнаходження. Переконайтеся, що геолокацію ввімкнено, і спробуйте ще раз.',locUnsupported:'Ваш браузер не підтримує геолокацію.',locStart:'Показати моє місцезнаходження',locStop:'Вимкнути геолокацію',removeHintCustom:'Це видалить доданий вами магазин.',removeHintBuiltin:'Це приховає магазин лише на цьому пристрої. Ви можете відновити його будь-коли.',confirmRemoveCustom:'Видалити цей магазин зі списку?',confirmHideBuiltin:'Приховати цей магазин з вашої карти? Це стосується лише цього пристрою — ви можете відновити його будь-коли внизу списку.',hiddenCount:'Приховано магазинів: {n}',restoreHidden:'Відновити всі'}
 };
 function t(k){return(TR[lang]||TR.en)[k]||k;}
+// Escape user/imported data before it goes into innerHTML (text or double-quoted attr).
+function escHtml(v){ return String(v==null?'':v).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;'); }
 function setLang(l){
   lang=l;
   localStorage.setItem('lviv_sh_lang',l);
@@ -690,8 +692,8 @@ function renderList() {
       <div class="card-top">
         <div class="store-dot ${s.type==='humana'?'dot-humana':'dot-other'}">${s.type==='humana'?'🔴':'🛍️'}</div>
         <div class="card-body">
-          <div class="card-name">${s.name}</div>
-          <div class="card-addr">${addr}</div>
+          <div class="card-name">${escHtml(s.name)}</div>
+          <div class="card-addr">${escHtml(addr)}</div>
           <div class="tags">
             ${s.custom?'<span class="tag" style="background:#fff3ea;color:#c45a00;">'+t('addedByYou')+'</span>':''}
             ${s.type==='humana'?'<span class="tag tag-red">'+t('humanaTag')+'</span>':''}
@@ -722,9 +724,11 @@ function openDetail(id) {
   const altAddr  = lang==='ua'?(s.addressEn||''):(s.address||'');
 
   // Hours table
-  const hoursHtml = Object.entries(s.hours).map(([d,h]) =>
-    `<tr class="${d===todayKey?'today':''}"><td>${DAY_NAMES[DAYS.indexOf(d)]}</td><td class="${h==='closed'?'closed-cell':''}">${h==='closed'?t('closedDay'):h}</td></tr>`
-  ).join('');
+  const hoursHtml = DAYS.map(d => {
+    const h = s.hours ? s.hours[d] : undefined;
+    if (h == null) return '';
+    return `<tr class="${d===todayKey?'today':''}"><td>${DAY_NAMES[DAYS.indexOf(d)]}</td><td class="${h==='closed'?'closed-cell':''}">${h==='closed'?t('closedDay'):escHtml(h)}</td></tr>`;
+  }).join('');
 
   // Tracker
   let trackerBody = '';
@@ -762,13 +766,13 @@ function openDetail(id) {
 
   // KG table
   let kgTable = '';
-  if (s.pricing === 'kg' && s.kgPrices) {
+  if (s.pricing === 'kg' && Array.isArray(s.kgPrices)) {
     const dayN = di ? di.day : -1;
     kgTable = `<div class="info-card">
       <div class="info-card-title">⚖️ Full Weekly Price Schedule</div>
       <table class="kg-table">
         <tr><th>Day</th><th>Price per KG</th><th></th></tr>
-        ${s.kgPrices.map((p,i) => `<tr class="${i===dayN?'today-kg':''}"><td>Day ${i+1}${i===0?' (delivery)':''}</td><td>${p} UAH/kg</td><td>${i===dayN?'👈 Today':''}</td></tr>`).join('')}
+        ${s.kgPrices.map((p,i) => `<tr class="${i===dayN?'today-kg':''}"><td>Day ${i+1}${i===0?' (delivery)':''}</td><td>${escHtml(p)} UAH/kg</td><td>${i===dayN?'👈 Today':''}</td></tr>`).join('')}
       </table>
     </div>`;
   }
@@ -776,8 +780,8 @@ function openDetail(id) {
   document.getElementById('detail-content').innerHTML = `
     <div class="det-header">
       <button class="back-btn" onclick="closeDetail()">${t('backBtn')}</button>
-      <div class="det-name">${s.name}</div>
-      <div class="det-sub">${s.brand} &nbsp;·&nbsp; ${s.pricing==='kg'?t('byWeight'):t('itemized')}</div>
+      <div class="det-name">${escHtml(s.name)}</div>
+      <div class="det-sub">${escHtml(s.brand)} &nbsp;·&nbsp; ${s.pricing==='kg'?t('byWeight'):t('itemized')}</div>
     </div>
     <div class="det-body">
 
@@ -810,12 +814,12 @@ function openDetail(id) {
         <div class="info-card-title">${t('storeInfo')}</div>
         <div class="info-row">
           <div class="info-icon">📍</div>
-          <div><div class="info-lbl">${t('addrLbl')}</div><div class="info-val">${dispAddr}</div><div class="info-sub">${altAddr}</div></div>
+          <div><div class="info-lbl">${t('addrLbl')}</div><div class="info-val">${escHtml(dispAddr)}</div><div class="info-sub">${escHtml(altAddr)}</div></div>
         </div>
-        ${s.phone ? `<div class="info-row"><div class="info-icon">📞</div><div><div class="info-lbl">${t('phoneLbl')}</div><div class="info-val"><a href="tel:${s.phone}" style="color:var(--green);text-decoration:none;">${s.phone}</a></div></div></div>` : ''}
+        ${s.phone ? `<div class="info-row"><div class="info-icon">📞</div><div><div class="info-lbl">${t('phoneLbl')}</div><div class="info-val"><a href="tel:${encodeURIComponent(s.phone)}" style="color:var(--green);text-decoration:none;">${escHtml(s.phone)}</a></div></div></div>` : ''}
         <div class="info-row">
           <div class="info-icon">💡</div>
-          <div><div class="info-lbl">${t('notesLbl')}</div><div class="info-val" style="font-size:14px;font-weight:400;line-height:1.5;">${s.note}</div></div>
+          <div><div class="info-lbl">${t('notesLbl')}</div><div class="info-val" style="font-size:14px;font-weight:400;line-height:1.5;">${escHtml(s.note)}</div></div>
         </div>
         <div class="info-row" style="align-items:flex-start;">
           <div class="info-icon">🕐</div>
@@ -1364,32 +1368,69 @@ function sameStore(a, b){
     && near(a.lat,b.lat) && near(a.lng,b.lng);
 }
 
+// ── Sanitizers: never trust imported data (it comes from arbitrary share links) ──
+const ALLOWED_CYCLES = [7, 14, 35];
+function _cleanStr(v, max){ return typeof v === 'string' ? v.slice(0, max) : ''; }
+function _cleanCycle(c){ const n = parseInt(c, 10); return ALLOWED_CYCLES.includes(n) ? n : 7; }
+function _cleanPricing(p){ return p === 'kg' ? 'kg' : 'item'; }
+function _cleanHours(h){
+  const out = {};
+  DAYS.forEach(d => { out[d] = (h && typeof h[d] === 'string') ? h[d].slice(0, 40) : '?'; });
+  return out;
+}
+function sanitizeImportedStore(s, i){
+  return {
+    id: 'u' + Date.now() + '_' + i,
+    name: _cleanStr(s.name, 120),
+    address: _cleanStr(s.address, 200),
+    addressEn: _cleanStr(s.addressEn, 200),
+    phone: _cleanStr(s.phone, 40),
+    note: _cleanStr(s.note, 500),
+    brand: _cleanStr(s.brand, 60) || 'Independent',
+    type: 'other',
+    pricing: _cleanPricing(s.pricing),
+    cycle: _cleanCycle(s.cycle),
+    lat: s.lat, lng: s.lng,
+    hours: _cleanHours(s.hours),
+    custom: true
+  };
+}
+function sanitizeOverride(o){
+  const out = {};
+  if(typeof o.name === 'string') out.name = o.name.slice(0, 120);
+  if(typeof o.addressEn === 'string') out.addressEn = o.addressEn.slice(0, 200);
+  if(typeof o.address === 'string') out.address = o.address.slice(0, 200);
+  if(typeof o.phone === 'string') out.phone = o.phone.slice(0, 40);
+  if(o.pricing === 'kg' || o.pricing === 'item') out.pricing = o.pricing;
+  if(ALLOWED_CYCLES.includes(parseInt(o.cycle, 10))) out.cycle = parseInt(o.cycle, 10);
+  if(typeof o.note === 'string') out.note = o.note.slice(0, 500);
+  return out;
+}
+
 function applyBundle(bundle){
   let added = 0, edited = 0, skipped = 0;
-  // Custom stores
+  // Custom stores — validate coordinates/name, then rebuild from a strict whitelist
   const mine = getCustomStores();
   const builtinNames = STORES.map(s => (s.name||'').trim().toLowerCase());
   (bundle.custom||[]).forEach((s,i) => {
-    if(typeof s.lat !== 'number' || typeof s.lng !== 'number' || !s.name){ skipped++; return; }
+    if(!s || typeof s.lat !== 'number' || typeof s.lng !== 'number' || isNaN(s.lat) || isNaN(s.lng)
+       || typeof s.name !== 'string' || !s.name.trim()){ skipped++; return; }
     // Skip if it duplicates one of my custom stores or a built-in store
-    if(mine.some(m => sameStore(m,s)) || builtinNames.includes((s.name||'').trim().toLowerCase())){ skipped++; return; }
-    const copy = Object.assign({}, s, {
-      id: 'u' + Date.now() + '_' + i,
-      type: s.type || 'other',
-      custom: true,
-      hours: s.hours || {mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}
-    });
-    mine.push(copy); added++;
+    if(mine.some(m => sameStore(m,s)) || builtinNames.includes(s.name.trim().toLowerCase())){ skipped++; return; }
+    mine.push(sanitizeImportedStore(s, i)); added++;
   });
   if(added) saveCustomStores(mine);
 
-  // Overrides — only fill in stores I haven't edited myself, and only for known stores
+  // Overrides — only for known built-in stores I haven't edited myself, whitelisted fields only
   const ov = getStoreOverrides();
   const knownIds = STORES.map(s => s.id);
-  Object.keys(bundle.overrides||{}).forEach(id => {
+  const bundleOv = (bundle.overrides && typeof bundle.overrides === 'object') ? bundle.overrides : {};
+  Object.keys(bundleOv).forEach(id => {
     if(!knownIds.includes(id)) return;
     if(ov[id]) { skipped++; return; }
-    ov[id] = bundle.overrides[id]; edited++;
+    const clean = sanitizeOverride(bundleOv[id] || {});
+    if(Object.keys(clean).length === 0) { skipped++; return; }
+    ov[id] = clean; edited++;
   });
   if(edited) saveStoreOverrides(ov);
 


### PR DESCRIPTION
## What & why

Fixes the two High-severity findings from the code review — the only directly exploitable ones now that map sharing/import is live.

**H1 — Stored XSS.** Every store field (`name`, `note`, `phone`, `address`, `brand`, `hours`, KG prices) was interpolated into `innerHTML` unescaped. Since custom stores and **imported share bundles** are arbitrary text, a crafted share link could persist a payload like ``'&lt;img src=x onerror=...&gt;'`` that executes on every `renderList()`/`openDetail()` — exfiltrating the victim's saved map or hijacking the page.

**H4 — Override poisoning.** `applyBundle` copied imported `overrides[id]` verbatim onto built-in stores with no validation, so `hours:"oops"` would break `Object.entries` and blank the detail view permanently.

## Changes
- Add `escHtml()` and wrap every interpolated data field in `renderList`, `openDetail`, the KG price table, and the hours table.
- `tel:` href now uses `encodeURIComponent`; phone text is escaped.
- Rebuild the hours table from the fixed `DAYS` list (guards missing/extra keys).
- `sanitizeImportedStore` / `sanitizeOverride`: strict field whitelist + type coercion — `cycle ∈ {7,14,35}`, `pricing ∈ {item,kg}`, `hours` → object of short strings, text fields length-capped, everything else dropped. `applyBundle` stores only sanitized data.

## Testing
Headless browser: imported a bundle with `onerror`/`onload`/`<script>` payloads in name/note/phone/hours and a poisoned `h1` override. Result: no payload executed (all probes null), list/detail render the payloads as inert escaped text, `cycle:'abc'`→7 and `hours:'not-an-object'`→proper object, the override kept only its whitelisted `name`, and `openDetail('h1')` no longer throws. No JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_