### PR TITLE
Auto-deploy the bot, add PR CI, and enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # GitHub Actions used across every workflow in .github/workflows/.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Telegram bot Worker (wrangler, etc.).
+  - package-ecosystem: "npm"
+    directory: "/telegram-bot"
+    schedule:
+      interval: "weekly"
+
+  # Android/Capacitor wrapper.
+  - package-ecosystem: "npm"
+    directory: "/native"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+# Runs the checks that used to only happen by hand before a merge: the
+# stores.json schema gate, a syntax check on index.html's inline script (it
+# has no build step, so nothing else parses it), and a syntax check on both
+# Cloudflare Workers. No dependencies to install — every check here is a
+# plain Node script.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Validate stores.json schema
+        run: node scripts/validate-stores.mjs
+
+      - name: Syntax-check index.html's inline script
+        run: node scripts/check-inline-js.mjs
+
+      - name: Syntax-check the metrics Worker
+        run: node --check worker/worker.js
+
+      - name: Syntax-check the Telegram bot Worker
+        run: node --check telegram-bot/worker.js
+
+      - name: Generate the bot's dataset (stores.json → stores.gen.js)
+        run: node build-data.mjs
+        working-directory: telegram-bot

--- a/.github/workflows/deploy-bot.yml
+++ b/.github/workflows/deploy-bot.yml
@@ -1,8 +1,9 @@
 name: Deploy Telegram bot
 
 # Deploys the Cloudflare Worker in telegram-bot/ (the @Secondhandlvivbot bot,
-# including the /visit field-agent subsystem). Run it from the Actions tab
-# whenever you want to push the current `main` to Cloudflare — no terminal needed.
+# including the /visit field-agent subsystem). Runs automatically whenever
+# telegram-bot/** changes on main — mirrors deploy-worker.yml. Can also be
+# run by hand from the Actions tab (no terminal needed).
 #
 # ── One-time setup: three repo secrets ──
 # GitHub → repo Settings → Secrets and variables → Actions → New repository secret:
@@ -22,6 +23,11 @@ name: Deploy Telegram bot
 # sets the BOT_TOKEN secret on it. WEBHOOK_SECRET (already set on the worker) and
 # any other existing secrets are preserved — `wrangler deploy` never deletes them.
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'telegram-bot/**'
+      - '.github/workflows/deploy-bot.yml'
   workflow_dispatch:
 
 permissions:

--- a/scripts/check-inline-js.mjs
+++ b/scripts/check-inline-js.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+// index.html's app logic lives in one inline <script> block with no build step,
+// so nothing else syntax-checks it. This extracts that block and runs it
+// through `node --check`, catching a stray typo before it reaches production.
+// Runnable by hand: `node scripts/check-inline-js.mjs`.
+import { readFileSync, writeFileSync, unlinkSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const htmlPath = resolve(here, '..', 'index.html');
+const html = readFileSync(htmlPath, 'utf8');
+
+// Matches only the bare <script> tag (no src=), i.e. the app's own code —
+// not the vendored <script src="..."> includes.
+const matches = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)];
+if (matches.length !== 1) {
+  throw new Error(`Expected exactly one inline <script> block in index.html, found ${matches.length}`);
+}
+const code = matches[0][1];
+
+const tmpFile = resolve(tmpdir(), `index-inline-${process.pid}-${Date.now()}.js`);
+writeFileSync(tmpFile, code);
+try {
+  execFileSync(process.execPath, ['--check', tmpFile], { stdio: 'inherit' });
+  console.log(`index.html inline script OK — ${code.length} chars.`);
+} finally {
+  unlinkSync(tmpFile);
+}


### PR DESCRIPTION
## Summary
- **Auto-deploy the bot**: `deploy-bot.yml` was `workflow_dispatch`-only, unlike `deploy-worker.yml` which auto-deploys on push. It now triggers on push to `telegram-bot/**` too, so merging a bot change deploys it — no more separate manual "and deploy" step.
- **CI on pull requests**: new `ci.yml` runs on every PR and push to `main`. It's the same checks that were previously only run by hand before a merge: `scripts/validate-stores.mjs` (schema gate), a new `scripts/check-inline-js.mjs` that extracts and syntax-checks `index.html`'s inline `<script>` block (nothing else parses it — there's no build step for the app), a `node --check` on both Workers, and a sanity run of the bot's `stores.gen.js` generator against the current `stores.json`.
- **Dependabot**: new `dependabot.yml` covering `github-actions` (root) and the two npm projects (`telegram-bot/`, `native/`) on a weekly schedule. The metrics Worker (`worker/`) has no `package.json`, so it's not included.

## Test plan
- [x] All three new/changed YAML files parse with `yaml.safe_load`
- [x] `node scripts/validate-stores.mjs`
- [x] `node scripts/check-inline-js.mjs` (extracts and syntax-checks `index.html`'s inline script)
- [x] `node --check worker/worker.js`
- [x] `node --check telegram-bot/worker.js`
- [x] `node telegram-bot/build-data.mjs` — dataset generator still runs clean against current `stores.json`


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_