### PR TITLE
Rename GITHUB_PAT to GH_PAT (reserved secret-name prefix)

### DIFF
--- a/.github/workflows/deploy-bot.yml
+++ b/.github/workflows/deploy-bot.yml
@@ -86,15 +86,15 @@ jobs:
         run: |
           if [ -z "$BOUNTY_SECRET" ]; then echo "BOUNTY_SECRET not set — skipping (field-scout flow stays off until you add it)"; exit 0; fi
           printf '%s' "$BOUNTY_SECRET" | npx wrangler secret put BOUNTY_SECRET
-      - name: Set GITHUB_PAT on the worker
+      - name: Set GH_PAT on the worker
         working-directory: telegram-bot
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
-          if [ -z "$GITHUB_PAT" ]; then echo "GITHUB_PAT not set — skipping (field-scout flow can't dispatch patches until you add it)"; exit 0; fi
-          printf '%s' "$GITHUB_PAT" | npx wrangler secret put GITHUB_PAT
+          if [ -z "$GH_PAT" ]; then echo "GH_PAT not set — skipping (field-scout flow can't dispatch patches until you add it)"; exit 0; fi
+          printf '%s' "$GH_PAT" | npx wrangler secret put GH_PAT
 
       # Crowdsourced moderation (Feature 6) — MUST match the metrics Worker's
       # ADMIN_KEY exactly (already used there by /admin/test, /flash-deal/approve).

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -93,7 +93,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
-          if [ -z "$GITHUB_PAT" ]; then echo "GITHUB_PAT not set — skipping (flash deals can't auto-publish/approve until you add it)"; exit 0; fi
-          printf '%s' "$GITHUB_PAT" | npx --yes wrangler@3 secret put GITHUB_PAT
+          if [ -z "$GH_PAT" ]; then echo "GH_PAT not set — skipping (flash deals can't auto-publish/approve until you add it)"; exit 0; fi
+          printf '%s' "$GH_PAT" | npx --yes wrangler@3 secret put GH_PAT

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ A **short, paid sale window** — separate from the ongoing promotion tiers abov
 | Subscribers + broadcast | D1 table `store_subs`, `broadcastFlashDeal()`, bot `/start sub_<id>` · `/stop` |
 | Shopper-facing banner/toast | `index.html` (`activeFlashDeal()`, `tickFlashCountdowns()`) |
 
-Needs `GITHUB_PAT` (on both Workers — publishing a deal dispatches through the same pipeline as everything else below) and, for the owner-review path, the existing `ADMIN_KEY`. Both optional; the feature stays inert without them.
+Needs `GH_PAT` (on both Workers — publishing a deal dispatches through the same pipeline as everything else below) and, for the owner-review path, the existing `ADMIN_KEY`. Both optional; the feature stays inert without them.
 
 ## ✏️ Community edits & the leaderboard
 
@@ -200,13 +200,13 @@ Every feature above that changes the map — a field-scout correction, a publish
 1. A signed **`repository_dispatch`** event carries a *targeted patch* (`{ store_id, updates }`), never the whole file, so two unrelated changes landing close together can't clobber each other.
 2. **`.github/workflows/update-map.yml`** applies it as a deep merge, runs it through a **schema gate** (valid JSON, required fields, coordinate ranges, no duplicate ids, ISO-formatted dates) that aborts the run on any violation, then commits straight to `main` — which *is* the deploy, since GitHub Pages serves this repo from `main` directly.
 
-`scripts/patch-store.js` is the reusable sender (also usable as a CLI: `node scripts/patch-store.js <store_id> '<json>'`) — both Workers call the same GitHub API endpoint it wraps. Needs a `GITHUB_PAT` (classic, `repo` scope) wherever it's called from; `repository_dispatch` can't be triggered with a workflow's own default token.
+`scripts/patch-store.js` is the reusable sender (also usable as a CLI: `node scripts/patch-store.js <store_id> '<json>'`) — both Workers call the same GitHub API endpoint it wraps. Needs a `GH_PAT` (classic, `repo` scope) wherever it's called from; `repository_dispatch` can't be triggered with a workflow's own default token.
 
 ## 🔍 Field-scout tool
 
 A faster alternative to the full `/visit` survey (see the handbook below) for a quick, structured correction while standing in a store: open `?store=<id>&agent_mode=true` from the map → **📨 Send to Telegram bot** → the bot walks through inventory cycle, restock weekday, and opening hours entirely via tappable buttons, no typing. Confirming dispatches straight through the pipeline above.
 
