### PR TITLE
Add /pay to the bot; document map-update flow and Stripe product scheme

### DIFF
--- a/docs/ADVERTISING.md
+++ b/docs/ADVERTISING.md
@@ -68,7 +68,10 @@ an `offer` (no gold pin unless `tier` is set — use `tier` only for Featured/Sp
 ## 4. Unit economics (internal)
 
 - **Infra:** ~₴0 — Cloudflare + GitHub Pages free tiers.
-- **Payments:** bank transfer / cash ≈ ₴0 fee; card ≈ 2–3% if used.
+- **Payments:** card via **Stripe** ≈ **2.9% + a small fixed fee** per successful
+  charge (confirm your country's exact rate). On a ₴600 Featured that's ≈ ₴17 +
+  fixed — immaterial against the margin. Bank transfer / cash stays available at ₴0
+  fee where a store prefers it.
 - **Fulfilment:** ~5 min owner time per sale (hand-edit `promo` + deploy).
 - **Agent cost now (Phase 1):** ₴80/verified visit + poster/sign-up bonuses.
 - **Agent cost when selling (Phase 2):** a **one-time bonus per signed store**
@@ -101,14 +104,53 @@ Small stores buy foot traffic, not "impressions." Give them tangible proof:
 ## 6. Billing, cadence & compliance
 
 - **Cadence:** monthly or annual prepay; set a reminder to renew/extend `until`
-  before it lapses.
-- **Collection:** cash or bank transfer (₴0 fee) is simplest at this scale.
-- **Tax/FOP:** ad revenue in Ukraine may need FOP registration / tax handling —
-  the owner's call (this is not legal advice).
+  before it lapses. Stripe handles recurring billing and renewal reminders for you.
+- **Collection:** **Stripe** is the primary processor (see §7); cash or bank transfer
+  (₴0 fee) stays available as a fallback for stores that prefer it.
+- **Tax/FOP:** ad revenue in Ukraine may need FOP registration / tax handling, and
+  Stripe onboarding depends on an eligible business entity/country — the owner's call
+  (this is not legal advice).
 - **Ad labelling:** every paid placement is marked `Реклама / Sponsored`; keep
   featured density low (≈1 sponsored per screen/area) so the map stays trusted.
 
-## 7. Rollout sequence
+## 7. Stripe: payments & product scheme
+
+Payments into the app are processed through **Stripe**. The rate card in §2 maps
+one-to-one onto Stripe **Products** (the tier) and **Prices** (the amount + billing
+interval):
+
+| Tier | Stripe Product | Price(s) |
+|---|---|---|
+| **Verified+** | `Verified+` | ₴250 / month · ₴2,500 / year (10× — 2 months free) |
+| **Featured** | `Featured` | ₴600 / month · ₴6,000 / year |
+| **Spotlight** | `Spotlight` | ₴1,200 / month · ₴12,000 / year |
+| **À la carte** | `Deal of the week` / `Poster placement` / `Sponsored push` | one-time ₴300 / ₴150 / ₴400 |
+
+- **Intro offer** (first month Featured at ₴300): a Stripe **coupon** (50% off the
+  first invoice) on the monthly price — keeps one clean product instead of a separate
+  discounted one.
+- **Currency:** prices are in **UAH (₴)**; confirm your Stripe account supports UAH
+  settlement (otherwise charge in a supported currency and show ₴ as guidance).
+
+**Checkout flow — two options:**
+
+1. **Payment Links (recommended first — no backend).** Create one Stripe **Payment
+   Link** per Price in the Stripe Dashboard. The owner (or agent) sends the store the
+   link for their tier; the store pays by card; Stripe emails the receipt and manages
+   the subscription, retries, and renewal reminders. Nothing to deploy — fits the
+   static PWA. The owner still fulfils the placement by hand (§3) once payment lands.
+2. **Worker + Checkout Sessions (later, automated).** The existing Cloudflare Worker
+   (`telegram-bot/`) gains a small endpoint that creates a Checkout Session, and a
+   Stripe **webhook** flips the store's `promo` / Verified state on `checkout.session
+   .completed` and clears it on cancellation/expiry — closing the loop so a sale
+   self-fulfils. Build this once volume justifies removing the manual step.
+
+> **Setup status.** Wiring live products/prices/links needs the **Stripe connector
+> authorized** in this workspace (it currently is not) plus the account's keys.
+> Once that's done, the tiers above can be created as Stripe Products/Prices and the
+> Payment Links generated. Until then this section is the plan of record.
+
+## 8. Rollout sequence
 
 1. **Now:** system built; owner sells 3–5 Featured/Verified+ by hand at the intro
    price; fulfil via §3; gather testimonials + real redemption data.

--- a/docs/FIELD_AGENT.md
+++ b/docs/FIELD_AGENT.md
@@ -60,6 +60,9 @@ Spotlight — no recurring trailer). See [ADVERTISING.md](ADVERTISING.md) for th
 card and how a sale is fulfilled. *Not active yet — the owner closes the first few
 deals by hand to validate pricing, then hands selling to the agent.*
 
+The agent can pull up this scheme anytime in @Secondhandlvivbot with **/pay** (it
+shows the live rates from `RATE_VISIT` / `RATE_BONUS`).
+
 ---
 
 ## 3. Standard operating procedure · Порядок роботи
@@ -83,6 +86,46 @@ deals by hand to validate pricing, then hands selling to the agent.*
 **End of day / Наприкінці дня**
 - Agent: quick summary in **capybara-bot** (areas done, issues, stores to revisit).
 - Owner: `/report` to see the running total; `/export` weekly for the CSV.
+
+---
+
+## Updating the map: app vs Telegram · Оновлення карти
+
+Two channels, split by what each does best.
+
+**Structured store data → edit in the app → submit via GitHub.** Restock days,
+opening hours, name changes, address, GPS, and notes are edited directly in **Lviv
+Second Hand** (open a store → **Edit**; or add a store that isn't on the map from the
+Map tab). To send the additions & corrections to the official map: **🤝 (top-right)
+→ 🌍 Contribute to the official map → 🚀 Submit on GitHub**. That opens a **pre-filled
+GitHub issue** on the repo; the owner reviews it and merges it into the map everyone
+downloads.
+
+> **The agent needs a free GitHub account** to post that issue (one-time signup at
+> github.com — no coding, just a login). Map updates flow through **GitHub issues on
+> the repo**, not by editing files. If a contribution is too large to fit in the
+> issue, the app tells you to also **💾 Download file** and attach the
+> `lviv-secondhand-stores.json` to the same issue.
+
+**Which submission path?** Two buttons in the app both open a GitHub issue:
+- **🌍 Contribute to the official map → 🚀 Submit on GitHub** — the agent's normal
+  path. It carries the whole bundle of stores she **added or corrected** while
+  surveying. Use this for survey data.
+- **🏪 Own a store? → Submit your store** — a single-store form that asks for the
+  submitter's **role + a contact to verify**. Use this only when signing up a real
+  store **owner** (the ₴200 bonus): fill it *with* the owner so their role and contact
+  are captured — that contact is the sign-up evidence. The owner can post it from
+  their own phone (their GitHub account), or the agent posts it from hers.
+
+**Photos, communication & live location → Telegram.** The app can't take photos,
+chat, or share live position — Telegram does. Storefront photos and the GPS check-in
+go through **/visit** in @Secondhandlvivbot; day-to-day questions, translation, voice
+notes, and live-location sharing go through **capybara-bot**.
+
+*Дані магазину (завезення, години, назва, адреса, GPS, нотатки) редагуються у
+застосунку → **🚀 Submit on GitHub** (потрібен безкоштовний акаунт GitHub) → оновлення
+йдуть через **GitHub issues** репозиторію. Фото, спілкування та жива геолокація — у
+Telegram.*
 
 ---
 
@@ -160,6 +203,7 @@ One-time enablement of the `/visit` subsystem is documented in
 | `/whoami` | anyone | replies with your numeric Telegram id (to be allow-listed) |
 | `/visit` | agent | start a survey |
 | `/myvisits` | agent | their running visit count |
+| `/pay` | agent · owner | show the pay scheme (live rates from `RATE_VISIT`/`RATE_BONUS`) |
 | `/cancel` | agent | abort the current survey |
 | `/report` | owner | totals, per-agent counts, **estimated pay** |
 | `/export` | owner | CSV of every logged visit |

--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -261,7 +261,7 @@ function say(env, chatId, text, keyboard) {
 // extended per-chat menu that also lists /visit — so only they see it in the menu
 // (it's already functionally gated regardless). Bump CMD_VER to force a re-sync
 // after editing the lists. Self-managing → no BotFather /setcommands needed.
-const CMD_VER = 'v1';
+const CMD_VER = 'v2';
 const PUBLIC_CMDS = [
   { command: 'today', description: 'Магазини із завезенням сьогодні' },
   { command: 'cheap', description: 'Найкращі ціни на вагу зараз' },
@@ -281,6 +281,7 @@ async function syncBotCommands(env, userId, isOwner, isAgent) {
   const cmds = PUBLIC_CMDS.concat([
     { command: 'visit', description: '📝 Записати візит у магазин' },
     { command: 'myvisits', description: 'Мої візити' },
+    { command: 'pay', description: '💰 Схема оплати' },
     { command: 'cancel', description: 'Скасувати поточний візит' },
   ]);
   if (isOwner) cmds.push(
@@ -468,6 +469,31 @@ function notAgentMsg(uid) {
     `Надішліть власнику цей ID, щоб отримати доступ · Send this ID to the owner to get access:\n<code>${uid}</code>`;
 }
 
+// Agent-facing pay scheme, rendered live from the configured rates so it always
+// matches /report. Keep in sync with docs/FIELD_AGENT.md §2.
+function payText(c) {
+  return [
+    '💰 <b>Схема оплати · Payment scheme</b>',
+    '',
+    `📍 <b>База за візит · Visit base: ₴${c.rateVisit}</b>`,
+    'За кожен перевірений візит: GPS + фото вітрини + повна анкета у /visit.',
+    'Per verified visit: GPS + storefront photo + full questionnaire in /visit.',
+    'Один магазин = одна база за цикл. · One store = one base per survey cycle.',
+    '',
+    `🎁 <b>Бонус · Bonus: ₴${c.rateBonus}</b> (кожен · each)`,
+    '• QR-плакат розміщено (фото-доказ) · QR poster placed (photo proof)',
+    '• Власник зареєструвався (контакт + згода) · Owner signed up (contact + consent)',
+    'Обидва можуть діяти разом → два бонуси. · Both can apply → two bonuses.',
+    '',
+    '🎯 Ціль · Target: 8–12 магазинів/день · stores/day.',
+    '🗓️ Виплати щотижня — власник звіряє /report і фото. · Weekly pay; owner reconciles /report + photos.',
+    '',
+    '📈 <b>Фаза 2 (згодом) · Phase 2 (later)</b> — коли ви продаєте промо:',
+    'разова премія за підписаний магазин · one-time bonus per signed store',
+    '(₴300–₴500 Featured, ₴800 Spotlight). Ще не активно. · Not active yet.',
+  ].join('\n');
+}
+
 // Handle an update for the visit subsystem. Returns true if it consumed the update.
 async function handleVisit(env, c, msg, ctx) {
   const { userId, chatId, text, from } = ctx;
@@ -496,6 +522,11 @@ async function handleVisit(env, c, msg, ctx) {
     if (!isAgent) return false;
     const n = Number((await env.VISITS.get('count:agent:' + userId)) || 0);
     await say(env, chatId, `📊 Ваших візитів усього · Your total visits: <b>${n}</b>`);
+    return true;
+  }
+  if (command === 'pay') {
+    if (!(isAgent || isOwner)) { await say(env, chatId, notAgentMsg(userId)); return true; }
+    await say(env, chatId, payText(c));
     return true;
   }
   if (command === 'visit') {


### PR DESCRIPTION
## What & why

Three related pieces the owner asked for: the agent needs to see her pay scheme in the bot, the map-update workflow (app vs Telegram, GitHub account requirement) needs writing down, and payments into the app will run through **Stripe** so the ad product scheme needs a Stripe mapping.

## Changes

**Bot (`telegram-bot/worker.js`)**
- New **`/pay`** command (agent + owner only) renders the pay scheme live from the configured `RATE_VISIT` / `RATE_BONUS`, so it always matches `/report`. Bilingual (UA-first), covers the visit base, per-result bonuses, targets, weekly cadence, and the Phase-2 one-time sale bonus.
- Listed in the extended per-user command menu; `CMD_VER` bumped `v1 → v2` so menus re-sync on next interaction.

**`docs/FIELD_AGENT.md`**
- New "Updating the map: app vs Telegram" section: structured store data (restock, hours, name, address, GPS, notes) is edited **in the app** and submitted via the in-app **🚀 Submit on GitHub** button, which opens a pre-filled **GitHub issue** — so the agent needs a **free GitHub account**. Photos, communication, and live location go through **Telegram**.
- Clarifies which of the two in-app submission paths to use: **Contribute to the official map** for her survey edits; the **owner-submission form** only when signing up a real store owner (captures their role + verification contact = the sign-up bonus evidence).
- Adds `/pay` to the command table and references it from the payment-scheme section.

**`docs/ADVERTISING.md`** (Stripe, docs-first)
- Payments now run through **Stripe**; folded the ~2.9% + fixed fee into the unit economics (immaterial vs margin) with cash/bank kept as a fallback.
- New "Stripe: payments & product scheme" section mapping each tier to a Stripe **Product** + **Price** (monthly + annual), the intro offer as a coupon, and the à-la-carte one-time prices.
- Documents the checkout flow: **Payment Links** first (no backend, fits the static PWA), **Worker + Checkout Sessions + webhook** later for self-fulfilment.
- Notes the **Stripe connector still needs authorizing** before live products/links can be created — this section is the plan of record until then.

No `index.html` change (no `APP_VERSION` bump). The worker change auto-deploys via `deploy-bot.yml`.

## Verification

- `node --check telegram-bot/worker.js` passes.
- `/pay` is gated to agents/owner (non-agents get the standard "not a field agent" reply); the text interpolates the live rates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_