### PR TITLE
Field-agent visit-logging in the Telegram bot + handbook

### DIFF
--- a/docs/FIELD_AGENT.md
+++ b/docs/FIELD_AGENT.md
@@ -1,0 +1,135 @@
+# Field Agent Handbook · Довідник польового агента
+
+How the Lviv Second Hand field agent surveys stores, advertises the app, records
+each visit, and gets paid. Sections that the agent uses day-to-day are bilingual
+(English / Українська).
+
+> **Roles.** *Owner* = you (operates in English). *Agent* = the field
+> representative in Lviv (operates in Ukrainian). *Sale model* = **survey &
+> advertise** — the agent is paid per verified store visit, with a bonus when a
+> visit produces a result (a QR poster placed, or an owner signed up).
+
+---
+
+## 1. The two bots · Два боти
+
+| Bot | Purpose | Who |
+|---|---|---|
+| **@Secondhandlvivbot** | Log each store visit: `/visit` walks through store → GPS → photo → questionnaire. This is the record that pay is calculated from. | Agent |
+| **capybara-bot** (private) | Day-to-day communication & notes between owner and agent. It translates English ↔ Ukrainian both ways, handles voice notes, and keeps a searchable memory (`/remember`, `/pin`, `/recap`). | Owner ↔ Agent |
+
+**Rule of thumb:** *work* (each store) is recorded in **@Secondhandlvivbot**;
+*talking* (questions, coordination, daily plan) happens in **capybara-bot**.
+
+**Правило:** *робота* (кожен магазин) — у **@Secondhandlvivbot**; *спілкування*
+(питання, координація, план на день) — у **capybara-bot**.
+
+---
+
+## 2. Payment scheme · Схема оплати
+
+Two components. Numbers below are the **defaults** — adjust them in
+`telegram-bot/wrangler.toml` (`RATE_VISIT`, `RATE_BONUS`); the bot's `/report`
+uses the same numbers.
+
+| Component | Default | Paid when |
+|---|---|---|
+| **Visit base** · база за візит | **₴80** | A visit is submitted in `/visit` with **GPS + storefront photo + full questionnaire**. One store = one base per survey cycle. |
+| **Bonus** · бонус | **₴200 each** | A verifiable result: **QR poster placed** in the store (photo proof), or **owner signed up** (owner contact captured *and* they submit via the form / agree to be featured). Both can apply → two bonuses. |
+
+**Targets & guardrails**
+
+- Suggested pace: **8–12 stores/day**. A realistic day ≈ ₴640–₴960 base, plus bonuses.
+- A visit **only counts** if it has a real GPS reading, a clear storefront photo,
+  and every question answered. Incomplete submissions don't count.
+- The bot records **distance from the store's map pin**; visits far from the pin
+  (or from a plausible new-store location) are flagged for the owner to review.
+- **No double-pay:** re-visiting the same store in the same survey cycle doesn't
+  earn a second base (it can still earn a bonus for a new poster/sign-up).
+- **Pay cadence:** weekly. The owner runs `/report` (totals + estimated pay) and
+  `/export` (full CSV), reconciles against poster photos / form submissions, and
+  pays by the agreed method (cash or bank transfer, ₴ UAH).
+
+*Оплата: **₴80** за перевірений візит (GPS + фото + анкета) + **₴200** бонус за
+результат (плакат розміщено або власник зареєструвався). Ціль: 8–12 магазинів/день.
+Виплати — щотижня.*
+
+---
+
+## 3. Standard operating procedure · Порядок роботи
+
+**Before the day / Перед виходом**
+1. Owner sends the day's target area/list in **capybara-bot**.
+2. Agent brings a charged phone with location on, and printed **QR posters**
+   (`marketing/qr-poster.pdf`).
+
+**At each store / У кожному магазині**
+1. Look at the storefront, go inside, be polite — you represent the app.
+2. Briefly advertise: “Цей магазин є на безкоштовній карті секонд-хендів Львова —
+   ось QR, покупці знаходять вас за годинами й цінами.” Offer to place a **QR poster**.
+2. Опишіть коротко застосунок і запропонуйте розмістити **QR-плакат**.
+3. In **@Secondhandlvivbot** send **/visit** and follow the steps:
+   `store name → 📍 location → 📷 storefront photo → questions`. Submit ✅.
+4. If the store isn't on the map yet, type `new <name>` at the first step.
+5. If the owner/manager is interested, capture their contact and point them at the
+   in-app **owner form** (or `/submit` in the bot) → that's a **bonus**.
+
+**End of day / Наприкінці дня**
+- Agent: quick summary in **capybara-bot** (areas done, issues, stores to revisit).
+- Owner: `/report` to see the running total; `/export` weekly for the CSV.
+
+---
+
+## 4. The questionnaire · Анкета (what `/visit` asks)
+
+Kept short so a survey takes ~1 minute. The bot captures these; keep this list
+and `QUESTIONS` in `telegram-bot/worker.js` in sync.
+
+| # | Field | Answer |
+|---|---|---|
+| 1 | **Store** · Магазин | pick from the map, or `new <name>` |
+| 2 | **Location** · Геолокація | share current GPS at the store |
+| — | **Photo** · Фото | one clear storefront/entrance photo |
+| 3 | **Pricing** · Тип цін | by weight / itemized / both / unknown |
+| 4 | **Restock day** · День завезення | Mon–Sun / none / unknown *(by-weight only)* |
+| 5 | **Hours** · Години роботи | e.g. `10:00–20:00`, or “closed …” |
+| 6 | **Size** · Розмір | S / M / L |
+| 7 | **Poster placed?** · Плакат розміщено? | yes / no  → 💰 bonus |
+| 8 | **Owner contact + consent?** · Контакт власника + згода? | yes / no  → 💰 bonus |
+| 9 | **Notes** · Нотатки | anything useful, or “-” |
+
+Auto-recorded with every visit: timestamp, agent, GPS, distance from the map pin,
+and the photo.
+
+---
+
+## 5. Data & privacy · Дані та приватність
+
+- The bot stores only what the survey needs (store, GPS, storefront photo,
+  answers) in a private Cloudflare KV namespace; nothing is public.
+- Photograph **storefronts and merchandise**, not people. Ask before photographing
+  anyone; don't record names/phones without the person's OK (that's the point of
+  the consent question).
+- Owner contacts are collected only to invite the store onto the map — handle them
+  respectfully and don't share them onward.
+
+---
+
+## 6. Owner setup & tallying · Налаштування власником
+
+One-time enablement of the `/visit` subsystem is documented in
+`telegram-bot/wrangler.toml` (create the `VISITS` KV namespace, set `BOT_TOKEN`,
+`OWNER_ID`, `AGENT_IDS`, and the rates). After that:
+
+| Command | Who | Does |
+|---|---|---|
+| `/whoami` | anyone | replies with your numeric Telegram id (to be allow-listed) |
+| `/visit` | agent | start a survey |
+| `/myvisits` | agent | their running visit count |
+| `/cancel` | agent | abort the current survey |
+| `/report` | owner | totals, per-agent counts, **estimated pay** |
+| `/export` | owner | CSV of every logged visit |
+
+Each submitted visit is also **pushed to the owner in real time** (photo +
+summary) for spot-checking. Reconcile `/export` against poster photos and form
+submissions before paying.

