### PR TITLE
Update privacy policy and README for recent changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,15 @@ No app store, no install required to use it in a browser — but adding it to yo
 ## ✨ Features
 
 - 🗺️ **Map** of all second-hand stores in Lviv
+- 📍 **Show my location** — see yourself on the map with a live GPS toggle
 - ⏱️ **Inventory cycle tracker** — counts days since last delivery, estimates current discounts
 - ⚖️ Supports both **by-KG** and **itemized** stores
 - 🌐 **EN / UA** language toggle
 - ✅ Mark stores as **visited**
-- ➕ **Add stores** missing from the map
+- ➕ **Add**, ✏️ **edit**, and 🗑️ **remove/hide** stores
 - 🤝 **Share your map** & **contribute** additions/edits to everyone
 - 📤 **Export** all store locations to Maps.me (KML)
+- 📶 **Works offline** — installable PWA with on-device caching, no CDN dependency
 
 ## 🤝 Sharing & Contributing
 
@@ -103,13 +105,15 @@ PWA (прогресивний веб-додаток) для пошуку та в
 ## ✨ Можливості
 
 - 🗺️ **Карта** усіх секонд-хенд магазинів Львова
+- 📍 **Показати моє місцезнаходження** — ви на карті з перемикачем GPS
 - ⏱️ **Трекер циклу завезення товару** — лічить дні з останньої доставки та оцінює поточні знижки
 - ⚖️ Підтримка магазинів **на кіло** та **поштучно**
 - 🌐 Перемикач мови **EN / UA**
 - ✅ Позначення магазинів як **відвіданих**
-- ➕ **Додавання магазинів**, яких немає на карті
+- ➕ **Додавання**, ✏️ **редагування** та 🗑️ **видалення/приховування** магазинів
 - 🤝 **Поділитися картою** та **внести** доповнення/зміни для всіх
 - 📤 **Експорт** усіх магазинів у Maps.me (KML)
+- 📶 **Працює офлайн** — встановлюваний застосунок (PWA) із локальним кешуванням, без залежності від CDN
 
 ## 🤝 Обмін і внесок
 

--- a/privacy.html
+++ b/privacy.html
@@ -68,7 +68,7 @@
     <p>The app saves the following on your device only, using your browser's <strong>local storage</strong>:</p>
     <ul>
       <li>Stores you mark as <strong>visited</strong>, and the delivery dates you record for the inventory tracker</li>
-      <li>Stores you <strong>add</strong> to the map, and any <strong>edits</strong> you make to existing stores</li>
+      <li>Stores you <strong>add</strong> to the map, <strong>edits</strong> you make to existing stores, and stores you <strong>hide</strong></li>
       <li>Your <strong>language</strong> preference (English or Ukrainian) and whether you've seen the welcome screen</li>
     </ul>
     <p>This information stays in your browser. It is not transmitted to us or anyone else, and we have no way to read it.</p>
@@ -85,13 +85,13 @@
     </ul>
 
     <h2>5. Third-party services</h2>
-    <p>To display the app and its map, your browser connects to a few third parties. Like any website visit, these connections reveal your device's IP address and basic technical details to those providers. We do not control their data practices:</p>
+    <p>To display the app and its map, your browser connects to a couple of third parties. Like any website visit, these connections reveal your device's IP address and basic technical details to those providers. We do not control their data practices:</p>
     <ul>
       <li><strong>GitHub Pages</strong> — hosts the website. See <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener">GitHub's privacy statement</a>.</li>
-      <li><strong>OpenStreetMap</strong> — provides the map tiles shown on the Map tab. See the <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy" target="_blank" rel="noopener">OpenStreetMap Foundation privacy policy</a>.</li>
-      <li><strong>unpkg</strong> — a content-delivery network that serves the Leaflet mapping library used to draw the map.</li>
+      <li><strong>OpenStreetMap</strong> — provides the map tiles shown on the Map tab (loaded only when you open the map). See the <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy" target="_blank" rel="noopener">OpenStreetMap Foundation privacy policy</a>.</li>
     </ul>
