### PR TITLE
Stripe self-fulfilment for paid promotions (Worker + D1)

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -43,3 +43,24 @@ jobs:
         run: |
           if [ -z "$ADMIN_KEY" ]; then echo "ADMIN_KEY not set — skipping (server-side broadcast test stays off until you add it)"; exit 0; fi
           printf '%s' "$ADMIN_KEY" | npx --yes wrangler@3 secret put ADMIN_KEY
+      # Paid promotions: restricted Stripe key (create Checkout Sessions) +
+      # webhook signing secret. Both optional — the promo checkout/webhook stay
+      # off until set. See docs/ADVERTISING.md §7.
+      - name: Set Stripe API key secret
+        working-directory: worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          STRIPE_API_KEY: ${{ secrets.STRIPE_API_KEY }}
+        run: |
+          if [ -z "$STRIPE_API_KEY" ]; then echo "STRIPE_API_KEY not set — skipping (promo checkout stays off until you add it)"; exit 0; fi
+          printf '%s' "$STRIPE_API_KEY" | npx --yes wrangler@3 secret put STRIPE_API_KEY
+      - name: Set Stripe webhook secret
+        working-directory: worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+        run: |
+          if [ -z "$STRIPE_WEBHOOK_SECRET" ]; then echo "STRIPE_WEBHOOK_SECRET not set — skipping (promo self-fulfil stays off until you add it)"; exit 0; fi
+          printf '%s' "$STRIPE_WEBHOOK_SECRET" | npx --yes wrangler@3 secret put STRIPE_WEBHOOK_SECRET

--- a/docs/ADVERTISING.md
+++ b/docs/ADVERTISING.md
@@ -139,11 +139,13 @@ interval):
    emails the receipt and manages the subscription, retries, and renewal reminders.
    Nothing to deploy — fits the static PWA. The owner still fulfils the placement by
    hand (§3) once payment lands.
-2. **Worker + Checkout Sessions (later, automated).** The existing Cloudflare Worker
-   (`telegram-bot/`) gains a small endpoint that creates a Checkout Session, and a
-   Stripe **webhook** flips the store's `promo` / Verified state on `checkout.session
-   .completed` and clears it on cancellation/expiry — closing the loop so a sale
-   self-fulfils. Build this once volume justifies removing the manual step.
+2. **Worker + webhook self-fulfilment (built — activate with two secrets).** The
+   metrics Worker (`worker/`) now exposes three routes: `GET /promote?store=<id>&tier=
+   <t>&cadence=<c>` opens a **store-bound** Checkout Session, `POST /stripe-webhook`
+   verifies Stripe's signature and writes/expires the promo in D1, and `GET /promos`
+   serves the live set. The app fetches `/promos` on load and renders the gold pin/
+   badge/offer automatically — **no `index.html` edit per sale**. See "Self-fulfil
+   activation" below.
 
 ### Live Stripe objects (account "Lviv Second Hand", live mode)
 
@@ -175,9 +177,34 @@ cadence:
 **`FEATURED50`** (coupon `6QsSUgXf`, 50% off the first invoice) to get the first month
 of Featured at ₴300 (or the same discount on any tier's first charge).
 
-> The products/prices/links above are **live** — real charges. Fulfilment is still
-> manual (§3): when a payment lands, add the store's `promo` and deploy. The Worker +
-> webhook automation (option 2) can later flip that state on its own.
+> The products/prices/links above are **live** — real charges. With self-fulfilment
+> activated (below), a paid checkout writes the promo to D1 and the app shows it on
+> its own; the generic Payment Links above still work but need the manual `promo` edit
+> (§3), so prefer the store-bound `/promote` links once activated.
+
+### Self-fulfil activation (owner, one-time)
+
+The code ships **inert** until two secrets are set — until then `/promos` returns an
+empty set and `/promote` + `/stripe-webhook` reply `503`, so nothing changes.
+
+1. **Restricted Stripe key.** Stripe Dashboard → Developers → API keys → **Create
+   restricted key** with **Checkout Sessions: Write** (everything else None). Add it as
+   the repo secret **`STRIPE_API_KEY`**.
+2. **Webhook endpoint.** Stripe Dashboard → Developers → Webhooks → **Add endpoint** →
+   URL `https://lviv-metrics.lshanalytic.workers.dev/stripe-webhook`, events:
+   `checkout.session.completed`, `invoice.paid`,
+   `customer.subscription.deleted`, `customer.subscription.updated`. Copy its **signing
+   secret** (`whsec_…`) into the repo secret **`STRIPE_WEBHOOK_SECRET`**.
+3. **Deploy.** Push to `main` (or run the *Deploy metrics Worker* action) —
+   `deploy-worker.yml` sets both secrets on the Worker. Confirm at
+   `…workers.dev/status` (`promoConfigured: true`).
+
+**How a sale then flows:** the owner/agent sends a store-bound link
+`…/promote?store=<storeId>&tier=featured&cadence=monthly` (the app's in-store
+**"Own this store? Promote it"** button builds one) → the store pays (₴, `FEATURED50`
+still applies) → the webhook writes `promos(store_id, tier, until, sub_id)` in D1 →
+the app's `/promos` fetch shows the pin/badge/offer within a page load. Renewals extend
+`until` (`invoice.paid`); cancellation clears it (`customer.subscription.deleted`).
 
 ## 8. Rollout sequence
 