--- a/docs/TELEGRAM_BOT.md
+++ b/docs/TELEGRAM_BOT.md
@@ -15,6 +15,12 @@ chat. It lives in [`telegram-bot/`](../telegram-bot).
 Every result links back into the app with a `?store=<id>` deep link, so tapping
 it opens that store's page, map pin, and price tracker.
 
+There is also an opt-in **field-agent subsystem** (`/visit`, `/report`, `/export`)
+for a hired rep to log store surveys — off by default, enabled per
+[`telegram-bot/wrangler.toml`](../telegram-bot/wrangler.toml). See the
+[Field Agent Handbook](FIELD_AGENT.md) for the process, payment scheme, and
+questionnaire.
+
 ## Why only by-weight stores drive `/today` and `/cheap`
 
 The bot answers from **global** facts only. The by-weight (Світ-style) stores have

--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -1,21 +1,27 @@
 // ─────────────────────────────────────────────────────────────────────────────
 // Lviv Second Hand — Telegram bot (Cloudflare Worker, webhook-based)
 //
-// Commands:
+// Public commands (stateless, answered inside the webhook response — no token):
 //   /start, /help — intro + command list
 //   /today        — stores getting fresh stock TODAY (fixed weekly restock day)
 //   /cheap        — best by-weight deals right now (late in the weekly cycle)
+//   /submit       — point store owners at the web submission form
 //
-// Data source: the app's own curated dataset, extracted from index.html at build
-// time into stores.gen.js (single source of truth — see build-data.mjs). The bot
-// only reasons about GLOBAL facts: the by-weight stores with a fixed weekly
-// restock day. Per-user delivery dates live in each visitor's browser and are
-// deliberately never on the server, so the bot never guesses about them.
+// Field-agent commands (stateful — require BOT_TOKEN + the VISITS KV binding):
+//   /visit        — guided store-survey flow (store → GPS → photo → questionnaire)
+//   /myvisits     — an agent's own running visit count
+//   /cancel       — abort an in-progress /visit
+//   /whoami       — reply with your numeric Telegram ID (to get allow-listed)
+//   /report       — OWNER only: totals, per-agent counts, estimated pay
+//   /export       — OWNER only: CSV of all logged visits
 //
