### PR TITLE
Merge map contribution #116: 4 added, 4 corrected, 1 removed

### DIFF
--- a/index.html
+++ b/index.html
@@ -2444,7 +2444,8 @@ function contributeGitHub(){
   if(c.edited){
     lines.push('### ✏️ Corrections to existing stores (' + c.edited + ')');
     (b.overrideList||[]).forEach(o => {
-      const fields = Object.keys(o.changes||{}).map(k => k + ': ' + o.changes[k]).join('; ');
+      const fmt = v => (v && typeof v === 'object') ? Object.keys(v).map(d => d + ' ' + v[d]).join(', ') : v;
+      const fields = Object.keys(o.changes||{}).map(k => k + ': ' + fmt(o.changes[k])).join('; ');
       lines.push('- **' + o.name + '** (`' + o.id + '`) → ' + fields);
     });
     lines.push('');
@@ -2821,7 +2822,7 @@ if ('serviceWorker' in navigator) {
 // UPDATE CHECK — notify when a newer build is deployed, so nobody is stuck on
 // a cached version (no reinstall needed). Bump APP_VERSION on each deploy.
 // ─────────────────────────────────────────────
-const APP_VERSION = '2026-08-12.6';
+const APP_VERSION = '2026-08-13.1';
 
 // ─────────────────────────────────────────────
 // DONATIONS — points at a Stripe Payment Link (hosted checkout). No API keys

--- a/stores.json
+++ b/stores.json
@@ -188,7 +188,7 @@
   "cycle": 35,
   "lat": 49.840059,
   "lng": 24.032867,
-  "note": "Central Lviv. 5-week cycle. Luxury section separate. Weekly promos."
+  "note": "Central Lviv. 5-week cycle. Luxury section separate. Weekly promos. Next restock 17.08.2026"
  },
  {
   "id": "s2",
@@ -556,7 +556,7 @@
   "cycle": 7,
   "lat": 49.835161,
   "lng": 24.005551,
-  "note": ""
+  "note": "50% off"
  },
  {
   "id": "c11",
@@ -1466,29 +1466,6 @@
   "note": "By weight."
  },
  {
-  "id": "c52",
-  "name": "Секонд-хенд Люкс",
-  "brand": "Independent",
-  "address": "вул. Федьковича, 18",
-  "addressEn": "Fedkovycha St, 18",
-  "phone": "",
-  "type": "other",
-  "pricing": "item",
-  "hours": {
-   "mon": "?",
-   "tue": "?",
-   "wed": "?",
-   "thu": "?",
-   "fri": "?",
-   "sat": "?",
-   "sun": "?"
-  },
-  "cycle": 7,
-  "lat": 49.835373,
-  "lng": 24.002616,
-  "note": "From locator.lviv.ua listing."
- },
- {
   "id": "c53",
   "name": "Світ секонд-хенду — Патона 2",
   "brand": "Світ секонд-хенду",
@@ -1674,7 +1651,7 @@
  },
  {
   "id": "c61",
-  "name": "Еврошоп",
+  "name": "Євро секонд хенд",
   "brand": "Independent",
   "address": "вул. Базарна, 1",
   "addressEn": "Bazarna St, 1",
@@ -1772,7 +1749,7 @@
   "addressEn": "Lypneva Sq, 6",
   "phone": "",
   "type": "other",
-  "pricing": "item",
+  "pricing": "kg",
   "hours": {
    "mon": "?",
    "tue": "?",
@@ -2085,5 +2062,97 @@
   "lat": 49.868508,
   "lng": 23.9523548,
   "note": "By weight. Part of the Світ секонд-хенду chain."
+ },
+ {
+  "id": "c79",
+  "name": "Супер секонд-хенд",
+  "brand": "Independent",
+  "address": "",
+  "addressEn": "",
+  "phone": "",
+  "type": "other",
+  "pricing": "item",
+  "cycle": 7,
+  "lat": 49.845533,
+  "lng": 24.01953,
+  "note": "",
+  "hours": {
+   "mon": "?",
+   "tue": "?",
+   "wed": "?",
+   "thu": "?",
+   "fri": "?",
+   "sat": "?",
+   "sun": "?"
+  }
+ },
+ {
+  "id": "c80",
+  "name": "Євро секонд-хенд",
+  "brand": "Independent",
+  "address": "",
+  "addressEn": "",
+  "phone": "",
+  "type": "other",
+  "pricing": "kg",
+  "cycle": 7,
+  "lat": 49.783495,
+  "lng": 23.641634,
+  "note": "",
+  "hours": {
+   "mon": "?",
+   "tue": "?",
+   "wed": "?",
+   "thu": "?",
+   "fri": "?",
+   "sat": "?",
+   "sun": "?"
+  }
+ },
+ {
+  "id": "c81",
+  "name": "Economic Class",
+  "brand": "Independent",
+  "address": "",
+  "addressEn": "",
+  "phone": "",
+  "type": "other",
+  "pricing": "kg",
+  "cycle": 7,
+  "lat": 49.783715,
+  "lng": 23.642052,
+  "note": "",
+  "hours": {
+   "mon": "?",
+   "tue": "?",
+   "wed": "?",
+   "thu": "?",
+   "fri": "?",
+   "sat": "?",
+   "sun": "?"
+  }
+ },
+ {
+  "id": "c82",
+  "name": "Family shop",
+  "brand": "Independent",
+  "address": "",
+  "addressEn": "",
+  "phone": "",
+  "type": "other",
+  "pricing": "kg",
+  "cycle": 7,
+  "lat": 49.782477,
+  "lng": 23.64264,
+  "note": "",
+  "hours": {
+   "mon": "?",
+   "tue": "?",
+   "wed": "?",
+   "thu": "?",
+   "fri": "?",
+   "sat": "?",
+   "sun": "?"
+  }
  }
 ]


### PR DESCRIPTION
## Summary

Applies the map contribution from #116 to `stores.json`:

- **Added (4):** Супер секонд-хенд, Євро секонд-хенд, Economic Class, Family shop (`c79`–`c82`) — name/coordinates/pricing only, as submitted (the summary format doesn't carry address/phone/hours for new stores).
- **Corrected (4 with an actual field change):**
  - `c61` name: Еврошоп → Євро секонд хенд
  - `c65` pricing: item → kg
  - `c10` note: "" → "50% off"
  - `h7` note: appended "Next restock 17.08.2026"
  - `c2`, `c7`, `c9`, `c20` were also listed as corrections, but every field in the submission was already identical to the live data, so nothing changed for them.
- **Removed (1):** `c52` (Секонд-хенд Люкс) — reported as nonexistent/wrong.

**Bug fix (`index.html`):** the contribution-issue exporter was string-concatenating the `hours` object directly, so any correction that touched opening hours rendered as literally `hours: [object Object]` in the GitHub issue body — silently discarding that data before a maintainer ever saw it (visible in #116 itself). It now formats hours as readable `day time` pairs. Note: this means any hours edits submitted in #116 could not be recovered and are not part of this PR.

**Flag for review:** the new "Супер секонд-хенд" (`c79`, 49.845533, 24.01953) sits ~18m from `c61` (вул. Базарна, 1). Could be a distinct shop in the same building, or an accidental duplicate — kept as submitted since only the contributor can confirm.

`APP_VERSION` bumped so the fix ships on load (SW is network-first).

## Test plan

- [x] `node scripts/validate-stores.mjs` — 93 stores, no duplicate ids, all dates ISO
- [x] `node --check` on `index.html`'s inline script
- [x] Diff reviewed field-by-field against the issue body and current `stores.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_