-    <p>No advertising, analytics, or tracking services are used.</p>
+    <p>The mapping library (Leaflet) is bundled with the app rather than loaded from a third-party CDN, so opening the app does not contact any other server. No advertising, analytics, or tracking services are used.</p>
+    <p>For offline use, the app stores a copy of its own files and any map tiles you've already viewed in your browser's cache on your device. This cached data never leaves your device and can be cleared like any other site data (see section 6).</p>
 
     <h2>6. Your control over your data</h2>
     <p>Because your data lives in your browser, you are always in full control of it:</p>
@@ -130,7 +130,7 @@
     <p>Додаток зберігає наведене нижче лише на вашому пристрої, у <strong>локальному сховищі</strong> браузера:</p>
     <ul>
       <li>Магазини, які ви позначили як <strong>відвідані</strong>, та дати поставок, які ви вказали для трекера товарів</li>
-      <li>Магазини, які ви <strong>додали</strong> на карту, та будь-які <strong>зміни</strong> до наявних магазинів</li>
+      <li>Магазини, які ви <strong>додали</strong> на карту, <strong>зміни</strong> до наявних магазинів і магазини, які ви <strong>приховали</strong></li>
       <li>Вашу <strong>мову</strong> (англійська чи українська) та чи бачили ви вітальний екран</li>
     </ul>
     <p>Ця інформація залишається у вашому браузері. Вона не передається ні нам, ні комусь іншому, і ми не маємо доступу до неї.</p>
@@ -150,10 +150,10 @@
     <p>Щоб показати додаток і карту, ваш браузер з'єднується з кількома сторонніми сервісами. Як і за будь-якого відвідування сайту, ці з'єднання розкривають IP-адресу вашого пристрою та базові технічні дані цим постачальникам. Ми не контролюємо їхні практики щодо даних:</p>
     <ul>
       <li><strong>GitHub Pages</strong> — хостинг сайту. Див. <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener">заяву про конфіденційність GitHub</a>.</li>
-      <li><strong>OpenStreetMap</strong> — надає плитки карти на вкладці «Карта». Див. <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy" target="_blank" rel="noopener">політику конфіденційності OpenStreetMap Foundation</a>.</li>
-      <li><strong>unpkg</strong> — мережа доставки вмісту (CDN), що надає бібліотеку карт Leaflet.</li>
+      <li><strong>OpenStreetMap</strong> — надає плитки карти на вкладці «Карта» (завантажуються лише коли ви відкриваєте карту). Див. <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy" target="_blank" rel="noopener">політику конфіденційності OpenStreetMap Foundation</a>.</li>
     </ul>
-    <p>Жодні рекламні сервіси, аналітика чи інструменти стеження не використовуються.</p>
+    <p>Бібліотека карт (Leaflet) вбудована в додаток, а не завантажується зі стороннього CDN, тож відкриття додатка не звертається до жодного іншого сервера. Жодні рекламні сервіси, аналітика чи інструменти стеження не використовуються.</p>
+    <p>Для роботи офлайн додаток зберігає копію власних файлів і вже переглянутих плиток карти в кеші браузера на вашому пристрої. Ці дані ніколи не залишають ваш пристрій і їх можна очистити, як будь-які інші дані сайту (див. розділ 6).</p>
 
     <h2>6. Ваш контроль над даними</h2>
     <p>Оскільки ваші дані зберігаються у вашому браузері, ви завжди повністю ними керуєте:</p>


### PR DESCRIPTION
## What & why

Brings the docs in line with the features and architecture changes shipped this session.

### `privacy.html` (EN + UA)
- **Removed `unpkg`** from the third-party services list — Leaflet is now bundled with the app, so opening it no longer contacts a CDN. Clarified that OpenStreetMap tiles load only when you open the Map tab.
- Added a note about **on-device offline caching** (the app now caches its own files and viewed map tiles via a service worker; this never leaves the device and clears like any site data).
- Added **hidden stores** to the list of what's kept in local storage.

### `README.md` (EN + UA)
- Added the new features to the feature lists: **show-my-location** GPS toggle, **edit / remove-hide** stores, and **offline / installable PWA** support.

## Notes
- Docs only — no app code changes. `privacy.html` verified to load with both language sections and no remaining unpkg references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_