### PR TITLE
Merge community map contributions (#28, #29, #30)

### DIFF
--- a/index.html
+++ b/index.html
@@ -609,7 +609,17 @@ const STORES = [
   { id:'c7', name:'Second Hand', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'kg', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.837062, lng:24.003367, note:'' },
   { id:'c8', name:'Second Hand Bomba', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.839957, lng:24.027046, note:'' },
   { id:'c9', name:'Sekond Hand', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.836733, lng:24.003885, note:'' },
-  { id:'c10', name:'Sekond Hand', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.835161, lng:24.005551, note:'' }
+  { id:'c10', name:'Sekond Hand', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.835161, lng:24.005551, note:'' },
+  { id:'c11', name:'Євро секонд хенд', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.797056, lng:24.053355, note:'' },
+  { id:'c12', name:'Євро секонд хенд', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.796824, lng:24.054227, note:'' },
+  { id:'c13', name:'Євро тренд секонд хенд', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'kg', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.794817, lng:24.06357, note:'' },
+  { id:'c14', name:'Humana', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.79484, lng:24.063709, note:'' },
+  { id:'c15', name:'Euro marke', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'kg', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.790719, lng:24.058095, note:'' },
+  { id:'c16', name:'Euro Second Hand', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'kg', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.78499, lng:24.06067, note:'' },
+  { id:'c17', name:'Євро секонд-хенд', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'kg', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.785544, lng:24.060836, note:'' },
+  { id:'c18', name:'Economy class', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'kg', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.785169, lng:24.05725, note:'' },
+  { id:'c19', name:'Second Hand super', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.840224, lng:24.048986, note:'' },
+  { id:'c20', name:'Second hand Bomba', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.8393, lng:24.035811, note:'' }
 ];
 
 const DAYS = ['sun','mon','tue','wed','thu','fri','sat'];


### PR DESCRIPTION
## What & why

Merges the three open community contributions.

## Added (10 net-new stores, c11–c20)
From **#28** (southern Sykhiv area): Євро секонд хенд ×2, Євро тренд секонд хенд (KG), Humana, Euro marke (KG), Euro Second Hand (KG), Євро секонд-хенд (KG), Economy class (KG).
From **#29 / #30**: Second Hand super, Second hand Bomba.

`#29`'s single store also appears in `#30`, so it's merged once. Entries carry names, coordinates, and pricing only (submissions were minimal), so they use a default weekly cycle and blank address/hours/notes.

## Note on removals
None of these three contributions contained a "Suggested removals" section, so **no stores are removed in this PR**. (See the issue comment / chat for why and next steps.)

## Testing
Parsed `STORES`: 37 stores, all IDs unique, the ten new entries present with expected coordinates/pricing and intact Cyrillic names. App JS syntax-checked.

Closes #28
Closes #29
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_