### PR TITLE
Force all subresources to HTTPS (fix mixed-content "not secure")

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,10 @@
 <html lang="uk">
 <head>
 <meta charset="UTF-8">
+<!-- Force every subresource (tiles, images, beacons, imported data) onto HTTPS so
+     the page can never drop to "not secure" mixed content. Must sit before any
+     resource is referenced. -->
+<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="copyright" content="© 2026 Lviv Second Hand. All rights reserved. Proprietary — see LICENSE.">
 <meta name="author" content="Lviv Second Hand">
@@ -2189,7 +2193,7 @@ if ('serviceWorker' in navigator) {
 // UPDATE CHECK — notify when a newer build is deployed, so nobody is stuck on
 // a cached version (no reinstall needed). Bump APP_VERSION on each deploy.
 // ─────────────────────────────────────────────
-const APP_VERSION = '2026-08-06.7';
+const APP_VERSION = '2026-08-06.8';
 
 // ─────────────────────────────────────────────
 // DONATIONS — points at a Stripe Payment Link (hosted checkout). No API keys


### PR DESCRIPTION
## Problem

On mobile Chrome the padlock reported **"Connection is not secure — this page includes other resources which are not secure."** That's classic **mixed content**: the page is served over HTTPS but at least one subresource is requested over plain `http://`, which downgrades the whole page's security state.

## Investigation

The page and every hard-coded reference are already HTTPS:
- Served HTML (live `www`) has **no** `http://` references.
- Map tiles use `https://{s}.tile.openstreetmap.org/…`.
- Analytics beacon, Cloudflare beacon, donate link, Telegram/GitHub links — all `https://`.
- Vendored Leaflet's only `http://` string is the SVG XML namespace (an identifier, never fetched).

So the insecure request is being made **at runtime**, from a dynamic source that isn't a fixed line in the file — a candidate is an `http://` URL inside imported/shared store data, or a Leaflet default-marker image path in an edge case. Rather than chase one symptom, this fixes the whole class.

## Fix

Add a single CSP directive to `<head>`, before any resource is referenced:

```html
<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
```

`upgrade-insecure-requests` makes the browser transparently rewrite every `http://` subresource request to `https://` before it's sent — tiles, images, beacons, and anything loaded from imported data. It does **not** restrict sources or block anything, so it's a no-op for our already-HTTPS resources and a permanent guard against mixed content from any dynamic source. GitHub Pages can't set real response headers, so the meta-tag form is used.

- Bumped `APP_VERSION` to `2026-08-06.8`.

## Notes / follow-up (not in this PR)

While checking, `https://lvivsecondhand.com/` (the **apex**, no `www`) returned a `502` from my side. It may be a fetch-proxy artifact, but it's worth confirming the apex cleanly redirects to `www` — I can look into the DNS/redirect separately if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_