### PR TITLE
Set OWNER_ID / AGENT_IDS for the field-agent bot

### DIFF
--- a/telegram-bot/wrangler.toml
+++ b/telegram-bot/wrangler.toml
@@ -36,7 +36,7 @@ binding = "VISITS"
 id = "69158c00d55a4d3ab750cd916afca445"
 
 [vars]
-OWNER_ID   = ""    # TODO: your numeric Telegram id — get it by sending the deployed bot /whoami (or via @userinfobot)
-AGENT_IDS  = ""    # TODO: agent Telegram ids, comma-separated (each sends /whoami). Add your own id here too, to smoke-test /visit.
+OWNER_ID   = "1212541015"    # owner — gets /report, /export, and a live push of each visit
+AGENT_IDS  = "1212541015"    # agents allowed to run /visit (comma-separated). Owner listed to smoke-test; add the agent's id next.
 RATE_VISIT = "80"  # ₴ per verified visit
 RATE_BONUS = "200" # ₴ per bonus event (poster placed / owner contact + consent)


### PR DESCRIPTION
Sets the owner's Telegram ID as `OWNER_ID` (reports/exports/live visit pushes) and as the first `AGENT_IDS` entry so `/visit` can be smoke-tested before the field agent is onboarded. The agent's ID gets appended later.

Final step for the owner: set the `BOT_TOKEN` secret (`npx wrangler secret put BOT_TOKEN`), `git pull`, then `npx wrangler deploy` in `telegram-bot/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_