### PR TITLE
Server-side push test: /status subs count + /admin/test broadcast

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -34,3 +34,12 @@ jobs:
         run: |
           if [ -z "$VAPID_PRIVATE" ]; then echo "VAPID_PRIVATE not set — skipping (restock push stays off until you add it)"; exit 0; fi
           printf '%s' "$VAPID_PRIVATE" | npx --yes wrangler@3 secret put VAPID_PRIVATE
+      - name: Set admin key secret
+        working-directory: worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ADMIN_KEY: ${{ secrets.ADMIN_KEY }}
+        run: |
+          if [ -z "$ADMIN_KEY" ]; then echo "ADMIN_KEY not set — skipping (server-side broadcast test stays off until you add it)"; exit 0; fi
+          printf '%s' "$ADMIN_KEY" | npx --yes wrangler@3 secret put ADMIN_KEY

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -142,7 +142,11 @@ export default {
     const url = new URL(request.url);
     if (request.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors() });
     if (request.method === 'GET') {
-      if (url.pathname === '/status') return json({ ok: true, push: true, vapidConfigured: !!env.VAPID_PRIVATE });
+      if (url.pathname === '/status') {
+        let subs = null;
+        try { await ensureSchema(env); const c = await env.DB.prepare('SELECT COUNT(*) AS n FROM push_subs').first(); subs = c ? c.n : 0; } catch {}
+        return json({ ok: true, push: true, vapidConfigured: !!env.VAPID_PRIVATE, subs });
+      }
       return new Response('ok', { status: 200, headers: cors() });
     }
     if (request.method !== 'POST') return new Response('method not allowed', { status: 405, headers: cors() });
@@ -152,6 +156,24 @@ export default {
       const ip = request.headers.get('CF-Connecting-IP') || 'anon';
       const { success } = await env.RATE_LIMITER.limit({ key: ip });
       if (!success) return new Response('rate limited', { status: 429, headers: cors() });
+    }
+
+    // ── Admin: broadcast a test push to every subscription (server-side verify) ──
+    if (url.pathname === '/admin/test') {
+      if (!env.ADMIN_KEY || request.headers.get('X-Admin-Key') !== env.ADMIN_KEY) return json({ ok: false, reason: 'unauthorized' }, 401);
+      if (!env.VAPID_PRIVATE) return json({ ok: false, reason: 'push_not_configured' }, 503);
+      await ensureSchema(env);
+      const res = await env.DB.prepare('SELECT endpoint, p256dh, auth FROM push_subs').all();
+      const subs = (res && res.results) || [];
+      const payload = JSON.stringify({
+        title: '✅ Server test — Lviv Second Hand',
+        body: 'This test push was sent from the server. Restock alerts are working!',
+        url: 'https://anonymouspartner.github.io/lviv-secondhand/',
+        tag: 'admin-test',
+      });
+      let sent = 0;
+      for (const s of subs) { try { await sendPush(s, payload, env); sent++; } catch {} }
+      return json({ ok: true, count: subs.length, sent }, 200);
     }
 
     let body;


### PR DESCRIPTION
## Summary

Enables triggering a push **from the server** on demand.

- `GET /status` now reports `subs` — the number of stored subscriptions, so we can see whether any device is subscribed.
- `POST /admin/test` with header `X-Admin-Key: <ADMIN_KEY>` sends a test push to **every** subscription. `401` without the key, `503` if push isn't configured. Gated by a new `ADMIN_KEY` Worker secret (set by a new workflow step from the `ADMIN_KEY` repo secret).

Worker-only change; merging redeploys it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_