### PR TITLE
Add field agent to the bot allow-list (AGENT_IDS)

### DIFF
--- a/telegram-bot/wrangler.toml
+++ b/telegram-bot/wrangler.toml
@@ -37,6 +37,6 @@ id = "69158c00d55a4d3ab750cd916afca445"
 
 [vars]
 OWNER_ID   = "1212541015"    # owner — gets /report, /export, and a live push of each visit
-AGENT_IDS  = "1212541015"    # agents allowed to run /visit (comma-separated). Owner listed to smoke-test; add the agent's id next.
+AGENT_IDS  = "1212541015,5677605074"    # agents allowed to run /visit (comma-separated): owner (smoke-test) + field agent.
 RATE_VISIT = "80"  # ₴ per verified visit
 RATE_BONUS = "200" # ₴ per bonus event (poster placed / owner contact + consent)


### PR DESCRIPTION
## What

Adds the field agent's Telegram id to `AGENT_IDS` in `telegram-bot/wrangler.toml` so they can run `/visit`, `/myvisits`, `/pay`, and see the field command menu. The owner id stays for smoke-testing.

`AGENT_IDS = "1212541015,5677605074"` (owner + agent).

## Deploy

The bot Worker deploys via the **Deploy Telegram bot** action (manual dispatch) — I'll trigger it after merge so the new allow-list takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_