### PR TITLE
Play Store: signed release (.aab) pipeline + listing copy

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,143 @@
+name: Build Android release (.aab)
+
+# Builds a SIGNED Android App Bundle (.aab) from the Capacitor wrapper in
+# native/, ready to upload to Google Play. Manual-only — run it from the Actions
+# tab when you want a release artifact.
+#
+# ── One-time setup: create an upload keystore and add it as repo secrets ──
+# Run this locally once (keep the .jks file and passwords backed up somewhere
+# safe — losing them means you can never update the app under the same listing):
+#
+#   keytool -genkey -v -keystore upload.jks -alias upload \
+#     -keyalg RSA -keysize 2048 -validity 10000
+#
+# Then base64-encode it and add these four repo secrets
+# (Settings → Secrets and variables → Actions):
+#
+#   base64 -w0 upload.jks        # macOS: base64 -i upload.jks | tr -d '\n'
+#
+#   ANDROID_KEYSTORE_BASE64   — the base64 string from the line above
+#   ANDROID_KEYSTORE_PASSWORD — the store password you chose
+#   ANDROID_KEY_ALIAS         — "upload" (or whatever -alias you used)
+#   ANDROID_KEY_PASSWORD      — the key password (often the same as the store pw)
+#
+# NOTE ON asset links: enable Play App Signing (the default). Google then re-signs
+# the app with its OWN key, so the SHA-256 that must go in
+# .well-known/assetlinks.json is the *App signing key* fingerprint from
+# Play Console → Setup → App signing — NOT the upload-key fingerprint this
+# workflow prints (that one is just for your reference / SHA verification uploads).
+on:
+  workflow_dispatch:
+    inputs:
+      version_name:
+        description: "versionName (e.g. 1.0.0)"
+        required: true
+        default: "1.0.0"
+      version_code:
+        description: "versionCode (integer, must increase every release)"
+        required: true
+        default: "1"
+
+permissions:
+  contents: read
+
+jobs:
+  release-aab:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: native
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Fail early if signing secrets are missing
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          missing=""
+          [ -z "$ANDROID_KEYSTORE_BASE64" ]   && missing="$missing ANDROID_KEYSTORE_BASE64"
+          [ -z "$ANDROID_KEYSTORE_PASSWORD" ] && missing="$missing ANDROID_KEYSTORE_PASSWORD"
+          [ -z "$ANDROID_KEY_ALIAS" ]         && missing="$missing ANDROID_KEY_ALIAS"
+          [ -z "$ANDROID_KEY_PASSWORD" ]      && missing="$missing ANDROID_KEY_PASSWORD"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing repo secret(s):$missing — add them (see this workflow's header comment) and re-run."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Add Android platform
+        run: npx cap add android
+
+      - name: Set versionName / versionCode
+        run: |
+          sed -i "s/versionCode 1/versionCode ${{ github.event.inputs.version_code }}/" android/app/build.gradle
+          sed -i "s/versionName \"1.0\"/versionName \"${{ github.event.inputs.version_name }}\"/" android/app/build.gradle
+          grep -nE "versionCode|versionName" android/app/build.gradle
+
+      - name: Sync web assets & config
+        run: npx cap sync android
+
+      - name: Build release bundle (unsigned)
+        run: |
+          cd android
+          chmod +x ./gradlew
+          ./gradlew bundleRelease --no-daemon
+
+      - name: Decode upload keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/upload.jks"
+
+      - name: Sign the .aab with the upload key
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          AAB=$(find android/app/build/outputs/bundle/release -name '*.aab' | head -n1)
+          if [ -z "$AAB" ]; then echo "::error::No .aab produced by bundleRelease"; exit 1; fi
+          echo "Signing $AAB"
+          jarsigner -sigalg SHA256withRSA -digestalg SHA-256 \
+            -keystore "$RUNNER_TEMP/upload.jks" \
+            -storepass "$ANDROID_KEYSTORE_PASSWORD" \
+            -keypass "$ANDROID_KEY_PASSWORD" \
+            "$AAB" "$ANDROID_KEY_ALIAS"
+          jarsigner -verify -verbose:summary "$AAB" | tail -n 3
+          # Copy to a stable name for the artifact upload step.
+          cp "$AAB" "$RUNNER_TEMP/lviv-secondhand-release.aab"
+
+      - name: Print upload-key SHA-256 (reference only)
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        run: |
+          echo "Upload-key fingerprint (NOT the assetlinks value unless Play App Signing is off):"
+          keytool -list -v -keystore "$RUNNER_TEMP/upload.jks" \
+            -alias "$ANDROID_KEY_ALIAS" -storepass "$ANDROID_KEYSTORE_PASSWORD" \
+            | grep -E "SHA256:" || true
+
+      - name: Upload .aab artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lviv-secondhand-release-aab
+          path: ${{ runner.temp }}/lviv-secondhand-release.aab
+          if-no-files-found: error

--- a/docs/PLAY_LISTING.md
+++ b/docs/PLAY_LISTING.md
@@ -1,0 +1,137 @@
+# Play Store listing — paste-ready copy
+
+Everything you type into the Play Console **Main store listing** and **App
+content** forms, in one place. Assets referenced here already live in the repo
+(`icon-512.png`, `screenshots/`). Bilingual: fill English as the default
+language and add Ukrainian as a translation (the app is EN/UA).
+
+---
+
+## Main store listing
+
+### App name (≤30 chars)
+- **EN:** `Lviv Second Hand`
+- **UA:** `Секонд-хенд Львів`
+
+### Short description (≤80 chars)
+- **EN:** `Find & track Lviv's second-hand stores — map, hours & price-drop timing.`
+- **UA:** `Секонд-хенди Львова: карта, години роботи та дні завезення.`
+
+### Full description (≤4000 chars)
+
+**EN**
+
+```
+Lviv Second Hand is the fastest way to find and track every second-hand and
+thrift clothing store in Lviv — on one map, in your pocket.
+
+WHAT YOU GET
+• Map of second-hand stores across Lviv and nearby towns
+• Show my location to see what's closest, with a live GPS toggle
+• Opening hours for every store
+• Inventory cycle tracker — record when a store last restocked and the app
+  counts the days and estimates how deep the current discounts are
+• Works for both by-weight (за вагу) and itemized stores
+• Best-deal timing: know which by-weight stores are latest in their cycle today
+• Mark stores as visited so you never double-check the same rail
+• Follow a store to get an optional restock reminder
+• Add, edit, and hide stores — and share your map with friends
+• Full English / Ukrainian toggle
+• Works offline once opened — no account, no ads, no personal tracking
+
+WHY
+Second-hand shopping in Lviv is a treasure hunt: prices drop day by day after
+each delivery, and every shop restocks on its own schedule. This app turns that
+into something you can actually plan around — so you show up when the racks are
+fresh, or when they're cheapest.
+
+PRIVACY
+No accounts and no ads. What you add or track stays in your browser on your
+device. Only anonymous, aggregate usage is measured (cookieless), and your
+location is used on-device only to center the map — it's never collected.
+Full policy: https://www.lvivsecondhand.com/privacy.html
+```
+
+**UA**
+
+```
+«Секонд-хенд Львів» — це найшвидший спосіб знайти й відстежувати всі
+секонд-хенди Львова на одній карті у вашому телефоні.
+
+ЩО ВСЕРЕДИНІ
+• Карта секонд-хендів Львова та довколишніх міст
+• «Показати моє місцезнаходження» з живим перемикачем GPS
+• Години роботи кожного магазину
+• Трекер циклу завезення — позначте, коли був останній завіз, а застосунок
+  лічитиме дні та оцінюватиме поточні знижки
+• Працює і для магазинів на вагу, і для поштучних
+• Найкращий час для покупки: які магазини на вагу сьогодні найдешевші
+• Позначайте відвідані магазини
+• Стежте за магазином і отримуйте нагадування про завезення (за бажанням)
+• Додавайте, редагуйте та приховуйте магазини; діліться картою з друзями
+• Повний перемикач мов English / Українська
+• Працює офлайн після відкриття — без акаунтів, без реклами, без стеження
+
+НАВІЩО
+Секонд у Львові — це полювання за скарбами: ціни щодня падають після завозу, і
+кожен магазин має власний графік. Застосунок допомагає це спланувати — приходьте,
+коли завіз свіжий або коли найдешевше.
+
+ПРИВАТНІСТЬ
+Без акаунтів і реклами. Усе, що ви додаєте, лишається у вашому браузері на
+пристрої. Вимірюється лише анонімна статистика (без cookie), а місцезнаходження
+використовується лише на пристрої для центрування карти й ніколи не збирається.
+Політика: https://www.lvivsecondhand.com/privacy.html
+```
+
+### Graphics
+| Asset | File | Size |
+| --- | --- | --- |
+| App icon | `icon-512.png` | 512×512 |
+| Feature graphic | `screenshots/feature-graphic-1024x500.png` | 1024×500 |
+| Phone screenshots | `screenshots/01-list.png`, `02-store.png`, `03-share.png` | 1080×2160 |
+
+### Categorization
+- **App category:** Shopping
+- **Tags:** map, shopping, local
+- **Contact email:** (your support email)
+- **Website:** https://www.lvivsecondhand.com/
+- **Privacy policy:** https://www.lvivsecondhand.com/privacy.html
+
+---
+
+## App content answers (quick reference)
+
+Full rationale is in [`PLAY_STORE.md`](PLAY_STORE.md) §5. Short version:
+
+- **Privacy policy URL:** `https://www.lvivsecondhand.com/privacy.html`
+- **Ads:** No.
+- **App access:** All features available without login.
+- **Content rating:** utility, no objectionable content → Everyone / PEGI 3.
+- **Target audience:** general audience (18+ / not directed at children).
+- **Data safety:**
+  - *Collected:* anonymous app-interaction + page-view analytics (Cloudflare,
+    cookieless) → collected, processed by Cloudflare, **not shared** for ads,
+    **not used to track** across apps/sites.
+  - *Restock notifications (opt-in):* push endpoint + followed store ids → a
+    **Device or other IDs** item, collected for **App functionality** only, not
+    shared, not for tracking, user-deletable by unfollowing.
+  - *Location:* **used, not collected** — on-device only to center the map.
+  - *Your added/edited stores, visits, settings:* stay on-device, not collected.
+
+---
+
+## Ship-today checklist (Internal testing track)
+
+1. [ ] Play Console → **Create app** (name, English default, Free).
+2. [ ] Upload the signed **`.aab`** to **Testing → Internal testing → Create release**.
+3. [ ] Copy the **App signing key SHA-256** from **Setup → App signing** into
+       `.well-known/assetlinks.json` (replace the placeholder), commit, let Pages
+       deploy. This is what hides the address bar / verifies deep links.
+4. [ ] Fill this listing (copy above) + the App content forms (answers above).
+5. [ ] Add testers (email list or a Google Group), save, and share the opt-in link.
+6. [ ] Install from the link on a real phone → confirm the URL bar is hidden
+       (= asset links verified) and the site loads.
+
+Production rollout follows once the account is eligible (see `PLAY_STORE.md` §6
+and the account note in chat).

--- a/docs/PLAY_STORE.md
+++ b/docs/PLAY_STORE.md
@@ -46,10 +46,15 @@ manifest URL, privacy-policy URL).
 
 ## 2. Generate the Android app (three options)
 
