### PR TITLE
Activate usage metrics + disclose in-app analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ You can export every store on the map as a `.kml` file and import it straight in
 
 ## 🔒 Privacy
 
-No accounts, no ads, no personal tracking. Everything you do stays in your own browser on your own device — it's never sent to a server, and nothing leaves your phone unless you choose to share it. The only thing measured is anonymous, aggregate traffic (page views and visits) via **Cloudflare Web Analytics** — cookieless, with no individual-visitor or cross-site tracking. Full details: **[Privacy Policy](https://anonymouspartner.github.io/lviv-secondhand/privacy.html)** (also linked from the in-app **?** Help panel).
+No accounts, no ads, no personal tracking. Everything you do stays in your own browser on your own device — it's never sent to a server, and nothing leaves your phone unless you choose to share it. The only things measured are anonymous, aggregate traffic (page views and visits) via **Cloudflare Web Analytics** and anonymous in-app usage (which stores/filters get used) via a small first-party service on Cloudflare — both cookieless, with no personal data and no individual-visitor or cross-site tracking. Full details: **[Privacy Policy](https://anonymouspartner.github.io/lviv-secondhand/privacy.html)** (also linked from the in-app **?** Help panel).
 
 ---
 
@@ -140,4 +140,4 @@ PWA (прогресивний веб-додаток) для пошуку та в
 
 ## 🔒 Конфіденційність
 
