### PR TITLE
Define bonus vs. sales commission across the docs

### DIFF
--- a/docs/ADVERTISING.md
+++ b/docs/ADVERTISING.md
@@ -74,17 +74,19 @@ an `offer` (no gold pin unless `tier` is set — use `tier` only for Featured/Sp
   fee where a store prefers it.
 - **Fulfilment:** ~5 min owner time per sale (hand-edit `promo` + deploy).
 - **Agent cost now (Phase 1):** ₴80/verified visit + poster/sign-up bonuses.
-- **Agent cost when selling (Phase 2):** a **one-time bonus per signed store**
-  (proposed ₴300–₴500 Featured, ₴800 Spotlight). No recurring trailer.
+- **Agent cost when selling (Phase 2):** a **one-time sales commission per signed
+  store**, paid only once the store subscribes and pays (proposed ₴300–₴500 Featured,
+  ₴800 Spotlight). No recurring trailer. *(Distinct from the Phase-1 **bonus**, which
+  rewards a poster/lead regardless of a sale.)*
 - **Margin:** software — very high. The only real variable cost is agent commission.
 
 **CAC vs LTV (example, Featured):**
-- Acquire ≈ 2–3 visits (₴160–₴240) + ₴300–₴500 bonus ≈ **₴500–₴750 CAC**.
+- Acquire ≈ 2–3 visits (₴160–₴240) + ₴300–₴500 commission ≈ **₴500–₴750 CAC**.
 - LTV ≈ ₴600/mo × ~6 months retention ≈ **₴3,600**. Ratio ≈ 5–7× — healthy.
 
 **Break-even (example):** if the agent's weekly base ≈ ₴3,000 (~40 visits), about
 **5 Featured subscriptions** (₴600) cover the agent; every additional subscription is
-near-pure margin minus its one-time bonus.
+near-pure margin minus its one-time commission.
 
 **Rule of thumb:** a Featured store pays for its own acquisition in ~1 month and is
 profit thereafter; churn is the number to watch, not price.

--- a/docs/FIELD_AGENT.md
+++ b/docs/FIELD_AGENT.md
@@ -37,6 +37,13 @@ uses the same numbers.
 | **Visit base** · база за візит | **₴80** | A visit is submitted in `/visit` with **GPS + storefront photo + full questionnaire**. One store = one base per survey cycle. |
 | **Bonus** · бонус | **₴200 each** | A verifiable result: **QR poster placed** in the store (photo proof), or **owner signed up** (owner contact captured *and* they submit via the form / agree to be featured). Both can apply → two bonuses. |
 
+> **Bonus vs. commission.** A **bonus** (above) is paid for the *action* — placing a
+> poster or signing up a lead — **even if that store never buys**. A **sales
+> commission** (Phase 2, below) is paid **only when a store actually subscribes and
+> pays**. The bonus rewards effort and pipeline; the commission rewards revenue.
+> *Бонус — за дію (плакат / лід), навіть якщо магазин не купить. Комісія — лише коли
+> магазин підписується та платить.*
+
 **Targets & guardrails**
 
 - Suggested pace: **8–12 stores/day**. A realistic day ≈ ₴640–₴960 base, plus bonuses.
@@ -55,8 +62,9 @@ uses the same numbers.
 Виплати — щотижня.*
 
 **Phase 2 — when the agent also sells promotions.** On top of the visit base, a
-**one-time bonus per signed store** (proposed **₴300–₴500** Featured, **₴800**
-Spotlight — no recurring trailer). See [ADVERTISING.md](ADVERTISING.md) for the rate
+**one-time sales commission per signed store** — paid only once the store actually
+subscribes and pays (proposed **₴300–₴500** Featured, **₴800** Spotlight — no
+recurring trailer). See [ADVERTISING.md](ADVERTISING.md) for the rate
 card and how a sale is fulfilled. *Not active yet — the owner closes the first few
 deals by hand to validate pricing, then hands selling to the agent.*
 
@@ -144,7 +152,7 @@ agent isn't "just surveying": they're generating qualified leads.
 **Phase 2 — selling promotions (later).** Once pricing is validated, the agent pitches
 the rate card ([ADVERTISING.md](ADVERTISING.md)) using a bilingual **sell-sheet**,
 handles objections (small budget → start with a free trial or the à-la-carte
-deal-of-week), and closes. Pay adds the one-time bonus per signed store. The owner
+deal-of-week), and closes. Pay adds the one-time sales commission per signed store. The owner
 approves any custom deal or price exception and fulfils the promo.
 
 **What the agent is measured on:** verified visits/day, data completeness, posters


### PR DESCRIPTION
## What

Writes the **bonus vs. sales commission** distinction into the docs and aligns terminology so the repo doesn't call the Phase-2 payment a "bonus" anymore.

- **`docs/FIELD_AGENT.md`** — adds a clear callout in §2: a **bonus** is paid for the *action* (poster/lead) even if the store never buys; a **sales commission** is paid **only when a store subscribes and pays**. Renames the Phase-2 "one-time bonus per signed store" → "one-time **sales commission**."
- **`docs/ADVERTISING.md`** — same rename in the unit-economics + CAC/break-even lines, with a one-line note that the commission is distinct from the Phase-1 bonus.

The hiring briefs (bilingual + Ukrainian-only artifacts) already carry the same definition.

Docs-only — no code or deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_