### PR TITLE
Harden webhook secret handling against stray whitespace

### DIFF
--- a/.github/workflows/deploy-bot.yml
+++ b/.github/workflows/deploy-bot.yml
@@ -41,4 +41,8 @@ jobs:
           WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
         run: |
           if [ -z "$WEBHOOK_SECRET" ]; then echo "WEBHOOK_SECRET not set — skipping (bot stays locked until you add it and call setWebhook)"; exit 0; fi
-          printf '%s' "$WEBHOOK_SECRET" | npx --yes wrangler@3 secret put WEBHOOK_SECRET
+          # Strip any stray whitespace/newlines so the Worker stores the exact same
+          # value the register-webhook workflow sends to Telegram (which rejects
+          # anything outside A-Z a-z 0-9 _ -).
+          CLEAN=$(printf '%s' "$WEBHOOK_SECRET" | tr -d '[:space:]')
+          printf '%s' "$CLEAN" | npx --yes wrangler@3 secret put WEBHOOK_SECRET

--- a/.github/workflows/register-webhook.yml
+++ b/.github/workflows/register-webhook.yml
@@ -37,9 +37,16 @@ jobs:
       - name: setWebhook
         run: |
           echo "Registering webhook → $WORKER_URL"
+          # Strip stray whitespace/newlines (a pasted secret often carries a
+          # trailing newline), then confirm only Telegram-allowed characters remain.
+          SECRET=$(printf '%s' "$WEBHOOK_SECRET" | tr -d '[:space:]')
+          case "$SECRET" in
+            *[!A-Za-z0-9_-]*)
+              echo "::error::WEBHOOK_SECRET contains characters Telegram disallows (only A-Z a-z 0-9 _ - are allowed). Set it to e.g. the output of 'openssl rand -hex 16', then re-run the deploy-bot and this workflow."; exit 1;;
+          esac
           resp=$(curl -sS "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook" \
             --data-urlencode "url=${WORKER_URL}" \
-            --data-urlencode "secret_token=${WEBHOOK_SECRET}" \
+            --data-urlencode "secret_token=${SECRET}" \
             --data-urlencode 'allowed_updates=["message"]' \
             -d "drop_pending_updates=true")
           echo "setWebhook response: $resp"


### PR DESCRIPTION
## Summary

A pasted `WEBHOOK_SECRET` often carries a trailing newline, which Telegram rejects with `Bad Request: secret token contains unallowed characters` (only `A-Z a-z 0-9 _ -` are allowed). This makes both workflows tolerant of it:

- **deploy-bot.yml** — strips whitespace/newlines before uploading the secret to the Worker, so the Worker stores the same cleaned value the register step sends.
- **register-webhook.yml** — strips whitespace, then validates the remaining value against Telegram's allowed charset with a clear, actionable error before calling `setWebhook`.

Both sides now derive from the identical cleaned value, so a stray newline can't cause a Worker/Telegram mismatch.

## Validation

- Both workflow YAMLs lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_