### PR TITLE
Add /billing-selftest so the customer portal can be checked before the first sale

### DIFF
--- a/docs/ADVERTISING.md
+++ b/docs/ADVERTISING.md
@@ -296,6 +296,27 @@ tier, update card, cancel). This needs the restricted key to *also* carry **Bill
 Portal Sessions: Write** and a saved portal configuration in Stripe; without either
 the route fails and the app just hides the link, so it is safe to skip.
 
+`/billing` looks up the store's `cust_id` first and returns **404 before touching
+Stripe** when there is no subscription — so it cannot tell you whether the portal is
+set up correctly. Ask Stripe directly instead:
+
+```
+curl -H "X-Admin-Key: $ADMIN_KEY" https://lviv-metrics.lshanalytic.workers.dev/billing-selftest
+```
+
+It attempts a portal session for a customer id that cannot exist — nothing is created
+— and reads the error back:
+
+| `state` | Meaning |
+|---|---|
+| `ready` | Key and portal config are both good ("No such customer" means it got that far) |
+| `key_missing_permission` | Add **Billing Portal Sessions: Write** at `dashboard.stripe.com/apikeys` |
+| `portal_not_configured` | Save a configuration at `dashboard.stripe.com/settings/billing/portal` |
+| `no_stripe_key` | `STRIPE_API_KEY` isn't set on the Worker |
+
+The response includes Stripe's own `stripeStatus`/`stripeMessage` for anything the
+classifier doesn't recognise. Gated on `ADMIN_KEY` — it reveals configuration state.
+
 > **Known limitation — no ownership check.** Anyone can promote any store, and the
 > offer line is free text. Paying for a store you do not own is self-punishing, but
 > the offer text is the abuse surface: it is length-capped, stripped and escaped, and

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -441,6 +441,48 @@ export default {
           return json({ ok: true, orders: (res && res.results) || [] }, 200, origin);
         } catch { return json({ ok: false, reason: 'db_error' }, 500, origin); }
       }
+      // Is the customer portal actually usable? /billing only reaches Stripe once a
+      // real subscription exists, so until the first sale there is no way to tell a
+      // working setup from a missing key permission or an unsaved portal config.
+      // This asks Stripe directly, using a customer id that cannot exist: the request
+      // never creates anything, and the error it comes back with names the problem.
+      //   403 / "permission"      → the restricted key lacks Billing Portal Sessions
+      //   "...configuration..."   → key is fine, no portal configuration saved yet
+      //   "No such customer"      → both are fine; it got all the way to the lookup
+      if (url.pathname === '/billing-selftest') {
+        if (!env.ADMIN_KEY || request.headers.get('X-Admin-Key') !== env.ADMIN_KEY) {
+          return json({ ok: false, reason: 'unauthorized' }, 401, origin);
+        }
+        if (!env.STRIPE_API_KEY) return json({ ok: false, state: 'no_stripe_key' }, 200, origin);
+        const form = new URLSearchParams();
+        form.set('customer', 'cus_lvivSelfTestNoSuchCustomer');
+        form.set('return_url', APP_URL);
+        try {
+          const res = await fetch('https://api.stripe.com/v1/billing_portal/sessions', {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${env.STRIPE_API_KEY}`, 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: form,
+          });
+          const data = await res.json().catch(() => ({}));
+          const msg = (data && data.error && data.error.message) || '';
+          let state = 'unknown';
+          if (res.ok) state = 'ready';                                  // shouldn't happen, but harmless
+          else if (res.status === 403 || /permission|not permitted/i.test(msg)) state = 'key_missing_permission';
+          else if (/configuration/i.test(msg)) state = 'portal_not_configured';
+          else if (/no such customer|resource_missing/i.test(msg)) state = 'ready';
+          return json({
+            ok: state === 'ready', state,
+            hint: state === 'key_missing_permission'
+              ? 'Add "Billing Portal Sessions: Write" to the restricted key at dashboard.stripe.com/apikeys'
+              : state === 'portal_not_configured'
+              ? 'Save a portal configuration at dashboard.stripe.com/settings/billing/portal'
+              : state === 'ready'
+              ? 'Manage billing will work as soon as a store has an active subscription'
+              : 'Unrecognised Stripe response — see stripeMessage',
+            stripeStatus: res.status, stripeMessage: msg,
+          }, 200, origin);
+        } catch (e) { return json({ ok: false, state: 'fetch_failed' }, 200, origin); }
+      }
       // Self-service billing: /billing?store=<id> sends the paying store to the
       // Stripe customer portal (change tier, update card, cancel) so none of that
       // has to come through the owner. Needs the restricted key to also carry


### PR DESCRIPTION
You can't currently tell whether Manage billing is set up correctly, and that's a gap in the tooling rather than in your Stripe config.

`/billing` looks up the store's `cust_id` and returns **404 before making any Stripe call** when there's no subscription. That's correct behaviour — but with an empty `promos` table every store 404s, so the route can't distinguish:

- a working setup,
- a restricted key missing **Billing Portal Sessions: Write**,
- a portal configuration that was never saved.

There was no way to check any of it until someone actually paid.

## How this works

It asks Stripe directly, using a customer id that cannot exist. **Nothing is created** — the request is designed to fail, and the error names the problem:

| Stripe's response | Verdict |
|---|---|
| `403` / "permission" | `key_missing_permission` |
| "…configuration…" | `portal_not_configured` |
| "No such customer" | `ready` — it got all the way to the customer lookup, so key and config are both fine |

```
curl -H "X-Admin-Key: $ADMIN_KEY" https://lviv-metrics.lshanalytic.workers.dev/billing-selftest
```

```json
{ "ok": true, "state": "ready",
  "hint": "Manage billing will work as soon as a store has an active subscription",
  "stripeStatus": 404, "stripeMessage": "No such customer: 'cus_lvivSelfTestNoSuchCustomer'" }
```

Stripe's own status and message come back alongside the verdict, so an unrecognised response is still diagnosable rather than silently misclassified. Gated on `ADMIN_KEY` since it reveals configuration state.

## Verification

Ran the classifier against all four real response shapes:

```
missing permission:    key_missing_permission
no portal config:      portal_not_configured
ready:                 ready
weird/unexpected:      unknown          ← falls through, not a false "ready"
```

That last case is the one that matters — an unrecognised Stripe response reports `unknown` with the raw message rather than claiming success.

Worker-only; no `index.html` change, so no `APP_VERSION` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_