### PR TITLE
Automated patch pipeline for stores.json (repository_dispatch)

### DIFF
--- a/.github/workflows/update-map.yml
+++ b/.github/workflows/update-map.yml
@@ -1,0 +1,67 @@
+name: Update map data
+
+# Applies a single-store patch to stores.json without a human in the loop.
+# Triggered by a `repository_dispatch` event of type `update_map_data`, sent
+# by scripts/patch-store.js (or a Worker calling the same GitHub API
+# endpoint directly) with a payload shaped:
+#   { store_id: "c21", updates: { phone: "...", hours: { mon: "..." } } }
+#
+# `updates` is a *partial* patch (deep-merged into the matching store, see
+# scripts/apply-map-patch.mjs), never the whole file — so two patches for
+# different stores arriving close together can't race and clobber each
+# other's unrelated fields the way a full-file overwrite could.
+#
+# The concurrency group still serialises runs (queued, not cancelled) so two
+# patches for the *same* store can't interleave their read-modify-write.
+on:
+  repository_dispatch:
+    types: [update_map_data]
+
+concurrency:
+  group: map-data-update
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  patch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # Step 1 — apply the patch. Reads store_id/updates from the event
+      # payload (GITHUB_EVENT_PATH), not a workflow-expression env var, so
+      # nested/quoted JSON survives without shell-escaping surprises.
+      - name: Apply patch
+        run: node scripts/apply-map-patch.mjs
+
+      # Step 2 — schema gate. Aborts the whole run (nothing committed) if the
+      # patch produced anything the app can't safely render: broken JSON,
+      # a missing required field, an out-of-range coordinate, a duplicate id,
+      # or a non-ISO date.
+      - name: Validate schema
+        run: node scripts/validate-stores.mjs
+
+      # Step 3 — commit & deploy. GitHub Pages for this repo serves straight
+      # from `main` (no separate build/deploy workflow), so pushing here IS
+      # the deploy. Skips cleanly if the patch was a no-op (e.g. updates
+      # matched the existing values).
+      - name: Commit
+        run: |
+          git config user.name "lviv-secondhand-bot"
+          git config user.email "actions@users.noreply.github.com"
+          git add stores.json
+          if git diff --cached --quiet; then
+            echo "No changes after patch — nothing to commit."
+            exit 0
+          fi
+          STORE_ID=$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.env.GITHUB_EVENT_PATH,'utf8')).client_payload.store_id)")
+          git commit -m "Auto-update store ${STORE_ID} [skip ci]"
+          git push

--- a/scripts/apply-map-patch.mjs
+++ b/scripts/apply-map-patch.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// Step 1 of .github/workflows/update-map.yml: applies a single { store_id,
+// updates } patch (from the repository_dispatch client_payload) to the
+// matching entry in stores.json. Deep-merges plain objects (so a patch can
+// touch just s.hours.mon without clobbering the rest of s.hours); arrays and
+// primitives are replaced outright.
+//
+// Reads the event payload from GITHUB_EVENT_PATH (the JSON file Actions
+// writes for every run) rather than a workflow-expression env var, so
+// nested/quoted JSON in `updates` can't be mangled by shell interpolation.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const storesPath = resolve(here, '..', 'stores.json');
+
+function isPlainObject(v) {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function deepMerge(target, patch) {
+  for (const [k, v] of Object.entries(patch)) {
+    target[k] = isPlainObject(v) && isPlainObject(target[k]) ? deepMerge(target[k], v) : v;
+  }
+  return target;
+}
+
+function main() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) throw new Error('GITHUB_EVENT_PATH is not set — this script must run inside a GitHub Actions job.');
+  const event = JSON.parse(readFileSync(eventPath, 'utf8'));
+  const payload = event.client_payload;
+  if (!payload || typeof payload !== 'object') throw new Error('Event has no client_payload.');
+
+  const { store_id: storeId, updates } = payload;
+  if (!storeId || typeof storeId !== 'string') throw new Error('client_payload.store_id is required.');
+  if (!isPlainObject(updates)) throw new Error('client_payload.updates must be a plain object.');
+  // id is the store's identity — a patch is never allowed to reassign it.
+  if ('id' in updates) throw new Error('updates must not include "id" — it identifies which store to patch.');
+
+  const stores = JSON.parse(readFileSync(storesPath, 'utf8'));
+  if (!Array.isArray(stores)) throw new Error('stores.json is not an array.');
+  const idx = stores.findIndex((s) => s && s.id === storeId);
+  if (idx === -1) throw new Error(`No store with id "${storeId}" in stores.json.`);
+
+  deepMerge(stores[idx], updates);
+  writeFileSync(storesPath, JSON.stringify(stores, null, 1) + '\n');
+  console.log(`Patched store "${storeId}":`, JSON.stringify(updates));
+}
+
+main();

