### PR TITLE
Document the Telegram bot's data practices in the privacy policy

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -52,7 +52,7 @@
 
 <main>
   <!-- ══════════ ENGLISH ══════════ -->
-  <p class="meta">Lviv Second Hand · Last updated: 7 August 2026</p>
+  <p class="meta">Lviv Second Hand · Last updated: 13 August 2026</p>
 
   <div class="tldr">
     <h2>The short version</h2>
@@ -83,6 +83,9 @@
     <ul>
       <li><strong>Share link / file / code</strong> — creates a link, file, or code containing the stores you added and edited. If you send it to someone, you are choosing to share that information with them. Nothing is uploaded to us; the data travels only through whatever channel you use to send it.</li>
       <li><strong>Contribute to the official map</strong> — opens GitHub with a pre-filled submission so a maintainer can add your stores to the shared map. Anything you post there becomes public and is governed by <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener">GitHub's privacy statement</a>. Only submit information you're comfortable making public.</li>
+      <li><strong>Telegram bot (@Secondhandlvivbot)</strong> — entirely optional, and separate from the app itself. Commands like /today and /cheap answer instantly with nothing stored. If you subscribe to flash-deal or restock alerts for a store (via a "Get alerts on Telegram" link, or /start sub_&lt;store&gt;), we store your Telegram chat ID against that store so we know who to notify — stop anytime with /stop, which deletes it. Using the bot is also governed by <a href="https://telegram.org/privacy" target="_blank" rel="noopener">Telegram's own privacy policy</a>.</li>
+      <li><strong>Map corrections reviewed via Telegram</strong> — a correction someone submits for review has no identity attached until they open the review link the app hands them. That identity is then used only to decide whether the edit publishes immediately or needs a moderator's OK (based on a running point total), and to show that total on the public /leaderboard command.</li>
+      <li><strong>Field-agent program</strong> — a small, separately invited group of paid contributors (not a feature available to app visitors generally) share visit details — store, GPS location, and a photo — through the bot as part of that paid work. That data is used only to verify visits and calculate pay.</li>
     </ul>
 
     <h2>5. Third-party services</h2>
@@ -120,7 +123,7 @@
 
   <!-- ══════════ УКРАЇНСЬКА ══════════ -->
   <div class="lang-divider">— Українською —</div>
-  <p class="meta">Lviv Second Hand · Останнє оновлення: 7 серпня 2026</p>
+  <p class="meta">Lviv Second Hand · Останнє оновлення: 13 серпня 2026</p>
 
   <div class="tldr">
     <h2>Коротко</h2>
@@ -151,6 +154,9 @@
     <ul>
       <li><strong>Посилання / файл / код для обміну</strong> — створює посилання, файл або код із магазинами, які ви додали та змінили. Якщо ви надішлете його комусь, ви самі вирішуєте поділитися цією інформацією. Нічого не завантажується до нас; дані йдуть лише через той канал, який ви оберете.</li>
       <li><strong>Внесок до офіційної карти</strong> — відкриває GitHub із попередньо заповненою формою, щоб супровідник додав ваші магазини до спільної карти. Усе, що ви там публікуєте, стає публічним і регулюється <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener">заявою про конфіденційність GitHub</a>. Надсилайте лише ту інформацію, яку готові зробити публічною.</li>
+      <li><strong>Telegram-бот (@Secondhandlvivbot)</strong> — повністю необов'язковий і окремий від самого додатку. Команди на кшталт /today і /cheap відповідають миттєво, нічого не зберігаючи. Якщо ви підписуєтесь на сповіщення про акції чи завезення для магазину (через посилання «Сповіщення в Telegram» або /start sub_&lt;магазин&gt;), ми зберігаємо ваш Telegram chat ID прив'язаним до цього магазину, щоб знати, кого сповіщати — відпишіться будь-коли командою /stop, яка видаляє цей запис. Використання бота також регулюється <a href="https://telegram.org/privacy" target="_blank" rel="noopener">власною політикою конфіденційності Telegram</a>.</li>
+      <li><strong>Виправлення карти, що перевіряються через Telegram</strong> — виправлення, надіслане на перевірку, не має прив'язаної особи, доки хтось не відкриє посилання на перевірку, яке дає додаток. Ця особа потім використовується лише для того, щоб вирішити, чи публікується виправлення одразу, чи потребує підтвердження модератора (на основі накопичених балів), а також щоб показати цю суму в публічній команді /leaderboard.</li>
+      <li><strong>Програма польових агентів</strong> — невелика, окремо запрошена група платних учасників (це не функція, доступна відвідувачам додатку загалом) ділиться деталями відвідування — магазин, GPS-локація та фото — через бота як частина цієї платної роботи. Ці дані використовуються лише для перевірки відвідувань і розрахунку оплати.</li>
     </ul>
 
     <h2>5. Сторонні сервіси</h2>


### PR DESCRIPTION
## Summary

The bot's flash-deal/restock alerts, crowdsourced-moderation review flow, and the field-agent program all touch someone's Telegram identity, but none of that was mentioned in `privacy.html` — only the web-push restock notification (section 2) and the GitHub contribution flow (section 4) were covered. Extends section 4 (English + Ukrainian) with what each one actually stores:

- **The bot itself (@Secondhandlvivbot)** — stateless commands (`/today`, `/cheap`) vs. the chat-id-keyed alert subscription (`/start sub_<store>`, `/stop`), plus a pointer to Telegram's own privacy policy.
- **Edit-review claims** — no identity attached until the reviewer opens the link; used only for the trust/leaderboard decision.
- **The field-agent program** — explicitly called out as a small, separately invited paid role, not something a general visitor encounters, sharing GPS + a photo as part of that work.

Bumped the "Last updated" date on both language versions to match (7 → 13 August 2026).

## Test plan

- [x] Tag balance check (`<li>`/`</li>`, `<ul>`/`</ul>`, `<a>`/`</a>`) confirms no broken markup
- [x] Read through both language versions for accuracy against the actual backend behavior (`worker/worker.js`, `telegram-bot/worker.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_