### PR TITLE
Add Cloudflare Web Analytics + disclose it in the privacy policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ You can export every store on the map as a `.kml` file and import it straight in
 
 ## 🔒 Privacy
 
-No accounts, no ads, no tracking. Everything you do stays in your own browser on your own device — it's never sent to a server, and nothing leaves your phone unless you choose to share it. Full details: **[Privacy Policy](https://anonymouspartner.github.io/lviv-secondhand/privacy.html)** (also linked from the in-app **?** Help panel).
+No accounts, no ads, no personal tracking. Everything you do stays in your own browser on your own device — it's never sent to a server, and nothing leaves your phone unless you choose to share it. The only thing measured is anonymous, aggregate traffic (page views and visits) via **Cloudflare Web Analytics** — cookieless, with no individual-visitor or cross-site tracking. Full details: **[Privacy Policy](https://anonymouspartner.github.io/lviv-secondhand/privacy.html)** (also linked from the in-app **?** Help panel).
 
 ---
 
@@ -140,4 +140,4 @@ PWA (прогресивний веб-додаток) для пошуку та в
 
 ## 🔒 Конфіденційність
 
-Без облікових записів, реклами та стеження. Усе, що ви робите, залишається у вашому браузері на вашому пристрої — воно ніколи не надсилається на сервер і не залишає ваш телефон, доки ви самі не вирішите поділитися. Докладніше: **[Політика конфіденційності](https://anonymouspartner.github.io/lviv-secondhand/privacy.html)** (також доступна з панелі довідки **?** у застосунку).
+Без облікових записів, реклами та персонального стеження. Усе, що ви робите, залишається у вашому браузері на вашому пристрої — воно ніколи не надсилається на сервер і не залишає ваш телефон, доки ви самі не вирішите поділитися. Єдине, що вимірюється, — це анонімний, узагальнений трафік (перегляди та відвідування) через **Cloudflare Web Analytics** — без файлів cookie, без відстеження окремих відвідувачів чи міжсайтового стеження. Докладніше: **[Політика конфіденційності](https://anonymouspartner.github.io/lviv-secondhand/privacy.html)** (також доступна з панелі довідки **?** у застосунку).

--- a/docs/PLAY_STORE.md
+++ b/docs/PLAY_STORE.md
@@ -135,17 +135,25 @@ In https://play.google.com/console → **Create app**:
 - [ ] Link `https://your-domain/privacy.html` in **Store settings → Privacy policy**.
 
 ### Data safety form (App content → Data safety)
-This app is privacy-friendly; answer honestly:
-- **Does your app collect or share user data?** No data is collected or sent to
-  you — all user content (added/edited/hidden stores, visits, settings) stays in
-  the browser's local storage on the device.
+This app is privacy-friendly, but it **does** use cookieless analytics, so answer
+honestly:
+- **Does your app collect or share user data?** **Yes — a small amount.** All
+  *user content* (added/edited/hidden stores, visits, settings) stays in the
+  browser's local storage on the device and is never sent anywhere. But the app
+  loads **Cloudflare Web Analytics**, which collects aggregate, non-identifying
+  usage data (page views / visits, plus the coarse technical info any web request
+  exposes). Declare this under **App activity → App interactions** (and/or **Web
+  page views**): **collected**, processed by a third party (Cloudflare),
+  **not shared** onward for advertising, and **not used to track** users across
+  apps/sites. It is cookieless and does not identify individuals.
 - **Location:** the app *uses* approximate/precise location (the "Show my
   location" feature) but does **not** collect, store, or transmit it — it's used
   only on-device to center the map. Declare it as **used, not collected/shared**.
-- **Data handling:** processed on-device; not shared with third parties.
-- Note in your own words that opening the app contacts GitHub Pages (hosting)
-  and OpenStreetMap (map tiles), which see the device IP like any website —
-  this matches `privacy.html`.
+- **Data handling:** user content is processed on-device; analytics is aggregate
+  and handled by Cloudflare. Nothing is sold. Data is **not** used for tracking.
+- Note in your own words that opening the app contacts GitHub Pages (hosting),
+  OpenStreetMap (map tiles), and Cloudflare (analytics), which see the device IP
+  like any website — this matches `privacy.html`.
 
 ### Content rating (App content → Content ratings)
 - Complete the IARC questionnaire. This is a utility with no objectionable

--- a/index.html
+++ b/index.html
@@ -1891,7 +1891,7 @@ function closeWelcome(){
 // INIT
 // ─────────────────────────────────────────────
 window.addEventListener('DOMContentLoaded',()=>{
-  renderWelcome(); renderHelp(); initDonate();
+  renderWelcome(); renderHelp(); initDonate(); initAnalytics();
   expireVisits();
   const _sl=localStorage.getItem('lviv_sh_lang');if(_sl)setLang(_sl);
   renderList();
@@ -1929,7 +1929,7 @@ if ('serviceWorker' in navigator) {
 // UPDATE CHECK — notify when a newer build is deployed, so nobody is stuck on
 // a cached version (no reinstall needed). Bump APP_VERSION on each deploy.
 // ─────────────────────────────────────────────
-const APP_VERSION = '2026-08-01.5';
+const APP_VERSION = '2026-08-03';
 
 // ─────────────────────────────────────────────
 // DONATIONS — points at a Stripe Payment Link (hosted checkout). No API keys
@@ -1945,6 +1945,22 @@ function initDonate(){
   if (!DONATE_URL) return;
   const b = document.getElementById('donate-btn');
   if (b) b.style.display = '';
+}
+
+// ─────────────────────────────────────────────
+// ANALYTICS — Cloudflare Web Analytics (cookieless, aggregate, no personal
+// data, no cross-site tracking). Injected only when a token is set; loading
+// it from the CDN fails silently offline. Leave blank to disable entirely.
+// See privacy.html §5. Disclosed there before this was enabled.
+// ─────────────────────────────────────────────
+const CF_ANALYTICS_TOKEN = '61b8929700694fe1b45730eb1f796d7c';
+function initAnalytics(){
+  if (!CF_ANALYTICS_TOKEN) return;
+  const s = document.createElement('script');
+  s.defer = true;
+  s.src = 'https://static.cloudflareinsights.com/beacon.min.js';
+  s.setAttribute('data-cf-beacon', JSON.stringify({ token: CF_ANALYTICS_TOKEN }));
+  document.head.appendChild(s);
 }
 
 let _updateShown = false;

--- a/privacy.html
+++ b/privacy.html
@@ -52,11 +52,11 @@
 
 <main>
   <!-- ══════════ ENGLISH ══════════ -->
-  <p class="meta">Lviv Second Hand · Last updated: 19 July 2026</p>
+  <p class="meta">Lviv Second Hand · Last updated: 3 August 2026</p>
 
   <div class="tldr">
     <h2>The short version</h2>
-    <p>Lviv Second Hand has no accounts, no ads, and no tracking. Everything you do — the stores you add, the edits you make, the places you mark as visited — is stored only in your own browser on your own device. We never see it, and it never leaves your phone unless <em>you</em> choose to share it.</p>
+    <p>Lviv Second Hand has no accounts and no ads. Everything you do — the stores you add, the edits you make, the places you mark as visited — is stored only in your own browser on your own device; we never see it, and it never leaves your phone unless <em>you</em> choose to share it. The only thing we measure is anonymous, aggregate traffic (page views and visits) through a cookieless analytics service that never identifies you.</p>
   </div>
 
   <div class="card">
@@ -64,7 +64,7 @@
     <p>Lviv Second Hand is a free, open-source Progressive Web App (PWA) for finding and tracking second-hand clothing stores in Lviv, Ukraine. It is a static website with no back-end server and no database. The app runs entirely inside your web browser.</p>
 
     <h2>2. What data we collect</h2>
-    <p><strong>We do not collect any personal data.</strong> There is no sign-up, no login, and no analytics. We do not use cookies for tracking.</p>
+    <p><strong>We do not collect any personal data.</strong> There is no sign-up and no login. We use a privacy-friendly, <strong>cookieless</strong> analytics service (Cloudflare Web Analytics) that measures only aggregate traffic — page views and visits — and does not identify you, build a profile of you, or track you across other websites. We do not use tracking cookies.</p>
     <p>The app saves the following on your device only, using your browser's <strong>local storage</strong>:</p>
     <ul>
       <li>Stores you mark as <strong>visited</strong>, and the delivery dates you record for the inventory tracker</li>
@@ -89,8 +89,9 @@
     <ul>
       <li><strong>GitHub Pages</strong> — hosts the website. See <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener">GitHub's privacy statement</a>.</li>
       <li><strong>OpenStreetMap</strong> — provides the map tiles shown on the Map tab (loaded only when you open the map). See the <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy" target="_blank" rel="noopener">OpenStreetMap Foundation privacy policy</a>.</li>
+      <li><strong>Cloudflare Web Analytics</strong> — measures anonymous, aggregate traffic (page views and visits) so we can see roughly how many people use the app. It is <strong>cookieless</strong>, does not track individual visitors, and does not follow you across other sites. See <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener">Cloudflare's privacy policy</a>.</li>
     </ul>
-    <p>The mapping library (Leaflet) is bundled with the app rather than loaded from a third-party CDN, so opening the app does not contact any other server. No advertising, analytics, or tracking services are used.</p>
+    <p>The mapping library (Leaflet) is bundled with the app rather than loaded from a third-party CDN. Aside from the services listed above, opening the app contacts no other server. We use no advertising and no cross-site tracking.</p>
     <p>For offline use, the app stores a copy of its own files and any map tiles you've already viewed in your browser's cache on your device. This cached data never leaves your device and can be cleared like any other site data (see section 6).</p>
 
     <h2>6. Your control over your data</h2>
@@ -114,11 +115,11 @@
 
   <!-- ══════════ УКРАЇНСЬКА ══════════ -->
   <div class="lang-divider">— Українською —</div>
-  <p class="meta">Lviv Second Hand · Останнє оновлення: 19 липня 2026</p>
+  <p class="meta">Lviv Second Hand · Останнє оновлення: 3 серпня 2026</p>
 
   <div class="tldr">
     <h2>Коротко</h2>
-    <p>Lviv Second Hand не має облікових записів, реклами чи стеження. Усе, що ви робите — магазини, які додаєте, зміни, які вносите, місця, які позначаєте як відвідані — зберігається лише у вашому браузері на вашому пристрої. Ми цього не бачимо, і воно не залишає ваш телефон, доки <em>ви</em> самі не вирішите поділитися.</p>
+    <p>Lviv Second Hand не має облікових записів і реклами. Усе, що ви робите — магазини, які додаєте, зміни, які вносите, місця, які позначаєте як відвідані — зберігається лише у вашому браузері на вашому пристрої; ми цього не бачимо, і воно не залишає ваш телефон, доки <em>ви</em> самі не вирішите поділитися. Єдине, що ми вимірюємо, — це анонімний, узагальнений трафік (перегляди та відвідування) через аналітичний сервіс без файлів cookie, який ніколи вас не ідентифікує.</p>
   </div>
 
   <div class="card">
@@ -126,7 +127,7 @@
     <p>Lviv Second Hand — це безкоштовний прогресивний веб-додаток (PWA) з відкритим кодом для пошуку та відстеження магазинів секонд-хенду у Львові. Це статичний сайт без сервера та без бази даних. Додаток працює повністю у вашому браузері.</p>
 
     <h2>2. Які дані ми збираємо</h2>
-    <p><strong>Ми не збираємо жодних персональних даних.</strong> Немає реєстрації, входу чи аналітики. Ми не використовуємо файли cookie для стеження.</p>
+    <p><strong>Ми не збираємо жодних персональних даних.</strong> Немає реєстрації чи входу. Ми використовуємо приватний аналітичний сервіс <strong>без файлів cookie</strong> (Cloudflare Web Analytics), який вимірює лише узагальнений трафік — перегляди сторінок і відвідування — і не ідентифікує вас, не будує ваш профіль і не стежить за вами на інших сайтах. Ми не використовуємо файли cookie для стеження.</p>
     <p>Додаток зберігає наведене нижче лише на вашому пристрої, у <strong>локальному сховищі</strong> браузера:</p>
     <ul>
       <li>Магазини, які ви позначили як <strong>відвідані</strong>, та дати поставок, які ви вказали для трекера товарів</li>
@@ -151,8 +152,9 @@
     <ul>
       <li><strong>GitHub Pages</strong> — хостинг сайту. Див. <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener">заяву про конфіденційність GitHub</a>.</li>
       <li><strong>OpenStreetMap</strong> — надає плитки карти на вкладці «Карта» (завантажуються лише коли ви відкриваєте карту). Див. <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy" target="_blank" rel="noopener">політику конфіденційності OpenStreetMap Foundation</a>.</li>
+      <li><strong>Cloudflare Web Analytics</strong> — вимірює анонімний, узагальнений трафік (перегляди та відвідування), щоб ми приблизно бачили, скільки людей користуються додатком. Працює <strong>без файлів cookie</strong>, не відстежує окремих відвідувачів і не стежить за вами на інших сайтах. Див. <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener">політику конфіденційності Cloudflare</a>.</li>
     </ul>
-    <p>Бібліотека карт (Leaflet) вбудована в додаток, а не завантажується зі стороннього CDN, тож відкриття додатка не звертається до жодного іншого сервера. Жодні рекламні сервіси, аналітика чи інструменти стеження не використовуються.</p>
+    <p>Бібліотека карт (Leaflet) вбудована в додаток, а не завантажується зі стороннього CDN. Окрім перелічених вище сервісів, відкриття додатка не звертається до жодного іншого сервера. Ми не використовуємо рекламу чи міжсайтове стеження.</p>
     <p>Для роботи офлайн додаток зберігає копію власних файлів і вже переглянутих плиток карти в кеші браузера на вашому пристрої. Ці дані ніколи не залишають ваш пристрій і їх можна очистити, як будь-які інші дані сайту (див. розділ 6).</p>
 
     <h2>6. Ваш контроль над даними</h2>


### PR DESCRIPTION
## Summary

Enables **Cloudflare Web Analytics** so the maintainer can see aggregate traffic (page views, visits, country, referrer, device) — cookieless, no personal data, no individual-visitor or cross-site tracking.

- **Beacon** injected in `index.html` only when `CF_ANALYTICS_TOKEN` is set (mirrors the donation-button pattern). Loaded from Cloudflare's CDN; the service worker passes cross-origin requests straight through, so it works online and fails silently offline. No CSP changes needed (the app has no CSP meta).
- **Disclosure shipped in the same commit** so the posted policy never contradicts what's running:
  - `privacy.html` (EN + UA): rewrote the TL;DR and §2 "no analytics" lines, added Cloudflare to the §5 third-parties list, corrected the "contacts no other server" wording, bumped Last-updated to 3 Aug 2026.
  - `README.md` (EN + UA): privacy line now notes the aggregate analytics.
  - `docs/PLAY_STORE.md`: Data Safety guidance updated to declare **App activity** (collected, not shared, not for tracking) instead of "no data collected."
- Bumps `APP_VERSION` to `2026-08-03`. No store-data changes; map stays at 89.

## Activating in the dashboard
The token (`61b8929…`) is live in this build. After deploy, Cloudflare's Web Analytics page for `anonymouspartner.github.io` will start showing data within a few minutes of real traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_