### PR TITLE
Document /materials; trigger fresh Pages deploy

### DIFF
--- a/docs/TELEGRAM_BOT.md
+++ b/docs/TELEGRAM_BOT.md
@@ -21,6 +21,9 @@ for a hired rep to log store surveys — off by default, enabled per
 [Field Agent Handbook](FIELD_AGENT.md) for the process, payment scheme, and
 questionnaire.
 
+The `/materials` command returns download links to the print-ready flyers, QR
+stickers, in-store poster, and owner sell-sheet (served from `/marketing/`).
+
 ## Why only by-weight stores drive `/today` and `/cheap`
 
 The bot answers from **global** facts only. The by-weight (Світ-style) stores have


### PR DESCRIPTION
Documents the `/materials` bot command, and — more importantly right now — creates a **fresh commit on `main`** to trigger a **new GitHub Pages deployment**. Re-running the stalled deployment (stuck in `deployment_queued`) hasn't cleared it; a brand-new deployment context may sidestep the stuck one.

Docs-only change (no app/bot/behavior impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_