--- a/index.html
+++ b/index.html
@@ -1220,7 +1220,7 @@ function openDetail(id) {
       <button onclick="copyStoreLink('${id}')" style="width:100%;padding:12px;background:white;border:2px solid var(--muted);color:var(--muted);border-radius:14px;font-size:14px;font-weight:700;cursor:pointer;margin-top:12px;">🔗 ${t('copyStoreLink')}</button>
 
       <!-- PROMOTE (owner-facing, opens a store-bound Stripe checkout) -->
-      ${METRICS_URL ? `<button onclick="promoteStore('${id}','featured','monthly')" style="width:100%;padding:11px;background:transparent;border:1px dashed var(--muted);color:var(--muted);border-radius:14px;font-size:13px;font-weight:600;cursor:pointer;margin-top:10px;">📣 ${lang==='ua'?'Власник магазину? Просувати':'Own this store? Promote it'}</button>` : ''}
+      ${promoCheckoutEnabled ? `<button onclick="promoteStore('${id}','featured','monthly')" style="width:100%;padding:11px;background:transparent;border:1px dashed var(--muted);color:var(--muted);border-radius:14px;font-size:13px;font-weight:600;cursor:pointer;margin-top:10px;">📣 ${lang==='ua'?'Власник магазину? Просувати':'Own this store? Promote it'}</button>` : ''}
 
     </div>`;
 
@@ -2294,20 +2294,30 @@ function track(type, key){
 // render exactly like a hand-added `promo`. Fails silently offline; static
 // `promo` fields in STORES still work without the network.
 // ─────────────────────────────────────────────
+// True once the Worker confirms paid checkout is configured — gates the in-app
+// "Promote it" CTA so it only appears when a click will actually reach Stripe.
+let promoCheckoutEnabled = false;
 async function loadRemotePromos(){
   if (!METRICS_URL) return;
   try {
     const r = await fetch(METRICS_URL + '/promos', { cache:'no-store' });
-    if (!r.ok) return;
-    const map = await r.json();
-    if (!map || typeof map !== 'object') return;
-    let touched = false;
-    for (const s of STORES){
-      const p = map[s.id];
-      if (p && (p.tier || p.offer) && p.until){ s.promo = { tier:p.tier, offer:p.offer, until:p.until }; touched = true; }
+    if (r.ok){
+      const map = await r.json();
+      if (map && typeof map === 'object'){
+        let touched = false;
+        for (const s of STORES){
+          const p = map[s.id];
+          if (p && (p.tier || p.offer) && p.until){ s.promo = { tier:p.tier, offer:p.offer, until:p.until }; touched = true; }
+        }
+        if (touched){ renderList(); if (mapInst) renderPins(); }
+      }
     }
-    if (touched){ renderList(); if (mapInst) renderPins(); }
   } catch(e){ /* promotions must never break the app */ }
+  // Only surface the promote CTA when checkout is live (else a click 503s).
+  try {
+    const st = await fetch(METRICS_URL + '/status').then(x => x.ok ? x.json() : null);
+    if (st && st.promoConfigured) promoCheckoutEnabled = true;
+  } catch(e){ /* leave the CTA hidden if we can't confirm */ }
 }
 // Open a store-bound Stripe checkout for a promotion (owner-facing). The Worker
 // binds the store id so the purchase self-fulfils.

--- a/index.html
+++ b/index.html
@@ -1219,6 +1219,9 @@ function openDetail(id) {
       <!-- SHARE THIS STORE -->
       <button onclick="copyStoreLink('${id}')" style="width:100%;padding:12px;background:white;border:2px solid var(--muted);color:var(--muted);border-radius:14px;font-size:14px;font-weight:700;cursor:pointer;margin-top:12px;">🔗 ${t('copyStoreLink')}</button>
 
+      <!-- PROMOTE (owner-facing, opens a store-bound Stripe checkout) -->
+      ${METRICS_URL ? `<button onclick="promoteStore('${id}','featured','monthly')" style="width:100%;padding:11px;background:transparent;border:1px dashed var(--muted);color:var(--muted);border-radius:14px;font-size:13px;font-weight:600;cursor:pointer;margin-top:10px;">📣 ${lang==='ua'?'Власник магазину? Просувати':'Own this store? Promote it'}</button>` : ''}
+
     </div>`;
 
   document.querySelectorAll('.view').forEach(v => v.classList.add('hidden'));
@@ -2189,6 +2192,7 @@ window.addEventListener('DOMContentLoaded',()=>{
   setLang(lang); // apply saved-or-detected language to the UI (Ukrainian by default)
   renderList();
   updateStats();
+  loadRemotePromos(); // merge any live paid promotions, then re-render if present
   // Deep link (?store=<id>): a direct link to one store — from a shared link or
   // the Telegram bot — opens that store straight away and skips the interstitials.
   const deepLinkStore = getStoreFromURL();
@@ -2232,7 +2236,7 @@ if ('serviceWorker' in navigator) {
 // UPDATE CHECK — notify when a newer build is deployed, so nobody is stuck on
 // a cached version (no reinstall needed). Bump APP_VERSION on each deploy.
 // ─────────────────────────────────────────────
-const APP_VERSION = '2026-08-06.9';
+const APP_VERSION = '2026-08-07.1';
 
 // ─────────────────────────────────────────────
 // DONATIONS — points at a Stripe Payment Link (hosted checkout). No API keys
@@ -2281,6 +2285,39 @@ function track(type, key){
     if (navigator.sendBeacon) navigator.sendBeacon(METRICS_URL, body);
     else fetch(METRICS_URL, { method:'POST', body, keepalive:true }).catch(()=>{});
   } catch(e){ /* metrics must never break the app */ }
+}
+
+// ─────────────────────────────────────────────
+// PAID PROMOTIONS — live feed. A store that buys a promotion (Stripe checkout,
+// self-fulfilled by the Worker) appears in GET /promos as {storeId:{tier,offer,
+// until}}. We merge it onto STORES on load so the gold pin / list badge / offer
+// render exactly like a hand-added `promo`. Fails silently offline; static
+// `promo` fields in STORES still work without the network.
+// ─────────────────────────────────────────────
+async function loadRemotePromos(){
+  if (!METRICS_URL) return;
+  try {
+    const r = await fetch(METRICS_URL + '/promos', { cache:'no-store' });
+    if (!r.ok) return;
+    const map = await r.json();
+    if (!map || typeof map !== 'object') return;
+    let touched = false;
+    for (const s of STORES){
+      const p = map[s.id];
+      if (p && (p.tier || p.offer) && p.until){ s.promo = { tier:p.tier, offer:p.offer, until:p.until }; touched = true; }
+    }
+    if (touched){ renderList(); if (mapInst) renderPins(); }
+  } catch(e){ /* promotions must never break the app */ }
+}
+// Open a store-bound Stripe checkout for a promotion (owner-facing). The Worker
+// binds the store id so the purchase self-fulfils.
+function promoteStore(id, tier, cadence){
+  if (!METRICS_URL) return;
+  const url = METRICS_URL + '/promote?store=' + encodeURIComponent(id)
+    + '&tier=' + encodeURIComponent(tier || 'featured')
+    + '&cadence=' + encodeURIComponent(cadence || 'monthly');
+  track('action', 'promote_' + (tier || 'featured'));
+  window.open(url, '_blank', 'noopener');
 }
 
 // ─────────────────────────────────────────────

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -53,7 +53,69 @@ async function ensureSchema(env) {
   await env.DB.prepare(
     "CREATE TABLE IF NOT EXISTS push_subs (id INTEGER PRIMARY KEY AUTOINCREMENT, endpoint TEXT UNIQUE NOT NULL, p256dh TEXT NOT NULL, auth TEXT NOT NULL, stores TEXT NOT NULL DEFAULT '[]', created TEXT NOT NULL DEFAULT (datetime('now')))"
   ).run();
+  // Paid in-app promotions, self-fulfilled from Stripe (see stripe-webhook).
+  await env.DB.prepare(
+    "CREATE TABLE IF NOT EXISTS promos (store_id TEXT PRIMARY KEY, tier TEXT NOT NULL, offer TEXT, until TEXT NOT NULL, sub_id TEXT, cadence TEXT, status TEXT NOT NULL DEFAULT 'active', updated TEXT NOT NULL DEFAULT (datetime('now')))"
+  ).run();
   _schemaReady = true;
+}
+
+// ── Store promotions ↔ Stripe ────────────────────────────────────────────────
+// The rate card (docs/ADVERTISING.md) as Stripe Price ids, keyed by tier+cadence.
+// A store-bound Checkout Session (GET /promote) carries the store id in metadata;
+// the signed webhook (POST /stripe-webhook) writes/expires the promo in D1; the
+// app reads the live set from GET /promos and renders the gold pin/badge/offer.
+const PROMO_PRICES = {
+  verified_monthly:  'price_1U1dvd7ZlQqI3gQVAk6edEci',
+  verified_annual:   'price_1U1dvn7ZlQqI3gQVH2XJobOD',
+  featured_monthly:  'price_1U1dvq7ZlQqI3gQV51PMcCVM',
+  featured_annual:   'price_1U1dvt7ZlQqI3gQVd8utdXLA',
+  spotlight_monthly: 'price_1U1dvv7ZlQqI3gQVR5qnNNHk',
+  spotlight_annual:  'price_1U1dw17ZlQqI3gQVuizcyhYi',
+};
+const PROMO_TIERS = new Set(['verified', 'featured', 'spotlight']);
+const PROMO_CADENCES = new Set(['monthly', 'annual']);
+
+// Verify Stripe's `Stripe-Signature` header (HMAC-SHA256 over `${t}.${payload}`).
+async function verifyStripeSig(payload, header, secret) {
+  const parts = {};
+  for (const kv of String(header).split(',')) { const i = kv.indexOf('='); if (i > 0) parts[kv.slice(0, i)] = kv.slice(i + 1); }
+  const t = parts.t, v1 = parts.v1;
+  if (!t || !v1) return false;
+  if (Math.abs(Date.now() / 1000 - Number(t)) > 300) return false; // reject >5 min skew (replay)
+  const key = await crypto.subtle.importKey('raw', new TextEncoder().encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const mac = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(`${t}.${payload}`));
+  const hex = [...new Uint8Array(mac)].map((b) => b.toString(16).padStart(2, '0')).join('');
+  if (hex.length !== v1.length) return false;
+  let diff = 0; for (let i = 0; i < hex.length; i++) diff |= hex.charCodeAt(i) ^ v1.charCodeAt(i);
+  return diff === 0;
+}
+
+// Apply a verified Stripe event to the promos table (activate / extend / cancel).
+async function applyPromoEvent(env, ev) {
+  const o = (ev && ev.data && ev.data.object) || {};
+  const type = ev && ev.type;
+  const graceDays = (cad) => (cad === 'annual' ? 372 : 34); // period + a few days' grace
+  if (type === 'checkout.session.completed') {
+    const storeId = o.client_reference_id || (o.metadata && o.metadata.storeId);
+    const tier = o.metadata && o.metadata.tier;
+    const cadence = (o.metadata && o.metadata.cadence) === 'annual' ? 'annual' : 'monthly';
+    if (!storeId || !PROMO_TIERS.has(tier)) return;
+    const until = addDaysStr(kyivDateStr(), graceDays(cadence));
+    await env.DB.prepare(
+      "INSERT INTO promos (store_id, tier, offer, until, sub_id, cadence, status, updated) VALUES (?, ?, NULL, ?, ?, ?, 'active', datetime('now')) " +
+      "ON CONFLICT(store_id) DO UPDATE SET tier=excluded.tier, until=excluded.until, sub_id=excluded.sub_id, cadence=excluded.cadence, status='active', updated=datetime('now')"
+    ).bind(storeId, tier, until, o.subscription || null, cadence).run();
+  } else if (type === 'invoice.paid' || type === 'invoice.payment_succeeded') {
+    const subId = o.subscription;
+    if (!subId) return;
+    const row = await env.DB.prepare('SELECT cadence FROM promos WHERE sub_id = ?').bind(subId).first();
+    const until = addDaysStr(kyivDateStr(), graceDays(row && row.cadence));
+    await env.DB.prepare("UPDATE promos SET until = ?, status = 'active', updated = datetime('now') WHERE sub_id = ?").bind(until, subId).run();
+  } else if (type === 'customer.subscription.deleted' ||
+             (type === 'customer.subscription.updated' && ['canceled', 'unpaid', 'incomplete_expired'].includes(o.status))) {
+    await env.DB.prepare("UPDATE promos SET status = 'canceled', updated = datetime('now') WHERE sub_id = ?").bind(o.id).run();
+  }
 }
 
 // ── byte helpers ──
@@ -153,11 +215,74 @@ export default {
       if (url.pathname === '/status') {
         let subs = null;
         try { await ensureSchema(env); const c = await env.DB.prepare('SELECT COUNT(*) AS n FROM push_subs').first(); subs = c ? c.n : 0; } catch {}
-        return json({ ok: true, push: true, vapidConfigured: !!env.VAPID_PRIVATE, subs }, 200, origin);
+        return json({ ok: true, push: true, vapidConfigured: !!env.VAPID_PRIVATE, subs, promoConfigured: !!env.STRIPE_API_KEY }, 200, origin);
+      }
+      // Live paid promotions: { storeId: {tier, offer?, until} }. The app merges
+      // these onto STORES so the gold pin/badge/offer render automatically.
+      if (url.pathname === '/promos') {
+        try {
+          await ensureSchema(env);
+          const res = await env.DB.prepare("SELECT store_id, tier, offer, until FROM promos WHERE status = 'active' AND until >= ?").bind(kyivDateStr()).all();
+          const out = {};
+          for (const r of (res && res.results) || []) { out[r.store_id] = r.offer ? { tier: r.tier, offer: r.offer, until: r.until } : { tier: r.tier, until: r.until }; }
+          return json(out, 200, origin);
+        } catch { return json({}, 200, origin); }
+      }
+      // Store-bound Stripe Checkout: /promote?store=<id>&tier=<t>&cadence=<c>.
+      // Redirects to a hosted checkout carrying the store id so the webhook can
+      // fulfil it. Inert (503) until STRIPE_API_KEY is configured.
+      if (url.pathname === '/promote') {
+        const store = url.searchParams.get('store') || '';
+        const tier = url.searchParams.get('tier') || 'featured';
+        const cadence = url.searchParams.get('cadence') || 'monthly';
+        if (!/^[a-z0-9]{1,12}$/i.test(store) || !PROMO_TIERS.has(tier) || !PROMO_CADENCES.has(cadence)) {
+          return new Response('bad request', { status: 400, headers: cors(origin) });
+        }
+        const price = PROMO_PRICES[`${tier}_${cadence}`];
+        if (!price) return new Response('unknown tier', { status: 400, headers: cors(origin) });
+        if (!env.STRIPE_API_KEY) return new Response('checkout not configured', { status: 503, headers: cors(origin) });
+        const form = new URLSearchParams();
+        form.set('mode', 'subscription');
+        form.set('line_items[0][price]', price);
+        form.set('line_items[0][quantity]', '1');
+        form.set('allow_promotion_codes', 'true');
+        form.set('client_reference_id', store);
+        form.set('metadata[storeId]', store);
+        form.set('metadata[tier]', tier);
+        form.set('metadata[cadence]', cadence);
+        form.set('subscription_data[metadata][storeId]', store);
+        form.set('subscription_data[metadata][tier]', tier);
+        form.set('subscription_data[metadata][cadence]', cadence);
+        form.set('success_url', APP_URL + '?promoted=1');
+        form.set('cancel_url', APP_URL);
+        let data;
+        try {
+          const res = await fetch('https://api.stripe.com/v1/checkout/sessions', {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${env.STRIPE_API_KEY}`, 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: form,
+          });
+          data = await res.json();
+          if (!res.ok || !data.url) return new Response('checkout error', { status: 502, headers: cors(origin) });
+        } catch { return new Response('checkout error', { status: 502, headers: cors(origin) }); }
+        return Response.redirect(data.url, 302);
       }
       return new Response('ok', { status: 200, headers: cors(origin) });
     }
     if (request.method !== 'POST') return new Response('method not allowed', { status: 405, headers: cors(origin) });
+
+    // ── Stripe webhook: self-fulfil paid promotions ──
+    // Handled before rate-limiting/JSON-parse because the raw body is needed for
+    // signature verification. Inert (503) until STRIPE_WEBHOOK_SECRET is set.
+    if (url.pathname === '/stripe-webhook') {
+      if (!env.STRIPE_WEBHOOK_SECRET) return new Response('not configured', { status: 503 });
+      const payload = await request.text();
+      const sig = request.headers.get('Stripe-Signature') || '';
+      if (!(await verifyStripeSig(payload, sig, env.STRIPE_WEBHOOK_SECRET))) return new Response('bad signature', { status: 400 });
+      let ev; try { ev = JSON.parse(payload); } catch { return new Response('bad json', { status: 400 }); }
+      try { await ensureSchema(env); await applyPromoEvent(env, ev); } catch {}
+      return new Response('ok', { status: 200 }); // 2xx so Stripe stops retrying
+    }
 
     // Per-IP rate limit (guarded — skip if binding absent).
     if (env.RATE_LIMITER) {

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -26,3 +26,17 @@ crons = ["0 7 * * *"]
 # The private key is set separately as the VAPID_PRIVATE secret — NEVER commit it.
 [vars]
 VAPID_PUBLIC = "BBfji9HA_fVrn42DeYako-WekhEo60jc_9f7UmHf67kpEqv7JdmLaonrkLWfSEYMLARMgG9jVovK7W3uUDNp7kU"
+
+# ── Paid promotions (Stripe self-fulfilment) — optional, off until configured ──
+# GET /promos serves the live promo set with no secret. Selling + auto-fulfil
+# need two secrets (set them as repo secrets so deploy-worker.yml pushes them,
+# or with `wrangler secret put`); the feature stays inert until both exist:
+#   STRIPE_API_KEY       — a *restricted* Stripe secret key with write access to
+#                          Checkout Sessions (create) — used by GET /promote to
+#                          open a store-bound checkout. NEVER commit it.
+#   STRIPE_WEBHOOK_SECRET — the signing secret of the Stripe webhook endpoint
+#                          pointed at https://lviv-metrics.lshanalytic.workers.dev/stripe-webhook
+#                          (events: checkout.session.completed, invoice.paid,
+#                          customer.subscription.deleted/updated). Verifies the
+#                          POST /stripe-webhook signature. NEVER commit it.
+# See docs/ADVERTISING.md §7 for the full activation steps.


### PR DESCRIPTION
## What & why

Closes the loop on paid promotions: a store pays via a **store-bound** Stripe checkout and its gold pin / list badge / offer appear **automatically** — no hand-edit of `index.html` per sale. This is the "full self-fulfil via KV/D1" path chosen for the promotions product.

## How it works

1. **`GET /promote?store=<id>&tier=<t>&cadence=<c>`** (metrics Worker) creates a Checkout Session carrying the **store id** in metadata and redirects to Stripe.
2. Store pays (₴, `FEATURED50` still applies).
3. **`POST /stripe-webhook`** verifies Stripe's signature (HMAC-SHA256, ±5-min replay guard) and upserts the promo into a new D1 `promos` table on `checkout.session.completed`; `invoice.paid` extends `until`, `customer.subscription.deleted/updated` clears it.
4. **`GET /promos`** serves the live set `{storeId:{tier,offer,until}}`.
5. The app fetches `/promos` on load and merges onto `STORES`, so `activePromo()` renders it exactly like a hand-added `promo`.

## Changes

- **`worker/worker.js`** — `promos` table in `ensureSchema`; `/promos`, `/promote`, `/stripe-webhook` routes; Stripe signature verification; price map (the six live UAH prices).
- **`index.html`** — `loadRemotePromos()` (fetch + merge + re-render, fails silent offline); a discreet **"Own this store? Promote it"** button that opens the store-bound checkout; `APP_VERSION` → `2026-08-07.1`.
- **`worker/wrangler.toml`** + **`deploy-worker.yml`** — document and push two optional secrets (`STRIPE_API_KEY`, `STRIPE_WEBHOOK_SECRET`); both skip cleanly when absent.
- **`docs/ADVERTISING.md`** — marks the Worker+webhook path built; adds the one-time **activation steps** (restricted key + webhook endpoint).

## Inert until activated

Ships **off**: `/promos` returns `{}` and `/promote` + `/stripe-webhook` return `503` until `STRIPE_API_KEY` **and** `STRIPE_WEBHOOK_SECRET` are set (mirrors the existing VAPID/ADMIN gating). No behavior change to the live app until the owner completes activation (§7).

## Verification

- `node --check` passes on `worker/worker.js` and the app's inline script.
- Signature check rejects bad/old signatures; webhook always returns 2xx after verify so Stripe stops retrying.
- Static `promo` fields in `STORES` keep working with no network.

## Owner action to go live

Create a restricted Stripe key + a webhook endpoint at `…workers.dev/stripe-webhook`, add them as repo secrets `STRIPE_API_KEY` / `STRIPE_WEBHOOK_SECRET`, then deploy. Details in `docs/ADVERTISING.md` §7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_