### PR TITLE
Ping the owner on Telegram when a promotion or an order is paid

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -55,6 +55,17 @@ jobs:
         run: |
           if [ -z "$STRIPE_API_KEY" ]; then echo "STRIPE_API_KEY not set — skipping (promo checkout stays off until you add it)"; exit 0; fi
           printf '%s' "$STRIPE_API_KEY" | npx --yes wrangler@3 secret put STRIPE_API_KEY
+      # Lets the metrics Worker ping the owner on Telegram when a sale lands.
+      # Reuses the bot's own token; skips cleanly when it isn't set.
+      - name: Set Telegram bot token secret
+        working-directory: worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN || secrets.TELEGRAM_BOT_TOKEN }}
+        run: |
+          if [ -z "$BOT_TOKEN" ]; then echo "BOT_TOKEN not set — skipping (sale notifications stay off until you add it)"; exit 0; fi
+          printf '%s' "$BOT_TOKEN" | npx --yes wrangler@3 secret put BOT_TOKEN
       - name: Set Stripe webhook secret
         working-directory: worker
         env:

--- a/docs/ADVERTISING.md
+++ b/docs/ADVERTISING.md
@@ -251,8 +251,28 @@ curl -H "X-Admin-Key: $ADMIN_KEY" https://lviv-metrics.lshanalytic.workers.dev/o
 
 Returns the last 200 orders (store, item, amount, buyer email, optional note, status).
 It is gated on `ADMIN_KEY` because it carries buyer emails — never expose it publicly.
-There is no automatic notification yet: nothing tells you an order arrived, so check
-this after any period where an extra might have sold.
+
+**You also get a Telegram ping the moment either kind of sale lands**, so the queue is
+a ledger rather than something you have to remember to poll:
+
+```
+🧾 NEW ORDER — you need to fulfil this     💸 PROMOTION PAID — already live, nothing to do
+Item:  Poster placement                    Store: s2
+Store: h1                                  Plan:  featured · 7-day run
+Paid:  ₴150                                Paid:  ₴200
+Email: shop@example.com                    Offer: -10% із застосунком
+Note:  -20% цей тиждень                    Until: 2026-08-14
+```
+
+Each message ends with a deep link to the store. The wording is deliberately different:
+an order is a task, a promotion is already fulfilled and just tells you money arrived.
+
+This needs the metrics Worker to have the **`BOT_TOKEN`** secret (the same repo secret
+the bot Worker already uses — `deploy-worker.yml` pushes it) and the `OWNER_ID` var in
+`worker/wrangler.toml`. Without the token it silently does nothing and `/orders` is the
+only record. The ping is sent through `ctx.waitUntil`, so a slow or failed Telegram call
+can never delay or fail the Stripe webhook, and messages carry **no `parse_mode`** —
+buyer-supplied text cannot be made to render as markup.
 
 ### Self-service purchase (in-app)
 

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -122,6 +122,26 @@ function cleanOffer(raw) {
   return s.slice(0, OFFER_MAX);
 }
 
