### PR TITLE
Merge community map contribution (#24)

### DIFF
--- a/index.html
+++ b/index.html
@@ -589,7 +589,11 @@ const STORES = [
   { id:'c3', name:'Euro second hand', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.829852, lng:24.032385, note:'' },
   { id:'c4', name:'Second Hand - Bomba womens', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.839572, lng:24.026161, note:'' },
   { id:'c5', name:'Euro second hand', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.838513, lng:24.023277, note:'' },
-  { id:'c6', name:'HUMANA', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.840308, lng:24.027495, note:'' }
+  { id:'c6', name:'HUMANA', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.840308, lng:24.027495, note:'' },
+  { id:'c7', name:'Second Hand', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'kg', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.837062, lng:24.003367, note:'' },
+  { id:'c8', name:'Second Hand Bomba', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.839957, lng:24.027046, note:'' },
+  { id:'c9', name:'Sekond Hand', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.836733, lng:24.003885, note:'' },
+  { id:'c10', name:'Sekond Hand', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.835161, lng:24.005551, note:'' }
 ];
 
 const DAYS = ['sun','mon','tue','wed','thu','fri','sat'];


### PR DESCRIPTION
## What & why

Merges the latest community contribution (issue **#24**).

## Added (4 net-new stores)
- **Second Hand** — `49.837062, 24.003367` · **by KG**
- **Second Hand Bomba** — `49.839957, 24.027046`
- **Sekond Hand** — `49.836733, 24.003885`
- **Sekond Hand** — `49.835161, 24.005551`

Added with a default weekly cycle and blank address/hours/notes (only names, coordinates, and pricing came through — the submission exceeded the GitHub form's embed limit).

## Skipped
- The first **6 stores** in the issue (`humana vintage`, `Second hand`, two `Euro second hand`, `Second Hand - Bomba womens`, `HUMANA`) are already on the map as `c1`–`c6`.
- The **HUMANA — Sykhivska (`h4`)** cycle 14→35 edit — not applied, per the earlier decision to keep the 14-day cycle.

## Testing
Parsed `STORES` after the change: 27 stores, all IDs unique, the four new entries present with the expected coordinates and pricing (including the by-KG one). App JS syntax-checked.

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_