-Без облікових записів, реклами та персонального стеження. Усе, що ви робите, залишається у вашому браузері на вашому пристрої — воно ніколи не надсилається на сервер і не залишає ваш телефон, доки ви самі не вирішите поділитися. Єдине, що вимірюється, — це анонімний, узагальнений трафік (перегляди та відвідування) через **Cloudflare Web Analytics** — без файлів cookie, без відстеження окремих відвідувачів чи міжсайтового стеження. Докладніше: **[Політика конфіденційності](https://anonymouspartner.github.io/lviv-secondhand/privacy.html)** (також доступна з панелі довідки **?** у застосунку).
+Без облікових записів, реклами та персонального стеження. Усе, що ви робите, залишається у вашому браузері на вашому пристрої — воно ніколи не надсилається на сервер і не залишає ваш телефон, доки ви самі не вирішите поділитися. Єдине, що вимірюється, — це анонімний, узагальнений трафік (перегляди та відвідування) через **Cloudflare Web Analytics** та анонімне використання додатка (які магазини/фільтри застосовують) через невеликий власний сервіс на Cloudflare — обидва без файлів cookie, без персональних даних і без відстеження окремих відвідувачів чи міжсайтового стеження. Докладніше: **[Політика конфіденційності](https://anonymouspartner.github.io/lviv-secondhand/privacy.html)** (також доступна з панелі довідки **?** у застосунку).

--- a/docs/PLAY_STORE.md
+++ b/docs/PLAY_STORE.md
@@ -140,12 +140,15 @@ honestly:
 - **Does your app collect or share user data?** **Yes — a small amount.** All
   *user content* (added/edited/hidden stores, visits, settings) stays in the
   browser's local storage on the device and is never sent anywhere. But the app
-  loads **Cloudflare Web Analytics**, which collects aggregate, non-identifying
-  usage data (page views / visits, plus the coarse technical info any web request
-  exposes). Declare this under **App activity → App interactions** (and/or **Web
-  page views**): **collected**, processed by a third party (Cloudflare),
-  **not shared** onward for advertising, and **not used to track** users across
-  apps/sites. It is cookieless and does not identify individuals.
+  loads **Cloudflare Web Analytics** (aggregate page views / visits) **and** sends
+  **anonymous in-app usage events** (which stores/filters are opened, tab/language
+  switches, share/export actions) to a small first-party service we run on
+  Cloudflare (a Worker + D1 database). Declare this under **App activity → App
+  interactions** (and/or **Web page views**): **collected**, some processing by a
+  third-party infrastructure provider (Cloudflare), **not shared** onward for
+  advertising, and **not used to track** users across apps/sites. It is cookieless,
+  stores no personal data (no id, no location, no free text), and does not identify
+  individuals.
 - **Location:** the app *uses* approximate/precise location (the "Show my
   location" feature) but does **not** collect, store, or transmit it — it's used
   only on-device to center the map. Declare it as **used, not collected/shared**.

--- a/index.html
+++ b/index.html
@@ -1941,7 +1941,7 @@ if ('serviceWorker' in navigator) {
 // UPDATE CHECK — notify when a newer build is deployed, so nobody is stuck on
 // a cached version (no reinstall needed). Bump APP_VERSION on each deploy.
 // ─────────────────────────────────────────────
-const APP_VERSION = '2026-08-03.1';
+const APP_VERSION = '2026-08-03.2';
 
 // ─────────────────────────────────────────────
 // DONATIONS — points at a Stripe Payment Link (hosted checkout). No API keys
@@ -1982,7 +1982,7 @@ function initAnalytics(){
 // filter name, tab, language, action). Fire-and-forget via sendBeacon; inert
 // until METRICS_URL is set. Disclosed in privacy.html before it was enabled.
 // ─────────────────────────────────────────────
-const METRICS_URL = '';
+const METRICS_URL = 'https://lviv-metrics.lshanalytic.workers.dev';
 function track(type, key){
   if (!METRICS_URL) return;
   try {

--- a/privacy.html
+++ b/privacy.html
@@ -56,7 +56,7 @@
 
   <div class="tldr">
     <h2>The short version</h2>
-    <p>Lviv Second Hand has no accounts and no ads. Everything you do — the stores you add, the edits you make, the places you mark as visited — is stored only in your own browser on your own device; we never see it, and it never leaves your phone unless <em>you</em> choose to share it. The only thing we measure is anonymous, aggregate traffic (page views and visits) through a cookieless analytics service that never identifies you.</p>
+    <p>Lviv Second Hand has no accounts and no ads. Everything you do — the stores you add, the edits you make, the places you mark as visited — is stored only in your own browser on your own device; we never see it, and it never leaves your phone unless <em>you</em> choose to share it. The only things we measure are anonymous, aggregate traffic (page views and visits) and which app features get used (e.g. which stores are opened) — never who uses them, and never anything that identifies you.</p>
   </div>
 
   <div class="card">
@@ -65,6 +65,7 @@
 
     <h2>2. What data we collect</h2>
     <p><strong>We do not collect any personal data.</strong> There is no sign-up and no login. We use a privacy-friendly, <strong>cookieless</strong> analytics service (Cloudflare Web Analytics) that measures only aggregate traffic — page views and visits — and does not identify you, build a profile of you, or track you across other websites. We do not use tracking cookies.</p>
+    <p>We also record <strong>anonymous, aggregate in-app usage</strong> — such as which stores are opened, which filters are used, tab and language switches, and share/export actions — to understand what's useful and improve the app. These events contain <strong>no personal data</strong>: no name, no account, no device identifier, no location, and no free text — only which feature was used. They are sent to a small service we run on Cloudflare and cannot be tied back to you.</p>
     <p>The app saves the following on your device only, using your browser's <strong>local storage</strong>:</p>
     <ul>
       <li>Stores you mark as <strong>visited</strong>, and the delivery dates you record for the inventory tracker</li>
@@ -90,6 +91,7 @@
       <li><strong>GitHub Pages</strong> — hosts the website. See <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener">GitHub's privacy statement</a>.</li>
       <li><strong>OpenStreetMap</strong> — provides the map tiles shown on the Map tab (loaded only when you open the map). See the <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy" target="_blank" rel="noopener">OpenStreetMap Foundation privacy policy</a>.</li>
       <li><strong>Cloudflare Web Analytics</strong> — measures anonymous, aggregate traffic (page views and visits) so we can see roughly how many people use the app. It is <strong>cookieless</strong>, does not track individual visitors, and does not follow you across other sites. See <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener">Cloudflare's privacy policy</a>.</li>
+      <li><strong>Usage metrics service (our own, on Cloudflare)</strong> — the anonymous in-app events described in section 2 are sent to a small service we operate on Cloudflare (a Worker and database). It records only which app features are used, never who used them, and stores no personal data.</li>
     </ul>
     <p>The mapping library (Leaflet) is bundled with the app rather than loaded from a third-party CDN. Aside from the services listed above, opening the app contacts no other server. We use no advertising and no cross-site tracking.</p>
     <p>For offline use, the app stores a copy of its own files and any map tiles you've already viewed in your browser's cache on your device. This cached data never leaves your device and can be cleared like any other site data (see section 6).</p>
@@ -119,7 +121,7 @@
 
   <div class="tldr">
     <h2>Коротко</h2>
-    <p>Lviv Second Hand не має облікових записів і реклами. Усе, що ви робите — магазини, які додаєте, зміни, які вносите, місця, які позначаєте як відвідані — зберігається лише у вашому браузері на вашому пристрої; ми цього не бачимо, і воно не залишає ваш телефон, доки <em>ви</em> самі не вирішите поділитися. Єдине, що ми вимірюємо, — це анонімний, узагальнений трафік (перегляди та відвідування) через аналітичний сервіс без файлів cookie, який ніколи вас не ідентифікує.</p>
+    <p>Lviv Second Hand не має облікових записів і реклами. Усе, що ви робите — магазини, які додаєте, зміни, які вносите, місця, які позначаєте як відвідані — зберігається лише у вашому браузері на вашому пристрої; ми цього не бачимо, і воно не залишає ваш телефон, доки <em>ви</em> самі не вирішите поділитися. Єдине, що ми вимірюємо, — це анонімний, узагальнений трафік (перегляди та відвідування) і те, які функції додатка використовуються (наприклад, які магазини відкривають) — ніколи не хто саме, і ніколи нічого, що вас ідентифікує.</p>
   </div>
 
   <div class="card">
@@ -128,6 +130,7 @@
 
     <h2>2. Які дані ми збираємо</h2>
     <p><strong>Ми не збираємо жодних персональних даних.</strong> Немає реєстрації чи входу. Ми використовуємо приватний аналітичний сервіс <strong>без файлів cookie</strong> (Cloudflare Web Analytics), який вимірює лише узагальнений трафік — перегляди сторінок і відвідування — і не ідентифікує вас, не будує ваш профіль і не стежить за вами на інших сайтах. Ми не використовуємо файли cookie для стеження.</p>
+    <p>Ми також фіксуємо <strong>анонімне, узагальнене використання додатка</strong> — наприклад, які магазини відкривають, які фільтри застосовують, перемикання вкладок і мови, дії обміну/експорту — щоб розуміти, що корисно, і покращувати додаток. Ці події не містять <strong>жодних персональних даних</strong>: ні імені, ні облікового запису, ні ідентифікатора пристрою, ні місцезнаходження, ні довільного тексту — лише те, яку функцію було використано. Вони надсилаються до невеликого сервісу, який ми запускаємо на Cloudflare, і не можуть бути пов'язані з вами.</p>
     <p>Додаток зберігає наведене нижче лише на вашому пристрої, у <strong>локальному сховищі</strong> браузера:</p>
     <ul>
       <li>Магазини, які ви позначили як <strong>відвідані</strong>, та дати поставок, які ви вказали для трекера товарів</li>
@@ -153,6 +156,7 @@
       <li><strong>GitHub Pages</strong> — хостинг сайту. Див. <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener">заяву про конфіденційність GitHub</a>.</li>
       <li><strong>OpenStreetMap</strong> — надає плитки карти на вкладці «Карта» (завантажуються лише коли ви відкриваєте карту). Див. <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy" target="_blank" rel="noopener">політику конфіденційності OpenStreetMap Foundation</a>.</li>
       <li><strong>Cloudflare Web Analytics</strong> — вимірює анонімний, узагальнений трафік (перегляди та відвідування), щоб ми приблизно бачили, скільки людей користуються додатком. Працює <strong>без файлів cookie</strong>, не відстежує окремих відвідувачів і не стежить за вами на інших сайтах. Див. <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener">політику конфіденційності Cloudflare</a>.</li>
+      <li><strong>Сервіс метрик використання (наш власний, на Cloudflare)</strong> — анонімні події в додатку, описані в розділі 2, надсилаються до невеликого сервісу, який ми запускаємо на Cloudflare (Worker і база даних). Він фіксує лише те, які функції використовуються, ніколи не хто саме, і не зберігає персональних даних.</li>
     </ul>
     <p>Бібліотека карт (Leaflet) вбудована в додаток, а не завантажується зі стороннього CDN. Окрім перелічених вище сервісів, відкриття додатка не звертається до жодного іншого сервера. Ми не використовуємо рекламу чи міжсайтове стеження.</p>
     <p>Для роботи офлайн додаток зберігає копію власних файлів і вже переглянутих плиток карти в кеші браузера на вашому пристрої. Ці дані ніколи не залишають ваш пристрій і їх можна очистити, як будь-які інші дані сайту (див. розділ 6).</p>


### PR DESCRIPTION
## Summary

Turns on the in-app usage metrics now that the collector Worker is deployed.

- **`index.html`** — sets `METRICS_URL` to the live Worker (`https://lviv-metrics.lshanalytic.workers.dev`). The app now sends its anonymous events (store opens, filter/tab/language switches, add/share/export/contribute) to our own Cloudflare Worker + D1. Verified end-to-end: `GET → ok`, valid event `→ 204`, bogus event type dropped.
- **Disclosure shipped together** so the policy never lags the collection:
  - `privacy.html` (EN + UA): broadened the TL;DR, added an in-app-usage paragraph to §2, and a first-party "usage metrics service" bullet to §5.
  - `README.md` (EN + UA): privacy line now covers the in-app usage metrics.
  - `docs/PLAY_STORE.md`: Data Safety note expanded to include the first-party events alongside Cloudflare Web Analytics.

No personal data is collected — no id, no location, no free text; only which feature was used. Bumps `APP_VERSION` to `2026-08-03.2`. Map stays at 89.

## Viewing the data
Ask me any time (e.g. "top stores opened this week", "filter usage", "EN vs UA") and I'll query the `lviv-metrics` D1 database via the Cloudflare connector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_