### PR TITLE
Remove KML/dataset export (data protection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ No app store, no install required to use it in a browser — but adding it to yo
 - 🔔 **Restock alerts** — follow a store and get a push notification the morning it restocks (opt-in; installed PWA required on iOS 16.4+)
 - ➕ **Add**, ✏️ **edit**, and 🗑️ **remove/hide** stores
 - 🤝 **Share your map** & **contribute** additions/edits to everyone
-- 📤 **Export** all store locations to Maps.me (KML)
 - 📶 **Works offline** — installable PWA with on-device caching, no CDN dependency
 
 ## 🤝 Sharing & Contributing
@@ -62,15 +61,6 @@ Contributions arrive as GitHub issues labelled `map-contribution`. Each issue li
 - **`custom`** — copy each object into the `STORES` array in `index.html` (assign a stable `id`, fill in `hours`).
 - **`overrides`** — fold each into the matching store's fields.
 - **`removed`** — a list of built-in store `id`s the contributor reports as non-existent/wrong; delete those entries from the `STORES` array.
-
-## 🗺️ Maps.me Integration
-
-You can export every store on the map as a `.kml` file and import it straight into [Maps.me](https://maps.me):
-
-1. In the app, tap the export button to download the `.kml` file
-2. Open Maps.me → **Bookmarks** → **Import**
-3. Select the downloaded `.kml` file
-4. All stores now appear as bookmarks on your Maps.me map, even offline
 
 ## 🔒 Privacy
 
@@ -152,7 +142,6 @@ PWA (прогресивний веб-додаток) для пошуку та в
 - 🔔 **Сповіщення про завезення** — відстежуйте магазин і отримуйте push-сповіщення того ранку, коли буде завезення (за згодою; на iOS 16.4+ потрібен встановлений застосунок)
 - ➕ **Додавання**, ✏️ **редагування** та 🗑️ **видалення/приховування** магазинів
 - 🤝 **Поділитися картою** та **внести** доповнення/зміни для всіх
-- 📤 **Експорт** усіх магазинів у Maps.me (KML)
 - 📶 **Працює офлайн** — встановлюваний застосунок (PWA) із локальним кешуванням, без залежності від CDN
 
 ## 🤝 Обмін і внесок
@@ -164,15 +153,6 @@ PWA (прогресивний веб-додаток) для пошуку та в
 - **🌍 Внести до офіційної карти** — відкриває попередньо заповнене [звернення на GitHub](https://github.com/anonymouspartner/lviv-secondhand/issues) з вашими доповненнями та виправленнями. Після того як супровідник їх додасть, ваші зміни з’являться на карті, яку завантажують усі. (Для публікації потрібен безкоштовний акаунт GitHub.)
 
 > Оскільки застосунок — це статичний сайт без сервера, обмін між користувачами миттєвий і приватний, а внески до *офіційної* карти проходять через GitHub, щоб супровідник міг їх переглянути та додати.
-
-## 🗺️ Інтеграція з Maps.me
-
-Усі магазини на карті можна експортувати у файл `.kml` та імпортувати у [Maps.me](https://maps.me):
-
-1. У застосунку натисніть кнопку експорту, щоб завантажити файл `.kml`
-2. Відкрийте Maps.me → **Закладки** → **Імпорт**
-3. Виберіть завантажений файл `.kml`
-4. Усі магазини з'являться як закладки на вашій карті Maps.me, навіть офлайн
 
 ## 🔒 Конфіденційність
 

--- a/index.html
+++ b/index.html
@@ -330,8 +330,8 @@ header { background: var(--green); color: white; padding: calc(14px + env(safe-a
       <p style="margin-top:8px;">To help everyone, tap <strong>🌍 Contribute to the official map</strong> — it opens a pre-filled GitHub form with your additions and corrections so they can be merged into the map that ships with the app.</p>
     </div>
     <div class="help-section">
-      <h3>📤 Maps.me Integration</h3>
-      <p>Tap the <strong>📤</strong> button in the top-right to download a KML file with all store locations. In Maps.me: tap ☰ → Bookmarks → ⋮ → Import → select the file. All stores appear as bookmarks. Inside any store, tap <strong>📍 Maps.me</strong> to jump straight to that store on the Maps.me map. To add a new store you discover, long-press on the spot in Maps.me to drop a pin, then bookmark it.</p>
+      <h3>📍 Open in Maps.me / Google Maps</h3>
+      <p>Inside any store, tap <strong>📍 Maps.me</strong> or <strong>🗺️ Google Maps</strong> to jump straight to that store for turn-by-turn directions.</p>
     </div>
     <button class="sheet-btn" onclick="document.getElementById('help-overlay').classList.add('hidden')">Got it!</button>
     <p style="text-align:center;margin-top:14px;font-size:13px;color:var(--muted);">
@@ -515,7 +515,6 @@ header { background: var(--green); color: white; padding: calc(14px + env(safe-a
       <span class="lp" id="lang-ua" role="button" tabindex="0" aria-pressed="false" onclick="setLang('ua',true)">УА</span>
     </div>
     <button class="help-btn" onclick="openShareModal()" title="Share your map & contribute stores" aria-label="Share your map and contribute stores" style="font-size:18px;">🤝</button>
-    <button class="help-btn" onclick="exportKML()" title="Export all stores to Maps.me KML" aria-label="Export all stores to Maps.me KML" style="font-size:18px;">📤</button>
     <button class="help-btn" id="donate-btn" onclick="openDonate()" title="Support this app · Підтримати застосунок" aria-label="Support this app" style="font-size:18px;display:none;">❤️</button>
     <button class="help-btn" onclick="document.getElementById('help-overlay').classList.remove('hidden')" title="Help" aria-label="Help">?</button>
   </div>
@@ -1304,29 +1303,6 @@ function renderPins() {
 }
 
 // ─────────────────────────────────────────────
-// MAPS.ME KML EXPORT
-// ─────────────────────────────────────────────
-function exportKML() {
-  track('action','export');
-  function esc(s){ return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
-  const hidden = new Set(getHiddenStores());
-  const stores = [...STORES, ...getCustomStores()].filter(s => !hidden.has(s.id) && !s.watermark);
-  const marks = stores.map(s => {
-    const hrs = s.hours ? Object.entries(s.hours).map(([d,h])=>d+':'+h).join(', ') : '';
-    const desc = [s.addressEn||s.address||'', s.phone||'', s.pricing==='kg'?'By KG':'Itemized', (s.cycle||7)+'-day cycle', hrs, s.note||''].filter(Boolean).join('\n');
-    return '  <Placemark><name>'+esc(s.name)+'</name><description>'+esc(desc)+'</description><Point><coordinates>'+s.lng+','+s.lat+',0</coordinates></Point></Placemark>';
-  }).join('\n');
-  const kml = '<?xml version="1.0" encoding="UTF-8"?>\n<kml xmlns="http://www.opengis.net/kml/2.2"><Document>\n<name>Lviv Second Hand Stores</name>\n'+marks+'\n</Document></kml>';
-  const blob = new Blob([kml],{type:'application/vnd.google-earth.kml+xml'});
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href=url; a.download='lviv-secondhand.kml';
-  document.body.appendChild(a); a.click(); document.body.removeChild(a);
-  setTimeout(()=>URL.revokeObjectURL(url),1000);
-  alert(t('kmlDone'));
-}
-
-// ─────────────────────────────────────────────
 // CUSTOM STORES
 // ─────────────────────────────────────────────
 function getCustomStores(){
@@ -1912,7 +1888,7 @@ const HELP = {
     ['✏️ Edit or remove a store','Open any store and tap <strong>Edit Store</strong> to fix its details, or <strong>🗑️ Remove this store</strong> at the bottom. Stores <em>you</em> added are deleted; built-in stores are just hidden on your device — a <strong>"Restore all"</strong> link at the bottom of the list brings them back anytime.'],
     ['⚖️ KG vs Itemized','<strong>By KG</strong> stores charge by weight — you fill a bag and pay per kilogram, and prices drop every day. <strong>Itemized</strong> stores price each item individually.'],
     ['🤝 Share & Contribute','Tap <strong>🤝</strong> to share the stores you\'ve added or edited via a link, file, or code — anyone who opens it merges them onto their map (duplicates are skipped). Tap <strong>🌍 Contribute to the official map</strong> to open a pre-filled GitHub form so your changes can ship with the app.'],
-    ['📤 Maps.me Integration','Tap <strong>📤</strong> to download a KML file with all store locations. In Maps.me: ☰ → Bookmarks → ⋮ → Import → select the file. Inside any store, tap <strong>📍 Maps.me</strong> to jump straight there.'] ] },
+    ['📍 Directions','Inside any store, tap <strong>📍 Maps.me</strong> or <strong>🗺️ Google Maps</strong> to jump straight to it for directions.'] ] },
   ua: { title:'Як користуватися додатком', got:'Зрозуміло!', sections:[
     ['📋 Список','Показує всі магазини. Використовуйте <strong>кнопки фільтрів</strong> угорі, щоб показати лише HUMANA, лише на вагу, відвідані чи ще не відвідані. Проведіть фільтри вбік, якщо не всі видно.'],
     ['🗺️ Карта','Показує розташування магазинів як позначки. <strong>Червоні</strong> = HUMANA. <strong>Сині</strong> = інші. ✓ означає, що ви відвідали. Натисніть позначку для короткого опису, потім «Деталі».<br><br>Натисніть кнопку <strong>📍</strong> (внизу праворуч), щоб увімкнути <strong>ваше місцезнаходження</strong> — ви з\'явитесь синьою крапкою, що рухається за вами. Кнопка стає зеленою, коли ввімкнено; натисніть ще раз, щоб вимкнути. Уперше браузер запитає дозвіл.'],
@@ -1921,7 +1897,7 @@ const HELP = {
     ['✏️ Редагувати чи видалити','Відкрийте магазин і натисніть <strong>«Редагувати»</strong>, щоб змінити деталі, або <strong>🗑️ Видалити магазин</strong> внизу. Магазини, <em>додані вами</em>, видаляються; вбудовані просто ховаються на вашому пристрої — посилання <strong>«Відновити всі»</strong> внизу списку поверне їх будь-коли.'],
     ['⚖️ На вагу чи поштучно','Магазини <strong>на вагу</strong> рахують за кілограм — наповнюєте пакет і платите за кг, ціни падають щодня. <strong>Поштучні</strong> оцінюють кожну річ окремо.'],
     ['🤝 Обмін і внесок','Натисніть <strong>🤝</strong>, щоб поділитися доданими чи зміненими магазинами через посилання, файл або код — хто відкриє, додасть їх на свою карту (дублікати пропускаються). Натисніть <strong>🌍 Внести до офіційної карти</strong>, щоб відкрити заповнену форму GitHub і додати зміни до додатка.'],
-    ['📤 Інтеграція з Maps.me','Натисніть <strong>📤</strong>, щоб завантажити файл KML з усіма магазинами. У Maps.me: ☰ → Закладки → ⋮ → Імпорт → виберіть файл. У магазині натисніть <strong>📍 Maps.me</strong>, щоб одразу перейти туди.'] ] }
+    ['📍 Маршрут','У магазині натисніть <strong>📍 Maps.me</strong> або <strong>🗺️ Google Maps</strong>, щоб одразу прокласти маршрут.'] ] }
 };
 function renderHelp(){
   const hp = HELP[lang] || HELP.en;
@@ -2004,7 +1980,7 @@ if ('serviceWorker' in navigator) {
 // UPDATE CHECK — notify when a newer build is deployed, so nobody is stuck on
 // a cached version (no reinstall needed). Bump APP_VERSION on each deploy.
 // ─────────────────────────────────────────────
-const APP_VERSION = '2026-08-04.5';
+const APP_VERSION = '2026-08-04.6';
 
 // ─────────────────────────────────────────────
 // DONATIONS — points at a Stripe Payment Link (hosted checkout). No API keys

--- a/privacy.html
+++ b/privacy.html
@@ -83,7 +83,6 @@
     <ul>
       <li><strong>Share link / file / code</strong> — creates a link, file, or code containing the stores you added and edited. If you send it to someone, you are choosing to share that information with them. Nothing is uploaded to us; the data travels only through whatever channel you use to send it.</li>
       <li><strong>Contribute to the official map</strong> — opens GitHub with a pre-filled submission so a maintainer can add your stores to the shared map. Anything you post there becomes public and is governed by <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener">GitHub's privacy statement</a>. Only submit information you're comfortable making public.</li>
-      <li><strong>Export to Maps.me (KML)</strong> — generates a file on your device that you can import into the Maps.me app. The file is created locally; we don't receive it.</li>
     </ul>
 
     <h2>5. Third-party services</h2>
@@ -152,7 +151,6 @@
     <ul>
       <li><strong>Посилання / файл / код для обміну</strong> — створює посилання, файл або код із магазинами, які ви додали та змінили. Якщо ви надішлете його комусь, ви самі вирішуєте поділитися цією інформацією. Нічого не завантажується до нас; дані йдуть лише через той канал, який ви оберете.</li>
       <li><strong>Внесок до офіційної карти</strong> — відкриває GitHub із попередньо заповненою формою, щоб супровідник додав ваші магазини до спільної карти. Усе, що ви там публікуєте, стає публічним і регулюється <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener">заявою про конфіденційність GitHub</a>. Надсилайте лише ту інформацію, яку готові зробити публічною.</li>
-      <li><strong>Експорт у Maps.me (KML)</strong> — створює файл на вашому пристрої, який можна імпортувати в додаток Maps.me. Файл створюється локально; ми його не отримуємо.</li>
     </ul>
 
     <h2>5. Сторонні сервіси</h2>


### PR DESCRIPTION
## Summary

Removes the ability for users to dump or download the raw store dataset, in line with the proprietary-data-protection goal.

- Deleted the 📤 KML export header button and the `exportKML()` function from `index.html`.
- Rewrote the in-app help (static help section + `HELP` object EN/UA) so the Maps.me/Google Maps guidance describes only the per-store **📍 Open in Maps.me / Google Maps** directions link — no bulk export.
- Removed the "Export to Maps.me (KML)" / "Maps.me Integration" bullets and sections from `README.md` and `privacy.html` (EN + UA).
- Bumped `APP_VERSION` to `2026-08-04.6`.

The **🤝 Share your map** feature is intentionally kept: it shares only the user's *own* added/edited/removed stores (via `buildBundle`), never the built-in `STORES` dataset, so it is not a database dump.

## Validation

- `exportKML` references: 0
- `STORES` entries: 90 (89 visible + 1 watermark canary)
- App script parse: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_