### PR TITLE
Fix keystore decode in Android release workflow

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -105,7 +105,14 @@ jobs:
       - name: Decode upload keystore
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-        run: printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/upload.jks"
+        run: |
+          # A pasted secret often carries newlines/whitespace that GNU `base64 -d`
+          # rejects with "invalid input" — strip all whitespace before decoding.
+          printf '%s' "$ANDROID_KEYSTORE_BASE64" | tr -d '[:space:]' | base64 -d > "$RUNNER_TEMP/upload.jks"
+          if [ ! -s "$RUNNER_TEMP/upload.jks" ]; then
+            echo "::error::Decoded keystore is empty — ANDROID_KEYSTORE_BASE64 is not valid base64. Re-run 'base64 -w0 upload.jks' and paste the whole single line."
+            exit 1
+          fi
 
       - name: Sign the .aab with the upload key
         env:


### PR DESCRIPTION
## What & why

The first run of the **Build Android release (.aab)** workflow (after the four signing secrets were added) got all the way through — the signed-off steps confirm the secrets are present and the release bundle **built successfully** — but failed at *Decode upload keystore*:

```
base64: invalid input
```

A base64 value pasted into a GitHub secret commonly carries a trailing newline / whitespace that GNU `base64 -d` rejects. This strips all whitespace before decoding (same fix already used for the Telegram webhook secret) and adds a clear error if the decoded keystore ends up empty.

## Change
- `.github/workflows/android-release.yml` — `printf … | tr -d '[:space:]' | base64 -d`, plus an empty-file guard with an actionable message.

After merge I'll re-run the workflow to confirm it produces a signed `.aab` artifact end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_