--- a/scripts/patch-store.js
+++ b/scripts/patch-store.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// Sends a targeted store patch to the automated map-update pipeline
+// (.github/workflows/update-map.yml) via a GitHub repository_dispatch event.
+// The dispatch carries { store_id, updates } — a partial object merged into
+// the matching entry in stores.json — never the whole file, so concurrent
+// patches from different sources (field-scout submissions, flash-deal
+// payments, moderation approvals) can't clobber each other's unrelated
+// fields.
+//
+// Zero npm dependencies: only native fetch (Node 18+).
+//
+// Usage:
+//   node scripts/patch-store.js <store_id> '<json-updates>' [owner/repo]
+//   node scripts/patch-store.js c21 '{"promo":{"tier":"featured","until":"2026-09-30"}}'
+//
+// Or import dispatchMapPatch() directly from another Node script:
+//   import { dispatchMapPatch } from './scripts/patch-store.js';
+//   await dispatchMapPatch({ storeId: 'c21', updates: {...} });
+//
+// Requires a GITHUB_PAT environment variable — a classic PAT with the `repo`
+// scope (repository_dispatch cannot be triggered with the default
+// GITHUB_TOKEN a workflow run gets automatically; it needs a real PAT).
+// NEVER commit a token — set it as an env var or a repo/CLI secret.
+
+const DEFAULT_REPO = 'anonymouspartner/lviv-secondhand';
+
+export async function dispatchMapPatch({ storeId, updates, repo = DEFAULT_REPO, token = process.env.GITHUB_PAT }) {
+  if (!token) throw new Error('GITHUB_PAT is not set — cannot authenticate to the GitHub API.');
+  if (!/^[a-z0-9]{1,20}$/i.test(String(storeId || ''))) throw new Error('storeId must be a short alphanumeric id.');
+  if (!updates || typeof updates !== 'object' || Array.isArray(updates)) throw new Error('updates must be a plain object.');
+
+  const res = await fetch(`https://api.github.com/repos/${repo}/dispatches`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify({
+      event_type: 'update_map_data',
+      client_payload: { store_id: storeId, updates },
+    }),
+  });
+
+  if (res.status !== 204) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`GitHub dispatch failed (${res.status}): ${body}`);
+  }
+  return true;
+}
+
+// CLI entry point — only runs when this file is executed directly, not when imported.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const [storeId, updatesJson, repo] = process.argv.slice(2);
+  if (!storeId || !updatesJson) {
+    console.error('Usage: node scripts/patch-store.js <store_id> \'<json-updates>\' [owner/repo]');
+    process.exit(1);
+  }
+  let updates;
+  try {
+    updates = JSON.parse(updatesJson);
+  } catch (err) {
+    console.error('updates must be valid JSON:', err.message);
+    process.exit(1);
+  }
+  try {
+    await dispatchMapPatch({ storeId, updates, repo: repo || DEFAULT_REPO });
+    console.log(`Dispatched patch for store "${storeId}" — check the "Update map data" workflow run.`);
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}

