### PR TITLE
Add /materials command to the Telegram bot

### DIFF
--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -89,9 +89,28 @@ function helpText() {
     '/today — stores restocking today · магазини із завезенням сьогодні',
     '/cheap — best by-weight deals right now · найкращі ціни на вагу',
     '/submit — add your store (for owners) · додати свій магазин',
+    '/materials — print-ready flyers, stickers, poster · рекламні матеріали для друку',
     '/help — this message · ця довідка',
     '',
     `🗺️ Full map, hours &amp; price tracker: ${APP_URL}`,
+  ].join('\n');
+}
+
+// Print-ready marketing assets (served by GitHub Pages under /marketing/). Handed
+// back as tap-to-open links — no bot token needed. Keep in sync with tools/social/.
+function materialsText() {
+  const M = APP_URL + 'marketing/';
+  return [
+    '🖨️ <b>Рекламні матеріали · Print materials</b>',
+    'Готові до друку PDF — відкрий і надрукуй. · Print-ready PDFs — open and print.',
+    '',
+    `📄 <a href="${M}flyer.pdf">Флаєр · Flyer</a> — A4 → 4 листівки покупцям · shopper handouts`,
+    `🏷️ <a href="${M}qr-stickers.pdf">QR-наліпки · Stickers</a> — 24 шт. на аркуш · 24 per sheet`,
+    `🖼️ <a href="${M}qr-poster.pdf">Плакат · Poster</a> — A4 на вітрину/стіну · in-store`,
+    `💼 <a href="${M}sell-sheet.pdf">Прайс для власників · Sell-sheet</a> — пропозиція реклами · owner pitch`,
+    '',
+    'Друкуй наліпки на самоклейному папері A4. · Print stickers on A4 label paper.',
+    `🗺️ ${APP_URL}`,
   ].join('\n');
 }
 
@@ -169,6 +188,10 @@ function replyFor(text) {
     case 'submit':
     case 'owner':
       return submitText();
+    case 'materials':
+    case 'print':
+    case 'flyers':
+      return materialsText();
     default:
       return 'Unknown command. Send /help to see what I can do.';
   }


### PR DESCRIPTION
## What & why

Makes the print-ready marketing assets available on demand through the Telegram bot, so the field agent can pull them up in the field.

`/materials` (aliases `/print`, `/flyers`) replies with tap-to-open links to:
- **Flyer** (A4 → 4 shopper handouts)
- **QR stickers** (24/sheet)
- **In-store poster** (A4)
- **Owner sell-sheet** (pitch)

All are already served by GitHub Pages under `/marketing/`. The command is **stateless** (answered in the webhook response — no bot token needed), bilingual, and listed in `/help`.

## Note
The sell-sheet link includes the ad pricing. If you'd rather keep that one out of the public command and show it only to the agent/owner, say so and I'll gate it behind the agent allow-list.

## Follow-up (owner)
Update the BotFather command list (`/setcommands`) to include `submit` and `materials` so they show in the Telegram menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_