### PR TITLE
Fix: locale=uk broke checkout entirely — Stripe has no Ukrainian locale

### DIFF
--- a/worker/worker.js
+++ b/worker/worker.js
@@ -123,10 +123,15 @@ function cleanOffer(raw) {
 }
 
 // Stripe renders its hosted checkout in the buyer's browser locale unless told
-// otherwise, so a Ukrainian shop owner on an English phone would be asked to pay in
-// English. The app passes its own language through instead; Ukrainian is the default
-// because the app's is.
-const stripeLocale = (v) => (v === 'en' ? 'en' : 'uk');
+// otherwise, so the app passes its own language through. Stripe has NO Ukrainian
+// locale -- sending 'uk' is rejected outright and the session fails to create, which
+// broke checkout for the app's default language. Ukrainian therefore maps to 'auto'
+// (Stripe's own detection -- the best available), and only locales Stripe actually
+// supports are ever sent verbatim.
+const STRIPE_LOCALES = new Set(['auto', 'bg', 'cs', 'da', 'de', 'el', 'en', 'en-GB', 'es', 'es-419',
+  'et', 'fi', 'fil', 'fr', 'fr-CA', 'hr', 'hu', 'id', 'it', 'ja', 'ko', 'lt', 'lv', 'ms', 'mt',
+  'nb', 'nl', 'pl', 'pt', 'pt-BR', 'ro', 'ru', 'sk', 'sl', 'sv', 'th', 'tr', 'vi', 'zh', 'zh-HK', 'zh-TW']);
+const stripeLocale = (v) => (STRIPE_LOCALES.has(v) ? v : 'auto');
 
 // ── Owner notification ───────────────────────────────────────────────────────
 // An à la carte extra is delivered by hand, so a silent sale is a missed one. Ping


### PR DESCRIPTION
**Production hotfix.** The previous PR passed the app's language to Stripe as a `locale` so the hosted payment page would match the app. **Stripe has no Ukrainian locale.** It rejects `uk` outright, the session fails to create, and `/promote` returns **502**.

The app defaults to Ukrainian, so this broke the buy button for essentially every user — at the payment step itself.

## How it got missed

The smoke test ran seconds after the deploy, and the `lang=ua` calls landed on isolates still running the previous code, which sent no locale at all and returned 302. It looked fine.

Reading the created sessions back out of Stripe is what exposed it:

```
lang=en  → "locale": "en"      ✓
lang=ua  → "locale": null      ← should have been uk
```

Re-running once propagation had finished returned a clean **502** on every `lang=ua` call.

## Fix

Unsupported locales now fall back to `auto` (Stripe's own detection) instead of being sent verbatim, so this class of failure can't recur for any language:

```
ua → auto    uk → auto    null → auto    '' → auto    garbage → auto
en → en      pl → pl
```

Ukrainian buyers get Stripe's detection, which is the best available — Stripe simply does not offer a Ukrainian checkout page. The claim in the previous PR that checkout would render in Ukrainian was wrong, and `docs/ADVERTISING.md` needs that corrected too (follow-up).

Worker-only; no `APP_VERSION` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_