### PR TITLE
Harden IP/copyright + rate-limit metrics Worker

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,48 @@
+Copyright © 2026 the Lviv Second Hand project owner (github.com/anonymouspartner).
+All rights reserved.
+
+"Lviv Second Hand" — the software in this repository, including but not limited
+to its source code, HTML/CSS/JavaScript, design, user interface, and the curated
+store dataset it contains — is proprietary and protected by copyright and, where
+applicable, database rights. It is NOT open-source software.
+
+PERMITTED
+  - You may use the officially hosted application
+    (https://anonymouspartner.github.io/lviv-secondhand/) in a web browser for
+    your own personal, non-commercial purposes.
+
+NOT PERMITTED without the prior written permission of the copyright holder
+  - Copying, reproducing, republishing, mirroring, or redistributing the source
+    code or any substantial part of it, in any form or medium;
+  - Creating derivative works, clones, forks-for-reuse, ports, or adaptations;
+  - Copying, extracting, scraping, harvesting, or reusing the curated store
+    dataset (names, addresses, hours, coordinates, schedules), in whole or in
+    substantial part;
+  - Hosting, deploying, or distributing this application or a materially similar
+    application derived from it;
+  - Using the "Lviv Second Hand" name, logo, wordmark, or other branding, or any
+    confusingly similar mark.
+
+NO IMPLIED LICENSE
+  No license, express or implied, is granted except as expressly stated above.
+  The fact that this code is viewable in a web browser or hosted on a public
+  code-hosting platform does NOT grant any right to copy, reuse, or redistribute
+  it. Any platform-level fork/clone permissions (e.g. a code host's terms of
+  service) do not grant a copyright license to reuse the work.
+
+THIRD-PARTY COMPONENTS
+  This project bundles third-party open-source components under their own
+  licenses, which continue to apply to those components only:
+    - Leaflet — BSD-2-Clause
+    - qrcode-generator — MIT
+  Map tiles are © OpenStreetMap contributors (ODbL). Nothing in this license
+  restricts your rights under those third-party licenses.
+
+NO WARRANTY
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT.
+
+PERMISSIONS & CONTACT
+  To request permission for any use not permitted above, open an issue at
+  https://github.com/anonymouspartner/lviv-secondhand/issues.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A PWA (Progressive Web App) for finding and tracking second-hand clothing stores
 
 **🔗 Live app:** https://anonymouspartner.github.io/lviv-secondhand/
 
+> **© 2026 — All rights reserved. Proprietary, _not_ open-source.** You may use the hosted app in your browser for personal use. Copying, redistributing, or cloning the code, or reusing the curated store dataset, is prohibited without written permission — see [LICENSE](LICENSE).
+
 No app store, no install required to use it in a browser — but adding it to your home screen gives you a fullscreen, app-like experience with one tap.
 
 ---

--- a/index.html
+++ b/index.html
@@ -1,8 +1,17 @@
 <!DOCTYPE html>
+<!--
+  Lviv Second Hand
+  © 2026 the Lviv Second Hand project owner (github.com/anonymouspartner).
+  All rights reserved. Proprietary — NOT open-source. This source is provided to
+  run in your browser only; copying, redistributing, cloning, or reusing the code
+  or the curated store dataset is prohibited without written permission. See LICENSE.
+-->
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<meta name="copyright" content="© 2026 Lviv Second Hand. All rights reserved. Proprietary — see LICENSE.">
+<meta name="author" content="Lviv Second Hand">
 <meta name="theme-color" content="#1b5e38">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="mobile-web-app-capable" content="yes">
@@ -594,6 +603,8 @@ function setLang(l, viaUser){
 // DATA
 // ─────────────────────────────────────────────
 const STORES = [
+  // Copyright canary — never rendered/exported/shared (filtered by `watermark`).
+  { id:'wm1', watermark:true, name:'Секонд-хенд Орієнтир-7', brand:'Independent', address:'', addressEn:'', phone:'', type:'other', pricing:'item', hours:{mon:'?',tue:'?',wed:'?',thu:'?',fri:'?',sat:'?',sun:'?'}, cycle:7, lat:49.800017, lng:24.000073, note:'' },
   { id:'h1', name:'HUMANA — Knyahyni Olhy', brand:'HUMANA', address:'вул. Княгині Ольги, 5а', addressEn:'Knyahyni Olhy St, 5a', phone:'(032) 245-50-09', type:'humana', pricing:'item', hours:{mon:'10:00–20:00',tue:'10:00–20:00',wed:'10:00–20:00',thu:'10:00–20:00',fri:'10:00–20:00',sat:'10:00–20:00',sun:'10:00–20:00'}, cycle:35, lat:49.822992, lng:24.008012, note:'Large store. 5-week inventory cycle. Prices drop every day after delivery. Lucky hours: 30% off all items.' },
   { id:'h2', name:'HUMANA — Lyubinska', brand:'HUMANA', address:'вул. Любинська, 100 (2 поверх)', addressEn:'Lyubinska St, 100 (2nd floor)', phone:'(032) 24-04-40', type:'humana', pricing:'item', hours:{mon:'10:00–20:00',tue:'10:00–20:00',wed:'10:00–20:00',thu:'10:00–20:00',fri:'10:00–20:00',sat:'10:00–20:00',sun:'10:00–20:00'}, cycle:14, lat:49.822719, lng:23.973377, note:'2nd floor entrance. 2-week inventory cycle.' },
   { id:'h3', name:'HUMANA — Chornovola', brand:'HUMANA', address:'просп. В. Чорновола, 95', addressEn:'V. Chornovola Ave, 95', phone:'(032) 244-53-98', type:'humana', pricing:'item', hours:{mon:'10:00–20:00',tue:'10:00–20:00',wed:'10:00–20:00',thu:'10:00–20:00',fri:'10:00–20:00',sat:'10:00–20:00',sun:'10:00–20:00'}, cycle:35, lat:49.86345, lng:24.016631, note:'5-week inventory cycle. Prices decrease daily.' },
@@ -846,7 +857,10 @@ function isOpenNow(s) {
   return cur >= open && cur < close;
 }
 
-function allStores() { return [...STORES, ...getCustomStores()]; }
+// Watermark/canary entries live in STORES but are filtered out everywhere in
+// this app, so they never render, export, or share. If one ever appears on
+// another map, that map copied our dataset. Keep the filter centralized here.
+function allStores() { return [...STORES, ...getCustomStores()].filter(s => !s.watermark); }
 
 function filtered() {
   const hidden = new Set(getHiddenStores());
@@ -1266,7 +1280,7 @@ function exportKML() {
   track('action','export');
   function esc(s){ return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
   const hidden = new Set(getHiddenStores());
-  const stores = [...STORES, ...getCustomStores()].filter(s => !hidden.has(s.id));
+  const stores = [...STORES, ...getCustomStores()].filter(s => !hidden.has(s.id) && !s.watermark);
   const marks = stores.map(s => {
     const hrs = s.hours ? Object.entries(s.hours).map(([d,h])=>d+':'+h).join(', ') : '';
     const desc = [s.addressEn||s.address||'', s.phone||'', s.pricing==='kg'?'By KG':'Itemized', (s.cycle||7)+'-day cycle', hrs, s.note||''].filter(Boolean).join('\n');
@@ -1888,7 +1902,8 @@ function renderHelp(){
           + `<button class="sheet-btn" style="background:#ff5a5f;margin-top:8px;" onclick="openDonate()">${escHtml(t('donateBtn'))}</button>`
         : '')
     + `<p style="text-align:center;margin-top:14px;font-size:13px;color:var(--muted);"><a href="privacy.html" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:underline;">🔒 Privacy Policy · Політика конфіденційності</a></p>`
-    + `<p style="text-align:center;margin-top:6px;font-size:11px;color:var(--muted);">v${escHtml(APP_VERSION)}</p>`;
+    + `<p style="text-align:center;margin-top:6px;font-size:11px;color:var(--muted);">v${escHtml(APP_VERSION)}</p>`
+    + `<p style="text-align:center;margin-top:2px;font-size:11px;color:var(--muted);">© 2026 Lviv Second Hand · All rights reserved</p>`;
 }
 
 // ─────────────────────────────────────────────
@@ -1941,7 +1956,7 @@ if ('serviceWorker' in navigator) {
 // UPDATE CHECK — notify when a newer build is deployed, so nobody is stuck on
 // a cached version (no reinstall needed). Bump APP_VERSION on each deploy.
 // ─────────────────────────────────────────────
-const APP_VERSION = '2026-08-03.2';
+const APP_VERSION = '2026-08-03.3';
 
 // ─────────────────────────────────────────────
 // DONATIONS — points at a Stripe Payment Link (hosted checkout). No API keys

--- a/privacy.html
+++ b/privacy.html
@@ -61,7 +61,7 @@
 
   <div class="card">
     <h2>1. Who we are</h2>
-    <p>Lviv Second Hand is a free, open-source Progressive Web App (PWA) for finding and tracking second-hand clothing stores in Lviv, Ukraine. It is a static website with no back-end server and no database. The app runs entirely inside your web browser.</p>
+    <p>Lviv Second Hand is a free-to-use, <strong>proprietary</strong> Progressive Web App (PWA) for finding and tracking second-hand clothing stores in Lviv, Ukraine. It runs almost entirely inside your web browser; the only server-side component is the anonymous analytics described in section 5. All rights reserved (see section 10).</p>
 
     <h2>2. What data we collect</h2>
     <p><strong>We do not collect any personal data.</strong> There is no sign-up and no login. We use a privacy-friendly, <strong>cookieless</strong> analytics service (Cloudflare Web Analytics) that measures only aggregate traffic — page views and visits — and does not identify you, build a profile of you, or track you across other websites. We do not use tracking cookies.</p>
@@ -113,6 +113,9 @@
     <h2>9. Contact</h2>
     <p>Questions about privacy? Please open an issue on our GitHub repository:<br>
     <a href="https://github.com/anonymouspartner/lviv-secondhand/issues" target="_blank" rel="noopener">github.com/anonymouspartner/lviv-secondhand/issues</a></p>
+
+    <h2>10. Copyright &amp; terms of use</h2>
+    <p>Lviv Second Hand is <strong>proprietary software, © 2026, all rights reserved</strong> — it is <em>not</em> open-source. You may use the officially hosted app in your browser for personal, non-commercial purposes. You may <strong>not</strong> copy, mirror, redistribute, clone, or create derivative works of the code; extract, scrape, or reuse the curated store dataset; or use the "Lviv Second Hand" name or branding — without prior written permission. Viewing the source in your browser grants no right to reuse it. Full terms are in the project's <a href="https://github.com/anonymouspartner/lviv-secondhand/blob/main/LICENSE" target="_blank" rel="noopener">LICENSE</a>. Bundled third-party components (Leaflet, qrcode-generator) and OpenStreetMap map data remain under their own licenses.</p>
   </div>
 
   <!-- ══════════ УКРАЇНСЬКА ══════════ -->
@@ -126,7 +129,7 @@
 
   <div class="card">
     <h2>1. Хто ми</h2>
-    <p>Lviv Second Hand — це безкоштовний прогресивний веб-додаток (PWA) з відкритим кодом для пошуку та відстеження магазинів секонд-хенду у Львові. Це статичний сайт без сервера та без бази даних. Додаток працює повністю у вашому браузері.</p>
+    <p>Lviv Second Hand — це безкоштовний у користуванні, <strong>пропрієтарний</strong> прогресивний веб-додаток (PWA) для пошуку та відстеження магазинів секонд-хенду у Львові. Він працює майже повністю у вашому браузері; єдиний серверний компонент — анонімна аналітика, описана в розділі 5. Усі права застережено (див. розділ 10).</p>
 
     <h2>2. Які дані ми збираємо</h2>
     <p><strong>Ми не збираємо жодних персональних даних.</strong> Немає реєстрації чи входу. Ми використовуємо приватний аналітичний сервіс <strong>без файлів cookie</strong> (Cloudflare Web Analytics), який вимірює лише узагальнений трафік — перегляди сторінок і відвідування — і не ідентифікує вас, не будує ваш профіль і не стежить за вами на інших сайтах. Ми не використовуємо файли cookie для стеження.</p>
@@ -178,11 +181,14 @@
     <h2>9. Контакти</h2>
     <p>Питання щодо конфіденційності? Будь ласка, створіть звернення в нашому репозиторії GitHub:<br>
     <a href="https://github.com/anonymouspartner/lviv-secondhand/issues" target="_blank" rel="noopener">github.com/anonymouspartner/lviv-secondhand/issues</a></p>
+
+    <h2>10. Авторські права та умови використання</h2>
+    <p>Lviv Second Hand — це <strong>пропрієтарне програмне забезпечення, © 2026, усі права застережено</strong> — воно <em>не</em> є відкритим кодом. Ви можете користуватися офіційно розміщеним додатком у своєму браузері в особистих, некомерційних цілях. Ви <strong>не</strong> маєте права копіювати, дзеркалити, поширювати, клонувати чи створювати похідні роботи з коду; видобувати, збирати (scraping) чи повторно використовувати підготовлений набір даних магазинів; або використовувати назву чи брендинг «Lviv Second Hand» — без попереднього письмового дозволу. Перегляд коду у браузері не надає права на його повторне використання. Повні умови — у <a href="https://github.com/anonymouspartner/lviv-secondhand/blob/main/LICENSE" target="_blank" rel="noopener">LICENSE</a> проєкту. Вбудовані сторонні компоненти (Leaflet, qrcode-generator) та дані карт OpenStreetMap залишаються під власними ліцензіями.</p>
   </div>
 </main>
 
 <footer>
-  🧥 Lviv Second Hand — a free, open-source community project.
+  🧥 Lviv Second Hand — © 2026. All rights reserved · Усі права застережено.
 </footer>
 </body>
 </html>

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -29,6 +29,15 @@ export default {
     if (request.method === 'GET') return new Response('ok', { status: 200, headers: cors() });
     if (request.method !== 'POST') return new Response('method not allowed', { status: 405, headers: cors() });
 
+    // Per-IP rate limit so nobody can spam the collector to pollute D1 or burn
+    // the free-tier write quota. Guarded: if the binding is absent, skip rather
+    // than fail (the enum + size caps below still bound what any request can do).
+    if (env.RATE_LIMITER) {
+      const ip = request.headers.get('CF-Connecting-IP') || 'anon';
+      const { success } = await env.RATE_LIMITER.limit({ key: ip });
+      if (!success) return new Response('rate limited', { status: 429, headers: cors() });
+    }
+
     let body;
     try {
       const text = await request.text();

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -8,3 +8,11 @@ compatibility_date = "2026-08-01"
 binding = "DB"
 database_name = "lviv-metrics"
 database_id = "ed588947-b668-4082-8e2a-5eee35234832"
+
+# Per-IP rate limit: max 120 requests / 60s (each request may batch up to 20
+# events). Blocks scripted spam while leaving normal tapping unaffected.
+[[unsafe.bindings]]
+name = "RATE_LIMITER"
+type = "ratelimit"
+namespace_id = "1001"
+simple = { limit = 120, period = 60 }


### PR DESCRIPTION
## Summary

Aggressive pass on copyright/IP protection and one real security gap.

### Legal / anti-copy
- **New `LICENSE`** — proprietary, **All Rights Reserved** (explicitly *not* open-source). Forbids copying the code, reusing the curated store dataset, and using the branding without written permission; clarifies that viewing source grants no reuse right; carves out bundled third-party components.
- **Removed the "open-source / community project" wording** from `privacy.html` (EN + UA) and its footer — that framing invited copying. Also corrected the now-inaccurate "no back-end / no database" line (we now have the metrics Worker + D1).
- **New "Copyright & terms of use" section** in `privacy.html` (EN + UA, §10).
- **Copyright notices**: banner comment + `<meta name="copyright">` in `index.html`, a © line in the Help panel, and a © / LICENSE notice at the top of `README.md`.
- **User-safe data watermark**: a hidden canary store in `STORES` that is filtered out of every view/export/share (`allStores`, `exportKML`). It never renders in this app, so if it ever shows up on another map, that map copied our dataset. Visible store count unchanged (**89**).

### Security
- **Rate-limited the metrics Worker** — per-IP **120 req / 60 s** via Cloudflare's rate-limiting binding, **guarded** so a missing binding can't break the Worker. Blocks scripted spam that could pollute D1 or burn the free-tier write quota. (Merging this redeploys the Worker via the existing workflow.)

Bumps `APP_VERSION` to `2026-08-03.3`.

## Not in this PR (yours to do)
Trademark the name/logo, secure a domain, and decide whether to make the source repo private (the only way to stop source-level copying outright).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_