### PR TITLE
Remove duplicate "humana vintage" (c1)

### DIFF
--- a/index.html
+++ b/index.html
@@ -604,7 +604,6 @@ const STORES = [
   { id:'s9', name:'Planet of Second-Hand', brand:'Independent', address:'вул. Горська, 5а', addressEn:'Horska St, 5a', phone:'096 946 1702', type:'other', pricing:'item', hours:{mon:'10:00–19:00',tue:'10:00–19:00',wed:'10:00–19:00',thu:'10:00–19:00',fri:'10:00–19:00',sat:'10:00–19:00',sun:'10:00–19:00'}, cycle:7, lat:49.8155, lng:24.0495, note:'⭐ 4.1 (179 reviews). Open 7 days.' },
   { id:'s10', name:'Planeta Second Hand', brand:'Independent', address:'вул. Драгана, 4', addressEn:'Drahana St, 4', phone:'097 146 7226', type:'other', pricing:'item', hours:{mon:'10:00–19:00',tue:'10:00–19:00',wed:'10:00–19:00',thu:'10:00–19:00',fri:'10:00–19:00',sat:'10:00–19:00',sun:'closed'}, cycle:7, lat:49.8130, lng:24.0310, note:'⭐ 3.8 (187 reviews).' },
   // ── Community contributions (submitted via the app) ──
-  { id:'c1', name:'humana vintage', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:35, lat:49.839988, lng:24.032904, note:'' },
   { id:'c2', name:'Second hand', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.838766, lng:24.035492, note:'' },
   { id:'c3', name:'Euro second hand', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.829852, lng:24.032385, note:'' },
   { id:'c4', name:'Second Hand - Bomba womens', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.839572, lng:24.026161, note:'' },
@@ -1839,7 +1838,7 @@ if ('serviceWorker' in navigator) {
 // UPDATE CHECK — notify when a newer build is deployed, so nobody is stuck on
 // a cached version (no reinstall needed). Bump APP_VERSION on each deploy.
 // ─────────────────────────────────────────────
-const APP_VERSION = '2026-07-30.6';
+const APP_VERSION = '2026-07-31.1';
 let _updateShown = false;
 async function checkForUpdate(){
   if (_updateShown || !navigator.onLine) return;


### PR DESCRIPTION
## What & why

Removes `c1` **"humana vintage"** — a duplicate of the official **HUMANA — Valova** (`h7`) store, only ~8 m away. Flagged in the duplicate cross-reference and confirmed for removal by the maintainer (via a share code).

Bumps `APP_VERSION` → `2026-07-31.1` for the in-app update banner.

## Testing
Parsed `STORES`: 62 stores (was 63), `c1` gone, all IDs unique, app JS syntax-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_