### PR TITLE
Remove the /whoami (/myid) bot command

### DIFF
--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -11,7 +11,6 @@
 //   /visit        — guided store-survey flow (store → GPS → photo → questionnaire)
 //   /myvisits     — an agent's own running visit count
 //   /cancel       — abort an in-progress /visit
-//   /whoami       — reply with your numeric Telegram ID (to get allow-listed)
 //   /report       — OWNER only: totals, per-agent counts, estimated pay
 //   /export       — OWNER only: CSV of all logged visits
 //
@@ -520,10 +519,6 @@ async function handleVisit(env, c, msg, ctx) {
   // the extended /visit menu only for the owner & agents).
   if (command) await syncBotCommands(env, userId, isOwner, isAgent);
 
-  if (command === 'whoami' || command === 'myid') {
-    await say(env, chatId, `Your Telegram ID · Ваш ID: <code>${userId}</code>`);
-    return true;
-  }
   if (isOwner && (command === 'report' || command === 'visits')) { await ownerReport(env, c, chatId); return true; }
   if (isOwner && command === 'export') { await ownerExport(env, chatId); return true; }
 


### PR DESCRIPTION
## What

Removes the `/whoami` (and `/myid` alias) command from `@Secondhandlvivbot` — the handler and its header-comment doc line. It wasn't in any command menu, so no menu/`CMD_VER` change is needed.

A non-agent who sends `/visit` still sees their Telegram id in the "not a registered field agent" reply, so ID capture for allow-listing remains possible without a dedicated command.

## Deploy

Bot Worker deploys via the **Deploy Telegram bot** action (manual dispatch) — triggered after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_