-Needs `BOUNTY_SECRET` (identical value on both Workers — one signs the short-lived link, the other verifies it) and `GITHUB_PAT` on the bot Worker.
+Needs `BOUNTY_SECRET` (identical value on both Workers — one signs the short-lived link, the other verifies it) and `GH_PAT` on the bot Worker.
 
 ## 💼 Business model
 

--- a/scripts/patch-store.js
+++ b/scripts/patch-store.js
@@ -17,15 +17,15 @@
 //   import { dispatchMapPatch } from './scripts/patch-store.js';
 //   await dispatchMapPatch({ storeId: 'c21', updates: {...} });
 //
-// Requires a GITHUB_PAT environment variable — a classic PAT with the `repo`
+// Requires a GH_PAT environment variable — a classic PAT with the `repo`
 // scope (repository_dispatch cannot be triggered with the default
 // GITHUB_TOKEN a workflow run gets automatically; it needs a real PAT).
 // NEVER commit a token — set it as an env var or a repo/CLI secret.
 
 const DEFAULT_REPO = 'anonymouspartner/lviv-secondhand';
 
-export async function dispatchMapPatch({ storeId, updates, repo = DEFAULT_REPO, token = process.env.GITHUB_PAT }) {
-  if (!token) throw new Error('GITHUB_PAT is not set — cannot authenticate to the GitHub API.');
+export async function dispatchMapPatch({ storeId, updates, repo = DEFAULT_REPO, token = process.env.GH_PAT }) {
+  if (!token) throw new Error('GH_PAT is not set — cannot authenticate to the GitHub API.');
   if (!/^[a-z0-9]{1,20}$/i.test(String(storeId || ''))) throw new Error('storeId must be a short alphanumeric id.');
   if (!updates || typeof updates !== 'object' || Array.isArray(updates)) throw new Error('updates must be a plain object.');
 

--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -284,7 +284,7 @@ function say(env, chatId, text, keyboard) {
 // same VISITS KV as /visit, under a distinct bounty-session: prefix so the two
 // flows can't collide for one user. Needs BOT_TOKEN + VISITS (like /visit) plus
 // BOUNTY_SECRET (must match the metrics Worker's BOUNTY_SECRET — it verifies
-// the token that Worker signed) and GITHUB_PAT (to dispatch the resulting
+// the token that Worker signed) and GH_PAT (to dispatch the resulting
 // patch — see scripts/patch-store.js and .github/workflows/update-map.yml).
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -326,11 +326,11 @@ async function verifyBountyToken(env, token) {
 // here rather than imported — that script uses node:fs to resolve paths and
 // isn't portable to the Workers runtime.
 async function dispatchMapPatch(env, storeId, updates) {
-  if (!env.GITHUB_PAT) throw new Error('GITHUB_PAT not configured');
+  if (!env.GH_PAT) throw new Error('GH_PAT not configured');
   const res = await fetch('https://api.github.com/repos/anonymouspartner/lviv-secondhand/dispatches', {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${env.GITHUB_PAT}`,
+      Authorization: `Bearer ${env.GH_PAT}`,
       Accept: 'application/vnd.github+json',
       'Content-Type': 'application/json',
       'X-GitHub-Api-Version': '2022-11-28',

--- a/telegram-bot/wrangler.toml
+++ b/telegram-bot/wrangler.toml
@@ -51,9 +51,9 @@ RATE_BONUS = "200" # ₴ per bonus event (poster placed / owner contact + consen
 #                  same value as the metrics Worker's BOUNTY_SECRET (worker/),
 #                  which signs it — set both with the same random string:
 #                    printf '%s' "<random>" | npx wrangler@3 secret put BOUNTY_SECRET
-#   GITHUB_PAT    — classic PAT with the `repo` scope, used to dispatch the
+#   GH_PAT        — classic PAT with the `repo` scope, used to dispatch the
 #                  confirmed patch to .github/workflows/update-map.yml:
-#                    printf '%s' "<pat>" | npx wrangler@3 secret put GITHUB_PAT
+#                    printf '%s' "<pat>" | npx wrangler@3 secret put GH_PAT
 #
 # ── Crowdsourced moderation (opt-in) ────────────────────────────────────────
 # Adds /start edit_<id> (claims a web-submitted correction — see

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -215,14 +215,14 @@ const DEAL_TEXT_FIELD = {
 
 // Mirrors scripts/patch-store.js's dispatchMapPatch() — see that file's
 // comment for why this is reimplemented rather than imported (node:fs isn't
-// portable to the Workers runtime). A flash deal needs its own GITHUB_PAT on
+// portable to the Workers runtime). A flash deal needs its own GH_PAT on
 // this Worker (separate from the bot Worker's copy of the same secret).
 async function dispatchMapPatch(env, storeId, updates) {
-  if (!env.GITHUB_PAT) throw new Error('GITHUB_PAT not configured');
+  if (!env.GH_PAT) throw new Error('GH_PAT not configured');
   const res = await fetch('https://api.github.com/repos/anonymouspartner/lviv-secondhand/dispatches', {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${env.GITHUB_PAT}`,
+      Authorization: `Bearer ${env.GH_PAT}`,
       Accept: 'application/vnd.github+json',
       'Content-Type': 'application/json',
       'X-GitHub-Api-Version': '2022-11-28',
@@ -817,7 +817,7 @@ export default {
             flashDeal: { text: row.text, startsAt: row.starts_at, expiresAt: row.expires_at, alert: !!row.alert },
           });
         } catch (e) {
-          return new Response('dispatch failed — check GITHUB_PAT and the map-update workflow logs', { status: 502 });
+          return new Response('dispatch failed — check GH_PAT and the map-update workflow logs', { status: 502 });
         }
         await env.DB.prepare("UPDATE flash_deals SET status = 'approved' WHERE id = ?").bind(id).run();
         if (row.alert) await broadcastFlashDeal(env, ctx, row.store_id, row.text, row.expires_at);

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -73,10 +73,10 @@ OWNER_ID = "1212541015"
 # ── Flash deals (GET /flash-deal, POST /stripe-webhook, GET /flash-deal/approve) — optional ──
 # A short-lived paid sale (Stripe self-fulfilment, same pattern as promotions
 # above). Needs STRIPE_API_KEY + STRIPE_WEBHOOK_SECRET above, plus:
-#   GITHUB_PAT — classic PAT with the `repo` scope, used to dispatch the
+#   GH_PAT — classic PAT with the `repo` scope, used to dispatch the
 #               published deal to .github/workflows/update-map.yml (same
 #               pipeline the field-scout flow uses — see scripts/patch-store.js):
-#                 printf '%s' "<pat>" | npx wrangler@3 secret put GITHUB_PAT
+#                 printf '%s' "<pat>" | npx wrangler@3 secret put GH_PAT
 # ADMIN_KEY (already used by /admin/test and /orders — see docs/ADVERTISING.md)
 # gates the one-tap "approve" link sent to the owner when a deal has no
 # matching PIN on file. A store's PIN (optional; lets a trusted buyer skip


### PR DESCRIPTION
## Summary

GitHub rejects repository secret names starting with `GITHUB_` (reserved for GitHub's own injected variables). `GITHUB_PAT` — the secret name used throughout the automated patch-dispatch pipeline — hit that wall when actually creating it.

Renamed to `GH_PAT` everywhere: `worker/worker.js` and `telegram-bot/worker.js`'s `dispatchMapPatch()`, `scripts/patch-store.js`'s CLI/env var, both `wrangler.toml` comment blocks, both deploy workflows' secret references, and the README. Pure rename, no behavior change.

## Test plan

- [x] `node --check` on all touched JS
- [x] Workflow YAML + wrangler TOML re-validated
- [x] Confirmed zero remaining `GITHUB_PAT` references repo-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_