--- a/scripts/validate-stores.mjs
+++ b/scripts/validate-stores.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// Step 2 of .github/workflows/update-map.yml: the schema gate. Runs after a
+// patch is applied and before it's committed — aborts the workflow (non-zero
+// exit) rather than let a bad patch reach the live map. Also runnable by
+// hand: `node scripts/validate-stores.mjs`.
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const storesPath = resolve(here, '..', 'stores.json');
+
+const REQUIRED_FIELDS = ['id', 'name', 'lat', 'lng', 'cycle'];
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?Z)?$/;
+// Field names that hold a date value, wherever they appear in the store
+// object (top-level or nested, e.g. promo.until, flashDeal.expires_at).
+const DATE_FIELD_RE = /(^|_)(until|date|starts_at|expires_at|starts|expires)$/i;
+
+function collectDateFields(obj, path, out) {
+  if (!obj || typeof obj !== 'object') return;
+  for (const [k, v] of Object.entries(obj)) {
+    const p = path ? `${path}.${k}` : k;
+    if (typeof v === 'string' && DATE_FIELD_RE.test(k)) out.push([p, v]);
+    else if (v && typeof v === 'object') collectDateFields(v, p, out);
+  }
+}
+
+function main() {
+  let raw;
+  try {
+    raw = readFileSync(storesPath, 'utf8');
+  } catch (err) {
+    console.error(`Could not read ${storesPath}: ${err.message}`);
+    process.exit(1);
+  }
+
+  let stores;
+  try {
+    stores = JSON.parse(raw);
+  } catch (err) {
+    console.error(`stores.json is not valid JSON: ${err.message}`);
+    process.exit(1);
+  }
+
+  const errors = [];
+  if (!Array.isArray(stores)) errors.push('stores.json must be a top-level array.');
+
+  const seenIds = new Set();
+  const dupIds = new Set();
+
+  if (Array.isArray(stores)) {
+    stores.forEach((s, i) => {
+      const where = `stores[${i}]${s && s.id ? ` (id: ${s.id})` : ''}`;
+      if (!s || typeof s !== 'object') { errors.push(`${where}: not an object.`); return; }
+
+      for (const field of REQUIRED_FIELDS) {
+        if (s[field] === undefined || s[field] === null || s[field] === '') {
+          errors.push(`${where}: missing required field "${field}".`);
+        }
+      }
+
+      if (typeof s.id === 'string') {
+        if (seenIds.has(s.id)) dupIds.add(s.id);
+        seenIds.add(s.id);
+      }
+
+      if (typeof s.lat === 'number') {
+        if (!Number.isFinite(s.lat) || s.lat < -90 || s.lat > 90) errors.push(`${where}: lat "${s.lat}" out of range [-90, 90].`);
+      } else if (s.lat !== undefined) {
+        errors.push(`${where}: lat must be a number.`);
+      }
+      if (typeof s.lng === 'number') {
+        if (!Number.isFinite(s.lng) || s.lng < -180 || s.lng > 180) errors.push(`${where}: lng "${s.lng}" out of range [-180, 180].`);
+      } else if (s.lng !== undefined) {
+        errors.push(`${where}: lng must be a number.`);
+      }
+
+      if (typeof s.cycle === 'number' && (!Number.isFinite(s.cycle) || s.cycle <= 0)) {
+        errors.push(`${where}: cycle "${s.cycle}" must be a positive number.`);
+      }
+
+      const dateFields = [];
+      collectDateFields(s, '', dateFields);
+      for (const [field, value] of dateFields) {
+        if (!ISO_DATE_RE.test(value)) {
+          errors.push(`${where}: field "${field}" = "${value}" is not ISO YYYY-MM-DD or YYYY-MM-DDTHH:mm:ssZ.`);
+        }
+      }
+    });
+  }
+
+  for (const id of dupIds) errors.push(`Duplicate store id: "${id}".`);
+
+  if (errors.length) {
+    console.error(`stores.json failed validation (${errors.length} issue${errors.length === 1 ? '' : 's'}):`);
+    for (const e of errors) console.error(`  - ${e}`);
+    process.exit(1);
+  }
+
+  console.log(`stores.json OK — ${stores.length} stores, no duplicate ids, all dates ISO-formatted.`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Second slice of the larger effort — this is pure infrastructure that the field-scout (next PR), flash-deal, and moderation features will call into; nothing triggers it yet.

- **`scripts/patch-store.js`** — sends a targeted `{ store_id, updates }` patch to GitHub as a `repository_dispatch` event, using native `fetch()` only (no npm dependencies). Exports `dispatchMapPatch()` for reuse from other Node scripts, and doubles as a CLI (`node scripts/patch-store.js c21 '{"phone":"..."}'`). Needs a `GITHUB_PAT` repo secret (classic PAT, `repo` scope) — `repository_dispatch` can't be triggered with a workflow's default `GITHUB_TOKEN`.
- **`.github/workflows/update-map.yml`** — triggered by that dispatch, serialized by a `concurrency` group (queued, not cancelled, so same-store patches can't interleave):
  1. **Apply** (`scripts/apply-map-patch.mjs`) — deep-merges `updates` into the matching store in `stores.json` (so a patch can touch just `hours.mon` without clobbering the rest of `hours`). Refuses to reassign `id`, refuses an unknown `store_id`.
  2. **Validate** (`scripts/validate-stores.mjs`) — the schema gate: JSON validity, required fields (`id`/`name`/`lat`/`lng`/`cycle`), coordinate ranges, duplicate ids, ISO-formatted date fields anywhere in the object (`promo.until` and friends). Aborts the run — nothing gets committed — on any violation.
  3. **Commit** — pushes straight to `main`, which *is* the deploy (this repo's GitHub Pages serves from `main` directly, confirmed in the previous PR). Skips cleanly if the patch was a no-op.
- A patch is always a **partial** object, never the whole file — so patches from unrelated sources landing close together can't race and overwrite each other's fields.

## Test plan

- [x] `node --check` on all three new scripts; workflow YAML validated with a YAML parser
- [x] End-to-end in an isolated scratch git repo: valid patch → deep merge is correct (touches only the targeted field, e.g. `hours.mon`, leaves the rest of the object alone) → validator passes → `git diff --cached` correctly detects the change → commit created with the right message
- [x] Schema gate correctly **rejects** (non-zero exit, `stores.json` left untouched): out-of-range coordinates, a non-ISO date, a duplicate id (manually corrupted for the test)
- [x] `apply-map-patch.mjs` correctly **rejects**: an unknown `store_id`, a patch that tries to include `id` (identity reassignment)
- [x] No-op patch (updates match existing values) correctly produces an empty `git diff --cached` — the commit step would skip cleanly
- [x] Confirmed the real repo's `stores.json` is unmodified after all of the above (tested in isolated scratch copies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_