### PR TITLE
Merge community map contribution (#18, #19)

### DIFF
--- a/index.html
+++ b/index.html
@@ -585,7 +585,11 @@ const STORES = [
   { id:'s10', name:'Planeta Second Hand', brand:'Independent', address:'вул. Драгана, 4', addressEn:'Drahana St, 4', phone:'097 146 7226', type:'other', pricing:'item', hours:{mon:'10:00–19:00',tue:'10:00–19:00',wed:'10:00–19:00',thu:'10:00–19:00',fri:'10:00–19:00',sat:'10:00–19:00',sun:'closed'}, cycle:7, lat:49.8130, lng:24.0310, note:'⭐ 3.8 (187 reviews).' },
   // ── Community contributions (submitted via the app) ──
   { id:'c1', name:'humana vintage', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:35, lat:49.839988, lng:24.032904, note:'' },
-  { id:'c2', name:'Second hand', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.838766, lng:24.035492, note:'' }
+  { id:'c2', name:'Second hand', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.838766, lng:24.035492, note:'' },
+  { id:'c3', name:'Euro second hand', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.829852, lng:24.032385, note:'' },
+  { id:'c4', name:'Second Hand - Bomba womens', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.839572, lng:24.026161, note:'' },
+  { id:'c5', name:'Euro second hand', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.838513, lng:24.023277, note:'' },
+  { id:'c6', name:'HUMANA', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.840308, lng:24.027495, note:'' }
 ];
 
 const DAYS = ['sun','mon','tue','wed','thu','fri','sat'];


### PR DESCRIPTION
## What & why

Merges the community contribution submitted via the app's 🌍 Contribute flow. Issues **#18** and **#19** were duplicate submissions of the same batch, so this handles both.

## Added (4 net-new stores)
- **Euro second hand** — `49.829852, 24.032385`
- **Second Hand - Bomba womens** — `49.839572, 24.026161`
- **Euro second hand** — `49.838513, 24.023277`
- **HUMANA** — `49.840308, 24.027495`

All added with itemized pricing, a default weekly cycle, and blank address/hours/notes (the submissions exceeded the GitHub form's embed limit, so only names + coordinates + pricing came through).

## Skipped
- **"humana vintage"** and **"Second hand"** — already on the map as `c1`/`c2` from the previous contribution.
- The **HUMANA — Sykhivska (`h4`)** cycle 14→35 edit — not applied, per the earlier decision to keep the 14-day cycle.

## Testing
Parsed the `STORES` array after the change: 23 stores, all IDs unique, the four new entries present with the expected coordinates. App JS syntax-checked.

Closes #18
Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_