-> **Capacitor route:** if you'd rather ship a native WebView shell with a plugin
-> bridge (room to add native push, share sheets, etc. later) instead of a TWA, use
-> the Capacitor wrapper in [`native/`](../native) — see [`CAPACITOR.md`](CAPACITOR.md).
-> It produces the same `.aab` for Play; sections 3–6 below still apply.
+> **Capacitor route (automated):** to ship the native WebView shell in
+> [`native/`](../native) (room to add native push, share sheets, etc. later)
+> instead of a TWA, use the **Build Android release (.aab)** GitHub Action
+> ([`android-release.yml`](../.github/workflows/android-release.yml)). One-time,
+> add an upload keystore as four repo secrets (the workflow's header comment has
+> the exact `keytool` + `base64` commands), then run it from the Actions tab with
+> a `versionName`/`versionCode` and download the signed `.aab` artifact. It
+> produces the same kind of `.aab` for Play; sections 3–6 below still apply.
+> See also [`CAPACITOR.md`](CAPACITOR.md).
 
 ### Option A — PWABuilder (easiest, browser-based)
 
@@ -206,5 +211,7 @@ honestly:
 | `assetlinks.json` template | ✅ package name set (fill in fingerprint) |
 | Custom domain for origin-root asset links | ✅ `www.lvivsecondhand.com` live |
 | Capacitor wrapper (`native/`) | ✅ ready to build (see `CAPACITOR.md`) |
