### PR TITLE
Add one-click Register Telegram webhook workflow

### DIFF
--- a/.github/workflows/register-webhook.yml
+++ b/.github/workflows/register-webhook.yml
@@ -1,0 +1,54 @@
+name: Register Telegram webhook
+
+# One-click, secure `setWebhook` for the Telegram bot. The bot token is read from
+# the TELEGRAM_BOT_TOKEN repo secret (GitHub masks it in logs) — it is never
+# printed or committed. Run this once after the bot Worker is deployed and its
+# WEBHOOK_SECRET is set, and again any time you rotate the secret or change the
+# Worker URL.
+#
+# Requires repo secrets:
+#   TELEGRAM_BOT_TOKEN — from @BotFather
+#   WEBHOOK_SECRET     — the SAME value set on the Worker (must match exactly)
+on:
+  workflow_dispatch:
+    inputs:
+      worker_url:
+        description: "Bot Worker URL"
+        required: true
+        default: "https://lviv-tg-bot.lshanalytic.workers.dev"
+
+permissions:
+  contents: read
+
+jobs:
+  set-webhook:
+    runs-on: ubuntu-latest
+    env:
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
+      WORKER_URL: ${{ github.event.inputs.worker_url }}
+    steps:
+      - name: Check secrets
+        run: |
+          if [ -z "$TELEGRAM_BOT_TOKEN" ]; then
+            echo "::error::TELEGRAM_BOT_TOKEN repo secret is not set. Add it (Settings → Secrets and variables → Actions) and re-run."; exit 1; fi
+          if [ -z "$WEBHOOK_SECRET" ]; then
+            echo "::error::WEBHOOK_SECRET repo secret is not set. Add it and re-run."; exit 1; fi
+      - name: setWebhook
+        run: |
+          echo "Registering webhook → $WORKER_URL"
+          resp=$(curl -sS "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook" \
+            --data-urlencode "url=${WORKER_URL}" \
+            --data-urlencode "secret_token=${WEBHOOK_SECRET}" \
+            --data-urlencode 'allowed_updates=["message"]' \
+            -d "drop_pending_updates=true")
+          echo "setWebhook response: $resp"
+          echo "$resp" | grep -q '"ok":true' || { echo "::error::setWebhook did not return ok:true"; exit 1; }
+      - name: Verify (getWebhookInfo)
+        run: |
+          # getWebhookInfo returns the Worker URL + delivery status — no token in the body.
+          info=$(curl -sS "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getWebhookInfo")
+          echo "getWebhookInfo: $info"
+          if echo "$info" | grep -q '"last_error_message"'; then
+            echo "::warning::Telegram reported a recent delivery error above. If it says 401, WEBHOOK_SECRET here doesn't match the value on the Worker — re-run the deploy-bot workflow so they match, then re-run this."
+          fi

--- a/docs/TELEGRAM_BOT.md
+++ b/docs/TELEGRAM_BOT.md
@@ -68,8 +68,13 @@ npm run deploy
 ```
 
 ### 4. Register the webhook with Telegram
-One-time `curl` (needs the bot token and the same secret). This is the only step
-that uses the token:
+
+**Easiest — the workflow:** add your bot token as a repo secret
+**`TELEGRAM_BOT_TOKEN`**, then run **Actions → “Register Telegram webhook” → Run
+workflow** (the Worker URL is pre-filled). It calls `setWebhook` with the token
+from the secret — never printed — and verifies with `getWebhookInfo`.
+
+**Or by hand** — one-time `curl` (needs the bot token and the same secret):
 ```bash
 curl "https://api.telegram.org/bot<BOT_TOKEN>/setWebhook" \
   -d "url=https://lviv-tg-bot.<your-subdomain>.workers.dev" \


### PR DESCRIPTION
## Summary

A `workflow_dispatch` action that registers the Telegram webhook securely, so the bot token never has to be pasted into a terminal or chat.

- Reads **`TELEGRAM_BOT_TOKEN`** from a repo secret (GitHub masks it in logs — never printed or committed) and **`WEBHOOK_SECRET`**.
- Calls `setWebhook` against the Worker URL (pre-filled: `https://lviv-tg-bot.lshanalytic.workers.dev`, overridable input) with `allowed_updates=["message"]` and `drop_pending_updates=true`.
- Verifies with `getWebhookInfo` and warns if Telegram reports a recent delivery error (e.g. a 401 secret mismatch).
- Fails clearly if either secret is missing.

Doc (`docs/TELEGRAM_BOT.md`) updated to present this as the easiest registration path, with the manual `curl` kept as an alternative.

## Usage

1. Add repo secret `TELEGRAM_BOT_TOKEN` (from @BotFather).
2. Actions → **Register Telegram webhook** → Run workflow.

## Validation

- YAML lints clean.
- Worker URL confirmed from the deploy log (`Deployed lviv-tg-bot … https://lviv-tg-bot.lshanalytic.workers.dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_