+// ── Owner notification ───────────────────────────────────────────────────────
+// An à la carte extra is delivered by hand, so a silent sale is a missed one. Ping
+// the owner on Telegram the moment money lands. Inert without BOT_TOKEN + OWNER_ID,
+// and never allowed to affect the webhook: it is fired through waitUntil so Stripe's
+// response is not held up, and any failure is swallowed (Stripe would otherwise retry
+// a delivery whose order row was already written).
+function tgNotify(env, ctx, text) {
+  if (!env.BOT_TOKEN || !env.OWNER_ID) return;
+  const p = fetch(`https://api.telegram.org/bot${env.BOT_TOKEN}/sendMessage`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    // No parse_mode: the body carries buyer-supplied text, and plain text cannot be
+    // made to render as markup.
+    body: JSON.stringify({ chat_id: env.OWNER_ID, text, disable_web_page_preview: true }),
+  }).catch(() => {});
+  if (ctx && typeof ctx.waitUntil === 'function') ctx.waitUntil(p);
+}
+const uah = (kop) => (kop == null ? '?' : '₴' + (kop / 100).toLocaleString('uk-UA'));
+const storeLink = (id) => `${APP_URL}?store=${encodeURIComponent(id)}`;
+
 // Verify Stripe's `Stripe-Signature` header (HMAC-SHA256 over `${t}.${payload}`).
 async function verifyStripeSig(payload, header, secret) {
   const parts = {};
@@ -138,7 +158,7 @@ async function verifyStripeSig(payload, header, secret) {
 }
 
 // Apply a verified Stripe event to the promos table (activate / extend / cancel).
-async function applyPromoEvent(env, ev) {
+async function applyPromoEvent(env, ev, ctx) {
   const o = (ev && ev.data && ev.data.object) || {};
   const type = ev && ev.type;
   const graceDays = (cad) => (cad === 'annual' ? 372 : 34); // period + a few days' grace
@@ -155,6 +175,16 @@ async function applyPromoEvent(env, ev) {
         o.id, storeId, md.item, o.amount_total || null, o.currency || null,
         (o.customer_details && o.customer_details.email) || null, cleanOffer(md.note) || null
       ).run();
+      const email = (o.customer_details && o.customer_details.email) || '—';
+      const note = cleanOffer(md.note);
+      tgNotify(env, ctx,
+        `🧾 NEW ORDER — you need to fulfil this\n\n` +
+        `Item:  ${ORDER_ITEMS[md.item].label}\n` +
+        `Store: ${storeId}\n` +
+        `Paid:  ${uah(o.amount_total)}\n` +
+        `Email: ${email}\n` +
+        (note ? `Note:  ${note}\n` : '') +
+        `\n${storeLink(storeId)}`);
       return;
     }
     const tier = md.tier;
@@ -172,6 +202,15 @@ async function applyPromoEvent(env, ev) {
       "INSERT INTO promos (store_id, tier, offer, until, sub_id, cadence, cust_id, status, updated) VALUES (?, ?, ?, ?, ?, ?, ?, 'active', datetime('now')) " +
       "ON CONFLICT(store_id) DO UPDATE SET tier=excluded.tier, offer=excluded.offer, until=excluded.until, sub_id=excluded.sub_id, cadence=excluded.cadence, cust_id=excluded.cust_id, status='active', updated=datetime('now')"
     ).bind(storeId, tier, offer, until, o.subscription || null, cadence, run ? null : (o.customer || null)).run();
+    // A promotion fulfils itself, so this is information rather than a task.
+    tgNotify(env, ctx,
+      `💸 PROMOTION PAID — already live, nothing to do\n\n` +
+      `Store: ${storeId}\n` +
+      `Plan:  ${tier} · ${run ? run.days + '-day run' : cadence}\n` +
+      `Paid:  ${uah(o.amount_total)}\n` +
+      (offer ? `Offer: ${offer}\n` : '') +
+      `Until: ${until}\n` +
+      `\n${storeLink(storeId)}`);
   } else if (type === 'invoice.paid' || type === 'invoice.payment_succeeded') {
     const subId = o.subscription;
     if (!subId) return;
@@ -273,7 +312,7 @@ async function sendPush(sub, payloadStr, env) {
 }
 
 export default {
-  async fetch(request, env) {
+  async fetch(request, env, ctx) {
     const url = new URL(request.url);
     const origin = request.headers.get('Origin') || '';
     if (request.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors(origin) });
@@ -445,7 +484,7 @@ export default {
       const sig = request.headers.get('Stripe-Signature') || '';
       if (!(await verifyStripeSig(payload, sig, env.STRIPE_WEBHOOK_SECRET))) return new Response('bad signature', { status: 400 });
       let ev; try { ev = JSON.parse(payload); } catch { return new Response('bad json', { status: 400 }); }
-      try { await ensureSchema(env); await applyPromoEvent(env, ev); } catch {}
+      try { await ensureSchema(env); await applyPromoEvent(env, ev, ctx); } catch {}
       return new Response('ok', { status: 200 }); // 2xx so Stripe stops retrying
     }
 

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -26,6 +26,10 @@ crons = ["0 7 * * *"]
 # The private key is set separately as the VAPID_PRIVATE secret — NEVER commit it.
 [vars]
 VAPID_PUBLIC = "BBfji9HA_fVrn42DeYako-WekhEo60jc_9f7UmHf67kpEqv7JdmLaonrkLWfSEYMLARMgG9jVovK7W3uUDNp7kU"
+# Telegram chat that gets a ping when a promotion or an à la carte order is paid.
+# Not a secret (it is just a chat id, same value as telegram-bot/wrangler.toml).
+# The notification stays off until the BOT_TOKEN secret is also set — see below.
+OWNER_ID = "1212541015"
 
 # ── Paid promotions (Stripe self-fulfilment) — optional, off until configured ──
 # GET /promos serves the live promo set with no secret. Selling + auto-fulfil
@@ -42,4 +46,9 @@ VAPID_PUBLIC = "BBfji9HA_fVrn42DeYako-WekhEo60jc_9f7UmHf67kpEqv7JdmLaonrkLWfSEYM
 #                          (events: checkout.session.completed, invoice.paid,
 #                          customer.subscription.deleted/updated). Verifies the
 #                          POST /stripe-webhook signature. NEVER commit it.
+#   BOT_TOKEN            — the same Telegram bot token the bot Worker uses (repo
+#                          secret BOT_TOKEN, already set if the bot is deployed).
+#                          With it, a paid promotion or à la carte order pings
+#                          OWNER_ID above. Without it, sales are silent and the
+#                          order queue has to be read from GET /orders by hand.
 # See docs/ADVERTISING.md §7 for the full activation steps.


### PR DESCRIPTION
Closes the gap flagged when ad-hoc advertising shipped: à la carte extras are delivered **by hand**, so a sale nobody notices is a sale nobody delivers. Until now the only trace was a row in D1 that had to be fetched deliberately.

The metrics Worker now messages the owner the moment money lands, with wording that separates a task from a receipt:

```
🧾 NEW ORDER — you need to fulfil this      💸 PROMOTION PAID — already live, nothing to do
Item:  Poster placement                     Store: s2
Store: h1                                   Plan:  featured · 7-day run
Paid:  ₴150                                 Paid:  ₴200
Email: shop@example.com                     Offer: -10% із застосунком
Note:  -20% цей тиждень                     Until: 2026-08-14
```

Both end with a deep link to the store. Promotions are included because they cost nothing extra here and a sale is worth knowing about even when it needs no action.

## Nothing new to configure

Reuses the bot's own **`BOT_TOKEN`** repo secret — already set if the bot is deployed — plus `OWNER_ID` as a plain var, since it's only a chat id. Without the token it does nothing at all and `GET /orders` stays the only record.

## Two things it's careful about

**It cannot break the webhook.** The send goes through `ctx.waitUntil`, so a slow or failed Telegram call can't delay Stripe's response or push it into a retry whose order row was already written.

**No `parse_mode`.** These messages carry buyer-supplied text (the note, the offer, the email). Plain text cannot be coerced into markup, so there's nothing to escape and nothing to get wrong.

## Verification

Drove `applyPromoEvent` directly against a stubbed `fetch` and D1 — four cases, all passing:

| Case | Result |
|---|---|
| À la carte order (poster) | ✅ order message, ₴150, email + note, angle brackets already stripped |
| One-off run (featured run7) | ✅ promotion message, ₴200, `until` = today **+7** |
| Subscription (spotlight annual) | ✅ promotion message, ₴12 000, `until` = today **+372** |
| No `BOT_TOKEN` | ✅ **0 messages sent** |

Also confirmed in the same run that `cust_id` binds `null` for a run but the customer id for a subscription — so the "Manage billing" link stays correctly hidden on one-offs, which is what makes a run genuinely fire-and-forget.

Worker-only change; no `index.html` edit, so no `APP_VERSION` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_