### PR TITLE
Make share-preview & SEO text Ukrainian-first

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,25 +17,25 @@
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="apple-mobile-web-app-title" content="LSH">
-<title>Lviv Second Hand</title>
-<meta name="description" content="Find and track every second-hand & thrift clothing store in Lviv on one map — opening hours, by-weight vs itemized pricing, and restock &amp; price-drop timing. Free, bilingual EN/UA, works offline.">
+<title>Секонд-хенди Львова — карта та ціни · Lviv Second Hand</title>
+<meta name="description" content="Усі секонд-хенди Львова на одній карті: години роботи, ціни на вагу та поштучно, дні завезення і коли найдешевше. Безкоштовно, українською та англійською, працює офлайн.">
 <link rel="canonical" href="https://www.lvivsecondhand.com/">
 <!-- Open Graph (Facebook · Telegram · Viber · LinkedIn) -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Lviv Second Hand">
-<meta property="og:title" content="Lviv Second Hand — find &amp; track Lviv's second-hand stores">
-<meta property="og:description" content="Every second-hand store in Lviv on one map: hours, by-weight vs itemized pricing, and restock &amp; price-drop timing. Free, EN/UA, offline-ready.">
+<meta property="og:title" content="Секонд-хенди Львова — карта, ціни та завезення">
+<meta property="og:description" content="Усі секонд-хенди Львова на одній карті: години роботи, ціни на вагу та поштучно, дні завезення і коли найдешевше. Безкоштовно, працює офлайн.">
 <meta property="og:url" content="https://www.lvivsecondhand.com/">
 <meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
-<meta property="og:image:alt" content="Lviv Second Hand — a map of second-hand clothing stores in Lviv">
+<meta property="og:image:alt" content="Секонд-хенди Львова — карта секонд-хенд магазинів одягу у Львові">
 <meta property="og:locale" content="uk_UA">
 <meta property="og:locale:alternate" content="en_US">
 <!-- Twitter / X -->
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Lviv Second Hand — find &amp; track Lviv's second-hand stores">
-<meta name="twitter:description" content="Every second-hand store in Lviv on one map: hours, pricing, and restock timing. Free, EN/UA, offline-ready.">
+<meta name="twitter:title" content="Секонд-хенди Львова — карта, ціни та завезення">
+<meta name="twitter:description" content="Усі секонд-хенди Львова на одній карті: години, ціни та дні завезення. Безкоштовно, працює офлайн.">
 <meta name="twitter:image" content="https://www.lvivsecondhand.com/og-image.png">
 <link rel="manifest" href="manifest.webmanifest">
 <link rel="icon" href="favicon.svg" type="image/svg+xml">
@@ -2189,7 +2189,7 @@ if ('serviceWorker' in navigator) {
 // UPDATE CHECK — notify when a newer build is deployed, so nobody is stuck on
 // a cached version (no reinstall needed). Bump APP_VERSION on each deploy.
 // ─────────────────────────────────────────────
-const APP_VERSION = '2026-08-06.5';
+const APP_VERSION = '2026-08-06.6';
 
 // ─────────────────────────────────────────────
 // DONATIONS — points at a Stripe Payment Link (hosted checkout). No API keys


### PR DESCRIPTION
## What & why

Follow-up to the Ukrainian-default change (#72). The OG image was already bilingual, but the link-preview blurbs and page metadata were still English-only. This flips the remaining text surfaces to Ukrainian-first.

## Changes (all in `index.html`)

- **`og:title` / `og:description`** → Ukrainian.
- **`twitter:title` / `twitter:description`** (same preview text on X) → Ukrainian, mirroring OG.
- **`og:image:alt`** → Ukrainian.
- **`<title>` and `<meta name="description">`** → Ukrainian-first. The title keeps a `· Lviv Second Hand` brand tail so the app is still recognisable in tabs and search.
- Bumped `APP_VERSION` to `2026-08-06.6`.

## Notes

- Text-only metadata change; no logic, data, or layout changes.
- After merge the previews need a re-scrape to pick up the new text — Facebook Sharing Debugger (**Scrape Again**) and Telegram **@WebpageBot**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_