### PR TITLE
Language toggle: clearer Ukrainian label (УКР)

### DIFF
--- a/index.html
+++ b/index.html
@@ -676,7 +676,7 @@ header{ background:linear-gradient(118deg,var(--green2),var(--green)); }
   </div>
   <div style="display:flex;gap:8px;align-items:center;">
     <div class="lang-pill" role="group" aria-label="Language">
-      <span class="lp active" id="lang-ua" role="button" tabindex="0" aria-pressed="true" onclick="setLang('ua',true)">УА</span>
+      <span class="lp active" id="lang-ua" role="button" tabindex="0" aria-pressed="true" onclick="setLang('ua',true)">УКР</span>
       <span class="lp" id="lang-en" role="button" tabindex="0" aria-pressed="false" onclick="setLang('en',true)">EN</span>
     </div>
     <button class="help-btn" onclick="openShareModal()" title="Share your map & contribute stores" aria-label="Share your map and contribute stores" style="font-size:18px;">🤝</button>
@@ -2361,7 +2361,7 @@ if ('serviceWorker' in navigator) {
 // UPDATE CHECK — notify when a newer build is deployed, so nobody is stuck on
 // a cached version (no reinstall needed). Bump APP_VERSION on each deploy.
 // ─────────────────────────────────────────────
-const APP_VERSION = '2026-08-07.3';
+const APP_VERSION = '2026-08-07.4';
 
 // ─────────────────────────────────────────────
 // DONATIONS — points at a Stripe Payment Link (hosted checkout). No API keys


### PR DESCRIPTION
## What

Changes the Ukrainian language pill from **УА** to **УКР**. The old label was already correct Cyrillic (У+А) but its У letterform reads like Latin "YA", which looked like a typo. **УКР** is the standard, unambiguous Ukrainian abbreviation. English stays **EN**.

Only the visible label changed; `setLang` and the pill logic are untouched. `APP_VERSION` → `2026-08-07.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_