+| Signed release `.aab` CI (`android-release.yml`) | ✅ ready (add keystore secrets, then run) |
+| Store-listing copy (EN/UA) | ✅ `PLAY_LISTING.md` |
 | Feature graphic 1024×500 | ✅ `screenshots/feature-graphic-1024x500.png` |
 | Play Console account + listing + Data Safety | ⬜ your part |


### PR DESCRIPTION
## What & why

Prep to ship the app to Google Play. The repo already had the Capacitor wrapper, icons, manifest, screenshots, feature graphic, and an `assetlinks.json` template — but two things were missing to actually publish: a **signed release artifact** and the **store-listing paperwork**. This adds both.

## Changes

**`.github/workflows/android-release.yml`** — new manual workflow that:
- builds the Capacitor wrapper (`native/`) into a **signed `.aab`**,
- takes the upload keystore from four repo secrets (`ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, `ANDROID_KEY_PASSWORD`) — the header comment has the exact `keytool` + `base64` commands to create them,
- sets `versionName`/`versionCode` from workflow inputs,
- signs via `jarsigner`, verifies the signature, and prints the upload-key SHA-256 for reference,
- uploads the `.aab` as a build artifact.

The existing `android-build.yml` (unsigned debug APK) stays for smoke-testing.

**`docs/PLAY_LISTING.md`** — paste-ready Play Console copy: app name, short + full descriptions (EN + UA), graphics map, App-content/Data-safety answers, and a ship-to-internal-testing checklist.

**`docs/PLAY_STORE.md`** — points the Capacitor route at the new workflow and refreshes the status table.

## Notes / honest status
- **Signing:** assumes Play App Signing (the default). Google re-signs with its own key, so the SHA-256 that goes into `.well-known/assetlinks.json` is the **App signing key** fingerprint from Play Console → App signing, **not** the upload-key fingerprint the workflow prints. Both the workflow and the docs call this out.
- **Account gating:** publishing still requires a verified Google Play Developer account. A brand-new account needs identity verification (days), and new *personal* accounts must run a 12-tester / 14-day closed test before production. Nothing in this PR can shortcut that — it just makes the artifact + listing ready so upload is quick once the account clears.
- No app/runtime code changed; `index.html` and the dataset are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_