### PR TITLE
Correct the Ukrainian-checkout claim and drop stale /whoami references

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Contributions arrive as GitHub issues labelled `map-contribution`. Each issue li
 
 ## 📣 Store promotions (advertising)
 
-Shop owners can promote their own store without contacting anyone. Open the store in the app → **📣 Own this store? Promote it** → pick a plan and pay in ₴ (Stripe). Everything is priced and displayed in Ukrainian by default.
+Shop owners can promote their own store without contacting anyone. Open the store in the app → **📣 Own this store? Promote it** → pick a plan and pay in ₴ (Stripe). The app, the rate card and the prices are Ukrainian by default; Stripe's own payment page is not, because Stripe offers no Ukrainian locale — it falls back to Stripe's language detection.
 
 | Tier | Monthly | Annual | One-off 7 / 30 days |
 | --- | --- | --- | --- |
@@ -263,7 +263,7 @@ PWA (прогресивний веб-додаток) для пошуку та в
 
 ## 📣 Просування магазинів (реклама)
 
-Власник магазину може просунути свій магазин самостійно, без звернення до когось. Відкрийте магазин у застосунку → **📣 Власник магазину? Просувати** → оберіть тариф і оплатіть у ₴ (Stripe). Усе — ціни, оплата та сторінка Stripe — за замовчуванням українською.
+Власник магазину може просунути свій магазин самостійно, без звернення до когось. Відкрийте магазин у застосунку → **📣 Власник магазину? Просувати** → оберіть тариф і оплатіть у ₴ (Stripe). Застосунок, прайс і ціни — українською за замовчуванням; сама сторінка оплати Stripe — ні, бо Stripe не має української локалі, тож мова визначається автоматично.
 
 | Тариф | Щомісяця | Щороку | Разово 7 / 30 днів |
 | --- | --- | --- | --- |

--- a/docs/FIELD_AGENT.md
+++ b/docs/FIELD_AGENT.md
@@ -234,7 +234,6 @@ One-time enablement of the `/visit` subsystem is documented in
 
 | Command | Who | Does |
 |---|---|---|
-| `/whoami` | anyone | replies with your numeric Telegram id (to be allow-listed) |
 | `/visit` | agent | start a survey |
 | `/myvisits` | agent | their running visit count |
 | `/pay` | agent · owner | show the pay scheme (live rates from `RATE_VISIT`/`RATE_BONUS`) |

--- a/telegram-bot/wrangler.toml
+++ b/telegram-bot/wrangler.toml
@@ -27,7 +27,8 @@ compatibility_date = "2026-08-01"
 #      each visit to the owner, and upload the CSV export):
 #        printf '%s' "<telegram-bot-token>" | npx wrangler@3 secret put BOT_TOKEN
 #   3. Set who is who + the pay rates as [vars] below (ids are numeric Telegram
-#      user ids — anyone can get theirs by sending the bot /whoami).
+#      user ids — ask the person to forward a message to @userinfobot, or read
+#      the id from the bot's own logs after they message it).
 #   4. Re-register the webhook allowing location & photo updates:
 #        allowed_updates=["message"]   (the default already includes these)
 #


### PR DESCRIPTION
Two documentation errors, both of which would mislead someone acting on them.

**The README claimed the Stripe payment page renders in Ukrainian.** It does not and cannot — Stripe offers no Ukrainian locale, which is exactly what caused the checkout outage fixed in #108. Both language versions now say what's true: the app, rate card and prices are Ukrainian by default; Stripe's own page falls back to its language detection.

**`/whoami` was removed from the bot in #97** but was still documented as a live command in `docs/FIELD_AGENT.md` and in the bot's setup comments — which would send the field agent chasing a command that no longer exists. The setup comment now points at a method that actually works (forward a message to `@userinfobot`).

Docs only; no behaviour change, no `APP_VERSION` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_