-// Replies use Telegram's "answer in the webhook response" pattern: we return a
-// single sendMessage call as the HTTP response body, so no bot token is needed at
-// runtime. The only secret is WEBHOOK_SECRET, which authenticates that inbound
-// requests really come from Telegram.
+// The survey the agent fills in is the field questionnaire from
+// docs/FIELD_AGENT.md — that doc is the single source of truth for the process,
+// payment scheme, and questions; keep the two in sync.
+//
+// Data source for the public commands: the app's curated dataset, extracted from
+// index.html at build time into stores.gen.js (see build-data.mjs). Visit records
+// live in the VISITS KV namespace, keyed so they sort chronologically.
 // ─────────────────────────────────────────────────────────────────────────────
 import { STORES } from './stores.gen.js';
 
@@ -124,7 +130,7 @@ function submitText() {
   ].join('\n');
 }
 
-// Map a command to its reply text. Returns null for anything we don't handle.
+// Map a public command to its reply text. Returns null for anything we don't handle.
 function replyFor(text) {
   // Strip a leading /command, tolerate "/today@BotName" and trailing args.
   const m = /^\/([a-z]+)(?:@\w+)?/i.exec(text.trim());
@@ -145,6 +151,7 @@ function replyFor(text) {
   }
 }
 
+// Stateless reply: answer inside the webhook HTTP response (no bot token needed).
 function sendMessage(chatId, text) {
   return new Response(
     JSON.stringify({ method: 'sendMessage', chat_id: chatId, text, parse_mode: 'HTML', disable_web_page_preview: true }),
@@ -154,10 +161,388 @@ function sendMessage(chatId, text) {
 
 const ok = (body = 'ok') => new Response(body, { status: 200 });
 
+// ─────────────────────────────────────────────────────────────────────────────
+// FIELD-AGENT VISIT SUBSYSTEM
+// Active Bot API calls (needs BOT_TOKEN) + per-user state in the VISITS KV
+// namespace. Only enabled when both are configured; otherwise the field commands
+// report that the feature is not set up and the public bot is unaffected.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SESSION_TTL = 60 * 60 * 6; // abandon an in-progress visit after 6h
+const MATCH_LIMIT = 8; // how many candidate stores to list on an ambiguous name
+const NEAR_METERS = 250; // GPS this close to the picked store's pin = "on site"
+
+// The questionnaire, in agent order. `kb` = reply-keyboard rows (bilingual button
+// labels). Keep in sync with docs/FIELD_AGENT.md.
+const QUESTIONS = [
+  { key: 'pricing', q: '3️⃣ Тип цін? · Pricing type?', kb: [['⚖️ Вага / By weight', '🏷️ Штука / Itemized'], ['🔀 Обидва / Both', '❓ Не знаю / Unknown']] },
+  { key: 'restock', q: '4️⃣ День завезення (для ваги)? · Restock day (by-weight)?', kb: [['Пн/Mon', 'Вт/Tue', 'Ср/Wed'], ['Чт/Thu', 'Пт/Fri', 'Сб/Sat'], ['Нд/Sun', '— Немає/None', '❓ Unknown']], onlyWeight: true },
+  { key: 'hours', q: '5️⃣ Години роботи? (напр. 10:00–20:00, або «зачинено») · Opening hours?', kb: null },
+  { key: 'size', q: '6️⃣ Розмір магазину? · Store size?', kb: [['🟢 S малий/small', '🟡 M середній/medium', '🔴 L великий/large']] },
+  { key: 'poster', q: '7️⃣ QR-плакат розміщено? · QR poster placed?  (💰 бонус/bonus)', kb: [['✅ Так / Yes', '❌ Ні / No']] },
+  { key: 'contact', q: '8️⃣ Контакт власника + згода на карту? · Owner contact + consent to feature?  (💰 бонус/bonus)', kb: [['✅ Так / Yes', '❌ Ні / No']] },
+  { key: 'notes', q: '9️⃣ Нотатки? (або «-») · Notes? (or "-")', kb: null },
+];
+
+function cfg(env) {
+  return {
+    enabled: Boolean(env.BOT_TOKEN && env.VISITS),
+    ownerId: String(env.OWNER_ID || ''),
+    agentIds: String(env.AGENT_IDS || '').split(',').map((s) => s.trim()).filter(Boolean),
+    rateVisit: Number(env.RATE_VISIT || 80),
+    rateBonus: Number(env.RATE_BONUS || 200),
+  };
+}
+
+// Call the Telegram Bot API actively (for the stateful flow / owner pushes).
+async function tg(env, method, params) {
+  const res = await fetch(`https://api.telegram.org/bot${env.BOT_TOKEN}/${method}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
+  });
+  return res.json().catch(() => ({}));
+}
+
+function say(env, chatId, text, keyboard) {
+  const reply_markup = keyboard
+    ? { keyboard: keyboard.map((row) => row.map((t) => ({ text: t }))), resize_keyboard: true, one_time_keyboard: true }
+    : { remove_keyboard: true };
+  return tg(env, 'sendMessage', { chat_id: chatId, text, parse_mode: 'HTML', disable_web_page_preview: true, reply_markup });
+}
+
+function norm(s) {
+  return String(s || '').toLowerCase().trim();
+}
+
+function searchStores(query) {
+  const q = norm(query);
+  if (!q) return [];
+  const byId = STORES.find((s) => s.id.toLowerCase() === q);
+  if (byId) return [byId];
+  return STORES.filter((s) => norm(s.name).includes(q) || (s.address && norm(s.address).includes(q))).slice(0, MATCH_LIMIT + 1);
+}
+
+// Metres between two {lat,lng} points (haversine).
+function distM(a, b) {
+  const R = 6371000, toRad = (d) => (d * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat), dLng = toRad(b.lng - a.lng);
+  const s = Math.sin(dLat / 2) ** 2 + Math.cos(toRad(a.lat)) * Math.cos(toRad(b.lat)) * Math.sin(dLng / 2) ** 2;
+  return Math.round(2 * R * Math.asin(Math.sqrt(s)));
+}
+
+const sessionKey = (uid) => `session:${uid}`;
+const getSession = (env, uid) => env.VISITS.get(sessionKey(uid), { type: 'json' });
+const putSession = (env, uid, s) => env.VISITS.put(sessionKey(uid), JSON.stringify(s), { expirationTtl: SESSION_TTL });
+const clearSession = (env, uid) => env.VISITS.delete(sessionKey(uid));
+
+// Interpret bilingual button text into stored values.
+function readPricing(t) {
+  const n = norm(t);
+  if (n.includes('вага') || n.includes('weight')) return 'kg';
+  if (n.includes('штук') || n.includes('itemi')) return 'item';
+  if (n.includes('обид') || n.includes('both')) return 'both';
+  return 'unknown';
+}
+function readDay(t) {
+  const n = norm(t);
+  for (const d of DAYS) if (n.startsWith(d) || n.includes('/' + d)) return d;
+  if (n.includes('пн')) return 'mon'; if (n.includes('вт')) return 'tue'; if (n.includes('ср')) return 'wed';
+  if (n.includes('чт')) return 'thu'; if (n.includes('пт')) return 'fri'; if (n.includes('сб')) return 'sat'; if (n.includes('нд')) return 'sun';
+  if (n.includes('немає') || n.includes('none')) return '—';
+  return 'unknown';
+}
+function readSize(t) {
+  const n = norm(t);
+  if (n.includes('s ') || n.includes('мал') || n.includes('small')) return 'S';
+  if (n.includes('l ') || n.includes('вел') || n.includes('large')) return 'L';
+  return 'M';
+}
+const readYes = (t) => /так|yes|✅/i.test(String(t));
+
+// Advance to the next questionnaire step, skipping restock for non-weight stores.
+async function askNext(env, uid, chatId, session) {
+  let i = session.qi;
+  while (i < QUESTIONS.length) {
+    const question = QUESTIONS[i];
+    if (question.onlyWeight && !['kg', 'both'].includes(session.data.pricing)) {
+      session.data.restock = 'n/a';
+      i++;
+      continue;
+    }
+    session.qi = i;
+    session.step = 'question';
+    await putSession(env, uid, session);
+    return say(env, chatId, question.q, question.kb);
+  }
+  // Questions done → confirmation.
+  session.step = 'confirm';
+  await putSession(env, uid, session);
+  return say(env, chatId, summary(session) + '\n\n<b>Надіслати? · Submit?</b>', [['✅ Надіслати / Submit', '✖️ Скасувати / Cancel']]);
+}
+
+function summary(session) {
+  const d = session.data;
+  const st = d.store;
+  const lines = [
+    '🧾 <b>Перевірте візит · Review visit</b>',
+    `🏪 ${esc(st.name)}${st.isNew ? ' <i>(новий · new)</i>' : ''}`,
+  ];
+  if (st.address) lines.push(`📍 ${esc(st.address)}`);
+  if (d.lat != null) lines.push(`🗺️ GPS ${d.lat.toFixed(5)}, ${d.lng.toFixed(5)}${d.distM != null ? ` (~${d.distM} м від точки/from pin)` : ''}`);
+  lines.push(`📷 Фото · Photo: ${d.photoFileId ? '✅' : '—'}`);
+  lines.push(`💰 Ціни · Pricing: ${esc(d.pricing || '—')}`);
+  if (d.restock && d.restock !== 'n/a') lines.push(`📦 Завезення · Restock: ${esc(d.restock)}`);
+  lines.push(`🕐 Години · Hours: ${esc(d.hours || '—')}`);
+  lines.push(`📐 Розмір · Size: ${esc(d.size || '—')}`);
+  lines.push(`🪧 Плакат · Poster: ${d.poster ? '✅' : '❌'}`);
+  lines.push(`🤝 Контакт · Contact: ${d.contact ? '✅' : '❌'}`);
+  if (d.notes && d.notes !== '-') lines.push(`📝 ${esc(d.notes)}`);
+  return lines.join('\n');
+}
+
+async function bump(env, key, by = 1) {
+  const cur = Number((await env.VISITS.get('count:' + key)) || 0) + by;
+  await env.VISITS.put('count:' + key, String(cur));
+  return cur;
+}
+
+async function finishVisit(env, c, uid, chatId, session, from) {
+  const d = session.data;
+  const now = new Date();
+  const rec = {
+    ts: now.toISOString(),
+    agentId: uid,
+    agentName: [from.first_name, from.last_name].filter(Boolean).join(' ') || from.username || String(uid),
+    store: d.store,
+    lat: d.lat ?? null,
+    lng: d.lng ?? null,
+    distM: d.distM ?? null,
+    photoFileId: d.photoFileId || null,
+    pricing: d.pricing || null,
+    restock: d.restock || null,
+    hours: d.hours || null,
+    size: d.size || null,
+    poster: !!d.poster,
+    contact: !!d.contact,
+    notes: d.notes && d.notes !== '-' ? d.notes : null,
+  };
+  // Key sorts chronologically; include uid so two agents can't collide on a ts.
+  await env.VISITS.put(`visit:${rec.ts}:${uid}`, JSON.stringify(rec));
+  const bonusUnits = (rec.poster ? 1 : 0) + (rec.contact ? 1 : 0);
+  await bump(env, 'total');
+  await bump(env, 'agent:' + uid);
+  if (bonusUnits) await bump(env, 'bonus', bonusUnits);
+  await clearSession(env, uid);
+
+  const earned = c.rateVisit + bonusUnits * c.rateBonus;
+  const mine = Number((await env.VISITS.get('count:agent:' + uid)) || 0);
+  await say(env, chatId,
+    `✅ <b>Візит записано! · Visit logged!</b>\n` +
+    `💵 +₴${c.rateVisit}${bonusUnits ? ` +₴${bonusUnits * c.rateBonus} бонус/bonus` : ''} = <b>₴${earned}</b>\n` +
+    `📊 Ваших візитів усього · Your total visits: <b>${mine}</b>\n\n` +
+    `Наступний магазин — /visit · Next store — /visit`);
+
+  // Real-time push to the owner (photo + summary) for verification, if configured.
+  if (c.ownerId) {
+    const caption = summary(session).replace('🧾 <b>Перевірте візит · Review visit</b>', `🆕 <b>Візит · Visit</b> — ${esc(rec.agentName)}`);
+    if (rec.photoFileId) await tg(env, 'sendPhoto', { chat_id: c.ownerId, photo: rec.photoFileId, caption, parse_mode: 'HTML' });
+    else await tg(env, 'sendMessage', { chat_id: c.ownerId, text: caption, parse_mode: 'HTML' });
+  }
+}
+
+async function ownerReport(env, c, chatId) {
+  const total = Number((await env.VISITS.get('count:total')) || 0);
+  const bonus = Number((await env.VISITS.get('count:bonus')) || 0);
+  const lines = ['📊 <b>Field report · Звіт</b>', `Visits logged: <b>${total}</b>`, `Bonus events: <b>${bonus}</b>`];
+  // Per-agent counts.
+  for (const id of c.agentIds) {
+    const n = Number((await env.VISITS.get('count:agent:' + id)) || 0);
+    if (n) lines.push(`• agent <code>${id}</code>: ${n} visits`);
+  }
+  const pay = total * c.rateVisit + bonus * c.rateBonus;
+  lines.push('', `💵 Estimated pay: <b>₴${pay}</b>  (₴${c.rateVisit}/visit + ₴${c.rateBonus}/bonus)`);
+  lines.push('Use /export for the full CSV.');
+  await say(env, chatId, lines.join('\n'));
+}
+
+async function ownerExport(env, chatId) {
+  const list = await env.VISITS.list({ prefix: 'visit:', limit: 1000 });
+  const rows = [['ts', 'agentId', 'agentName', 'storeId', 'storeName', 'lat', 'lng', 'distM', 'pricing', 'restock', 'hours', 'size', 'poster', 'contact', 'notes', 'photoFileId']];
+  for (const k of list.keys) {
+    const r = await env.VISITS.get(k.name, { type: 'json' });
+    if (!r) continue;
+    const csv = (v) => `"${String(v == null ? '' : v).replace(/"/g, '""')}"`;
+    rows.push([r.ts, r.agentId, r.agentName, r.store?.id || '', r.store?.name || '', r.lat, r.lng, r.distM, r.pricing, r.restock, r.hours, r.size, r.poster, r.contact, r.notes, r.photoFileId].map(csv));
+  }
+  const csvText = rows.map((row) => row.join(',')).join('\n');
+  const form = new FormData();
+  form.append('chat_id', String(chatId));
+  form.append('caption', `📄 ${rows.length - 1} visit(s)`);
+  form.append('document', new Blob([csvText], { type: 'text/csv' }), `visits-${new Date().toISOString().slice(0, 10)}.csv`);
+  await fetch(`https://api.telegram.org/bot${env.BOT_TOKEN}/sendDocument`, { method: 'POST', body: form });
+}
+
+function notAgentMsg(uid) {
+  return `🔒 Ви не в списку польових агентів. · You're not a registered field agent.\n` +
+    `Надішліть власнику цей ID, щоб отримати доступ · Send this ID to the owner to get access:\n<code>${uid}</code>`;
+}
+
+// Handle an update for the visit subsystem. Returns true if it consumed the update.
+async function handleVisit(env, c, msg, ctx) {
+  const { userId, chatId, text, from } = ctx;
+  const isOwner = c.ownerId && String(userId) === c.ownerId;
+  const isAgent = c.agentIds.includes(String(userId));
+  const command = text ? (/^\/([a-z]+)(?:@\w+)?/i.exec(text.trim()) || [])[1]?.toLowerCase() : null;
+
+  if (command === 'whoami' || command === 'myid') {
+    await say(env, chatId, `Your Telegram ID · Ваш ID: <code>${userId}</code>`);
+    return true;
+  }
+  if (isOwner && (command === 'report' || command === 'visits')) { await ownerReport(env, c, chatId); return true; }
+  if (isOwner && command === 'export') { await ownerExport(env, chatId); return true; }
+
+  const session = await getSession(env, userId);
+
+  if (command === 'cancel') {
+    if (session) { await clearSession(env, userId); await say(env, chatId, 'Скасовано. · Cancelled. /visit щоб почати знову.'); return true; }
+    return false;
+  }
+  if (command === 'myvisits') {
+    if (!isAgent) return false;
+    const n = Number((await env.VISITS.get('count:agent:' + userId)) || 0);
+    await say(env, chatId, `📊 Ваших візитів усього · Your total visits: <b>${n}</b>`);
+    return true;
+  }
+  if (command === 'visit') {
+    if (!isAgent) { await say(env, chatId, notAgentMsg(userId)); return true; }
+    const fresh = { step: 'store', qi: 0, data: {} };
+    await putSession(env, userId, fresh);
+    await say(env, chatId,
+      '📝 <b>Новий візит · New visit</b>\n' +
+      '1️⃣ Назва магазину (або частина)? Для нового магазину: <code>new Назва</code>.\n' +
+      'Store name (or part)? For a store not on the map: <code>new Name</code>.\n\n' +
+      '/cancel щоб вийти · to abort');
+    return true;
+  }
+
+  // No active session and not one of our commands → let the public handler reply.
+  if (!session) return false;
+
+  // ── In-session step machine ──
+  if (session.step === 'store') {
+    const raw = (text || '').trim();
+    if (!raw) { await say(env, chatId, 'Надішліть назву магазину текстом. · Send the store name as text.'); return true; }
+    if (/^new\s+/i.test(raw)) {
+      session.data.store = { isNew: true, name: raw.replace(/^new\s+/i, '').trim() };
+      session.step = 'location';
+      await putSession(env, userId, session);
+      await say(env, chatId, '📍 Надішліть <b>геолокацію</b> магазину (📎 → Location → Send current location).\nShare the store <b>location</b>.');
+      return true;
+    }
+    const hits = searchStores(raw);
+    if (!hits.length) { await say(env, chatId, '🤷 Не знайдено. Спробуйте іншу назву, або <code>new Назва</code>.\nNo match — try again, or <code>new Name</code>.'); return true; }
+    if (hits.length === 1) {
+      const s = hits[0];
+      session.data.store = { id: s.id, name: s.name, address: s.address || '', lat: s.lat, lng: s.lng };
+      session.step = 'location';
+      await putSession(env, userId, session);
+      await say(env, chatId, `✅ ${esc(s.name)}\n📍 Тепер надішліть <b>геолокацію</b> магазину.\nNow share the store <b>location</b> (📎 → Location).`);
+      return true;
+    }
+    // Ambiguous → numbered list.
+    session.step = 'store_pick';
+    session.data.candidates = hits.slice(0, MATCH_LIMIT).map((s) => ({ id: s.id, name: s.name, address: s.address || '', lat: s.lat, lng: s.lng }));
+    await putSession(env, userId, session);
+    const list = session.data.candidates.map((s, i) => `${i + 1}. ${esc(s.name)}${s.address ? ' — ' + esc(s.address) : ''}`).join('\n');
+    await say(env, chatId, 'Кілька збігів — надішліть номер · Several matches — reply with the number:\n' + list,
+      session.data.candidates.map((_, i) => [String(i + 1)]));
+    return true;
+  }
+
+  if (session.step === 'store_pick') {
+    const n = parseInt((text || '').trim(), 10);
+    const pick = session.data.candidates && session.data.candidates[n - 1];
+    if (!pick) { await say(env, chatId, 'Надішліть номер зі списку. · Reply with a number from the list.'); return true; }
+    session.data.store = pick;
+    delete session.data.candidates;
+    session.step = 'location';
+    await putSession(env, userId, session);
+    await say(env, chatId, `✅ ${esc(pick.name)}\n📍 Надішліть <b>геолокацію</b> магазину. · Share the store <b>location</b>.`);
+    return true;
+  }
+
+  if (session.step === 'location') {
+    if (!msg.location) { await say(env, chatId, '📍 Потрібна геолокація: 📎 → Location → Send current location.\nPlease share a location.'); return true; }
+    session.data.lat = msg.location.latitude;
+    session.data.lng = msg.location.longitude;
+    const st = session.data.store;
+    if (st && st.lat != null) {
+      session.data.distM = distM({ lat: st.lat, lng: st.lng }, { lat: session.data.lat, lng: session.data.lng });
+    }
+    session.step = 'photo';
+    await putSession(env, userId, session);
+    const warn = session.data.distM != null && session.data.distM > NEAR_METERS
+      ? `\n⚠️ ~${session.data.distM} м від точки на карті. Переконайтесь, що ви біля магазину. · ~${session.data.distM} m from the map pin — make sure you're at the store.`
+      : '';
+    await say(env, chatId, '📷 Надішліть <b>одне фото</b> вітрини/входу. · Send <b>one photo</b> of the storefront.' + warn);
+    return true;
+  }
+
+  if (session.step === 'photo') {
+    if (!msg.photo || !msg.photo.length) { await say(env, chatId, '📷 Потрібне фото. · A photo is required. Send one photo.'); return true; }
+    session.data.photoFileId = msg.photo[msg.photo.length - 1].file_id; // largest size
+    session.qi = 0;
+    await putSession(env, userId, session);
+    return handleQuestionsStart(env, userId, chatId, session);
+  }
+
+  if (session.step === 'question') {
+    const question = QUESTIONS[session.qi];
+    const val = (text || '').trim();
+    if (!val && question.key !== 'notes') { await say(env, chatId, 'Оберіть варіант або надішліть відповідь. · Pick an option or send an answer.'); return true; }
+    switch (question.key) {
+      case 'pricing': session.data.pricing = readPricing(val); break;
+      case 'restock': session.data.restock = readDay(val); break;
+      case 'hours': session.data.hours = val; break;
+      case 'size': session.data.size = readSize(val); break;
+      case 'poster': session.data.poster = readYes(val); break;
+      case 'contact': session.data.contact = readYes(val); break;
+      case 'notes': session.data.notes = val || '-'; break;
+    }
+    session.qi++;
+    await putSession(env, userId, session);
+    return askNext(env, userId, chatId, session);
+  }
+
+  if (session.step === 'confirm') {
+    if (readYes(text) || /надіслати|submit/i.test(text || '')) {
+      await finishVisit(env, c, userId, chatId, session, from);
+      return true;
+    }
+    if (/скасувати|cancel|✖️|❌/i.test(text || '')) {
+      await clearSession(env, userId);
+      await say(env, chatId, 'Скасовано. · Cancelled.');
+      return true;
+    }
+    await say(env, chatId, 'Оберіть: ✅ Надіслати або ✖️ Скасувати. · Choose Submit or Cancel.', [['✅ Надіслати / Submit', '✖️ Скасувати / Cancel']]);
+    return true;
+  }
+
+  return false;
+}
+
+// First questionnaire prompt after the photo.
+async function handleQuestionsStart(env, uid, chatId, session) {
+  session.step = 'question';
+  session.qi = 0;
+  await putSession(env, uid, session);
+  const question = QUESTIONS[0];
+  return say(env, chatId, question.q, question.kb);
+}
+
 export default {
   async fetch(request, env) {
-    const url = new URL(request.url);
-
     // Health check.
     if (request.method === 'GET') {
       return ok('Lviv Second Hand Telegram bot is running.');
@@ -180,9 +565,25 @@ export default {
     }
 
     const msg = update.message || update.edited_message;
-    const text = msg && typeof msg.text === 'string' ? msg.text : null;
-    if (!msg || !text) return ok(); // Ignore non-text updates (joins, photos, callbacks…).
+    if (!msg) return ok(); // Ignore callbacks/joins/etc.
+    const from = msg.from || {};
+    const chatId = msg.chat.id;
+    const text = typeof msg.text === 'string' ? msg.text : null;
 
-    return sendMessage(msg.chat.id, replyFor(text));
+    // Field-agent subsystem (stateful). Only when BOT_TOKEN + VISITS are set.
+    const c = cfg(env);
+    if (c.enabled) {
+      try {
+        const consumed = await handleVisit(env, c, msg, { userId: from.id, chatId, text, from });
+        if (consumed) return ok();
+      } catch (e) {
+        // Never let the field flow break the public bot; ack and move on.
+        return ok();
+      }
+    }
+
+    // Public, stateless commands (answered in the webhook response — no token).
+    if (!text) return ok();
+    return sendMessage(chatId, replyFor(text));
   },
 };

--- a/telegram-bot/wrangler.toml
+++ b/telegram-bot/wrangler.toml
@@ -2,7 +2,10 @@ name = "lviv-tg-bot"
 main = "worker.js"
 compatibility_date = "2026-08-01"
 
-# Serverless Telegram bot (see worker.js). Stateless — no D1/KV bindings.
+# ── Public bot (always on) ──────────────────────────────────────────────────
+# The /today /cheap /submit commands are stateless: the bot answers inside the
+# webhook response, so the bot token is NOT needed at runtime — only when
+# registering the webhook (see docs/TELEGRAM_BOT.md).
 #
 # One secret is required (set out-of-band, never committed):
 #   WEBHOOK_SECRET — a random string; Telegram echoes it back in the
@@ -10,6 +13,30 @@ compatibility_date = "2026-08-01"
 #   inbound requests really come from Telegram. Set it with:
 #     printf '%s' "<random>" | npx wrangler@3 secret put WEBHOOK_SECRET
 #   and pass the SAME value as `secret_token` when calling setWebhook.
+
+# ── Field-agent /visit subsystem (opt-in) ───────────────────────────────────
+# Adds the stateful store-survey flow (/visit, /report, /export — see
+# docs/FIELD_AGENT.md). It stays OFF until BOT_TOKEN *and* the VISITS KV
+# namespace below are both configured, so the public bot is unaffected until
+# you deliberately enable it.
 #
-# The bot answers inside the webhook response, so the bot token is NOT needed at
-# runtime — only when registering the webhook (see docs/TELEGRAM_BOT.md).
+# To enable:
+#   1. Create the KV namespace and paste its id below, then uncomment the block:
+#        npx wrangler@3 kv namespace create VISITS
+#   2. Add the bot token as a secret (used to send the guided prompts, push
+#      each visit to the owner, and upload the CSV export):
+#        printf '%s' "<telegram-bot-token>" | npx wrangler@3 secret put BOT_TOKEN
+#   3. Set who is who + the pay rates as [vars] below (ids are numeric Telegram
+#      user ids — anyone can get theirs by sending the bot /whoami).
+#   4. Re-register the webhook allowing location & photo updates:
+#        allowed_updates=["message"]   (the default already includes these)
+#
+# [[kv_namespaces]]
+# binding = "VISITS"
+# id = "REPLACE_WITH_KV_NAMESPACE_ID"
+#
+# [vars]
+# OWNER_ID   = "000000000"              # your numeric Telegram id (gets /report, /export, live visit pushes)
+# AGENT_IDS  = "111111111,222222222"    # comma-separated agent Telegram ids allowed to run /visit
+# RATE_VISIT = "80"                     # ₴ per verified visit
+# RATE_BONUS = "200"                    # ₴ per bonus event (poster placed / owner contact + consent)


### PR DESCRIPTION
## What & why

Groundwork for hiring a Lviv **field agent** who surveys second-hand stores, advertises the app, and is **paid per verified visit** (plus a bonus on results). Delivers the payment scheme, SOP, questionnaire, and the Telegram logging flow.

Confirmed scope with the owner: **survey & advertise** model · **base per visit + bonus** · log via the existing **@Secondhandlvivbot** · the **capybara-bot** (owner's separate repo) stays the owner↔agent comms channel and is **not modified**.

## Bot — `telegram-bot/worker.js`

Adds an **opt-in, stateful `/visit` subsystem** to the existing Cloudflare Worker; the public commands (`/today`, `/cheap`, `/submit`) are untouched.

- `/visit` walks the agent: **store → GPS → storefront photo → short questionnaire**, then writes a record to a `VISITS` KV namespace.
- Store lookup matches the app dataset, or `new <name>` for an unmapped store. **GPS distance from the map pin** is recorded and flagged for spot-checking.
- Agent **allow-list** (`AGENT_IDS`); helpers `/whoami`, `/myvisits`, `/cancel`.
- **Owner-only** `/report` (totals, per-agent counts, **estimated pay** from `RATE_VISIT`/`RATE_BONUS`) and `/export` (CSV via `sendDocument`). Every submitted visit is also **pushed to the owner live** (photo + summary) for verification.
- **Fully gated:** inert unless `BOT_TOKEN` **and** `VISITS` are both set, so the public bot is unaffected. Field-flow errors are swallowed so they can never break the public bot.

## Config — `telegram-bot/wrangler.toml`

Documented, **commented-out** KV binding + `[vars]` (`OWNER_ID`, `AGENT_IDS`, `RATE_VISIT`, `RATE_BONUS`) and the `BOT_TOKEN` secret. Nothing turns on until you deliberately provision it.

## Docs

- **`docs/FIELD_AGENT.md`** — bilingual (EN/UA) handbook: the two bots, payment scheme (₴80/visit + ₴200/bonus defaults, adjustable), SOP, questionnaire, data/privacy, owner tallying.
- **`docs/TELEGRAM_BOT.md`** — cross-links the new subsystem.

## Not deployed by this PR

Merging changes no running service. The worker only updates when you redeploy it, and the field feature stays **off** until you create the KV namespace and set `BOT_TOKEN` + the vars. It needs a live test with the bot once enabled (I can't exercise the Telegram webhook from here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_