### PR TITLE
Move the field-agent job brief off claude.ai onto the site

### DIFF
--- a/index.html
+++ b/index.html
@@ -2896,6 +2896,7 @@ function renderHelp(){
           + `<button class="sheet-btn" style="background:#ff5a5f;margin-top:8px;" onclick="openDonate()">${escHtml(t('donateBtn'))}</button>`
         : '')
     + `<p style="text-align:center;margin-top:14px;font-size:13px;color:var(--muted);"><a href="privacy.html" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:underline;">🔒 Privacy Policy · Політика конфіденційності</a></p>`
+    + `<p style="text-align:center;margin-top:4px;font-size:11px;color:var(--muted);"><a href="jobs/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:underline;">💼 Careers · Вакансії</a></p>`
     + `<p style="text-align:center;margin-top:6px;font-size:11px;color:var(--muted);">v${escHtml(APP_VERSION)}</p>`
     + `<p style="text-align:center;margin-top:2px;font-size:11px;color:var(--muted);">© 2026 Lviv Second Hand · All rights reserved</p>`;
 }
@@ -2984,7 +2985,7 @@ if ('serviceWorker' in navigator) {
 // UPDATE CHECK — notify when a newer build is deployed, so nobody is stuck on
 // a cached version (no reinstall needed). Bump APP_VERSION on each deploy.
 // ─────────────────────────────────────────────
-const APP_VERSION = '2026-08-13.12';
+const APP_VERSION = '2026-08-14.1';
 
 // ─────────────────────────────────────────────
 // DONATIONS — points at a Stripe Payment Link (hosted checkout). No API keys

--- a/jobs/index.html
+++ b/jobs/index.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="theme-color" content="#17693a">
+<title>Field Sales Rep — Lviv Second Hand</title>
+<meta name="description" content="Job brief for Lviv Second Hand's field sales rep role in Lviv, Ukraine — pay scheme, daily flow, and how to apply.">
+<link rel="icon" href="../favicon.svg" type="image/svg+xml">
+<link rel="icon" href="../favicon-32.png" sizes="32x32" type="image/png">
+<link rel="apple-touch-icon" href="../apple-touch-icon.png">
+<style>
+:root{
+  --paper:#fbf7ea; --ink:#12261b; --green:#17693a; --green2:#0f4526;
+  --acid:#ffd23f; --acid2:#ffb800; --muted:#5f7468; --line:#e6e0cd;
+  --card:#ffffff; --chip:#f0ead6; --shadow:0 1px 2px rgba(13,44,26,.06),0 8px 24px rgba(13,44,26,.06);
+}
+:root:not([data-theme="light"]){ }
+@media (prefers-color-scheme:dark){
+  :root:not([data-theme="light"]){
+    --paper:#0b2015; --ink:#eef1e6; --green:#37a266; --green2:#123b24;
+    --acid:#ffd23f; --acid2:#ffb800; --muted:#9db3a5; --line:#24402f;
+    --card:#0f2a1b; --chip:#143723; --shadow:0 1px 2px rgba(0,0,0,.3),0 10px 30px rgba(0,0,0,.35);
+  }
+}
+:root[data-theme="dark"]{
+  --paper:#0b2015; --ink:#eef1e6; --green:#37a266; --green2:#123b24;
+  --acid:#ffd23f; --acid2:#ffb800; --muted:#9db3a5; --line:#24402f;
+  --card:#0f2a1b; --chip:#143723; --shadow:0 1px 2px rgba(0,0,0,.3),0 10px 30px rgba(0,0,0,.35);
+}
+*{box-sizing:border-box}
+html,body{margin:0}
+body{
+  background:var(--paper); color:var(--ink);
+  font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  line-height:1.55; -webkit-font-smoothing:antialiased;
+}
+.wrap{max-width:820px;margin:0 auto;padding:clamp(20px,5vw,52px) clamp(18px,5vw,40px) 64px}
+.disp{font-weight:800;letter-spacing:-.01em;line-height:1.05}
+.ua{color:var(--muted);font-weight:400}
+.eyebrow{display:inline-block;font-size:12px;font-weight:800;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--green2);background:var(--acid);padding:5px 11px;border-radius:999px}
+@media (prefers-color-scheme:dark){:root:not([data-theme="light"]) .eyebrow{color:#0c2316}}
+:root[data-theme="dark"] .eyebrow{color:#0c2316}
+
+/* Hero */
+.hero{position:relative;margin-top:22px;padding:clamp(22px,4vw,34px);border-radius:22px;overflow:hidden;
+  background:radial-gradient(120% 130% at 88% -20%, var(--green) 0%, var(--green2) 62%, #0a2013 100%);
+  color:#f4f7ef;box-shadow:var(--shadow)}
+.brand{display:flex;align-items:center;gap:11px;margin-bottom:20px}
+.brand .mark{width:38px;height:38px;border-radius:9px;background:var(--acid);color:var(--green2);
+  display:flex;align-items:center;justify-content:center;font-size:19px;flex:none}
+.brand b{font-weight:800;letter-spacing:.01em;font-size:15px}
+.brand span{display:block;font-size:11.5px;color:#bfe0cd;font-weight:500}
+h1{margin:0;font-size:clamp(30px,6.4vw,50px)}
+h1 .k{color:var(--acid)}
+.tag{font-family:Georgia,"Times New Roman",serif;font-size:clamp(16px,2.5vw,20px);line-height:1.4;
+  margin:16px 0 4px;max-width:52ch;color:#eaf3ea}
+.tag .ua{color:#bcd8c6}
+.chips{display:flex;flex-wrap:wrap;gap:8px;margin-top:20px}
+.chip{font-size:12.5px;font-weight:700;color:#eaf3ea;background:rgba(255,255,255,.10);
+  border:1px solid rgba(255,255,255,.16);padding:6px 11px;border-radius:999px}
+.chip b{color:var(--acid)}
+
+/* Sections */
+section{margin-top:40px}
+h2{font-size:12.5px;font-weight:800;letter-spacing:.13em;text-transform:uppercase;color:var(--green);
+  margin:0 0 4px;display:flex;align-items:baseline;gap:9px}
+h2 .ua{font-size:11.5px;letter-spacing:.04em}
+.rule{height:2px;background:linear-gradient(90deg,var(--acid),transparent);border-radius:2px;margin:10px 0 18px;max-width:120px}
+.lead{font-size:16px;margin:0 0 14px}
+
+.cards{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+@media(max-width:620px){.cards{grid-template-columns:1fr}}
+.card{background:var(--card);border:1px solid var(--line);border-radius:16px;padding:18px 18px 16px;box-shadow:var(--shadow)}
+.card .n{font-size:12px;font-weight:800;letter-spacing:.1em;text-transform:uppercase;color:var(--muted)}
+.card h3{margin:8px 0 6px;font-size:18px;font-weight:800}
+.card p{margin:0;font-size:14.5px;color:var(--ink)}
+.card .ua{font-size:13px}
+.pricebar{display:flex;flex-wrap:wrap;gap:6px;margin-top:12px}
+.pricebar span{font-size:12.5px;font-weight:700;background:var(--chip);border:1px solid var(--line);
+  padding:4px 9px;border-radius:8px}
+.pricebar span b{color:var(--green)}
+
+ol.flow{list-style:none;counter-reset:s;margin:0;padding:0;display:grid;gap:11px}
+ol.flow li{position:relative;padding:2px 0 2px 44px;min-height:30px}
+ol.flow li::before{counter-increment:s;content:counter(s);position:absolute;left:0;top:0;width:30px;height:30px;
+  border-radius:50%;background:var(--green);color:#fff;font-weight:800;font-size:14px;display:flex;
+  align-items:center;justify-content:center}
+ol.flow b{font-weight:800}
+ol.flow .ua{display:block;font-size:13px}
+
+ul.ticks{list-style:none;margin:0;padding:0;display:grid;gap:9px}
+ul.ticks li{position:relative;padding-left:26px;font-size:14.5px}
+ul.ticks li::before{content:"";position:absolute;left:2px;top:7px;width:9px;height:9px;background:var(--acid);
+  clip-path:polygon(0 0,100% 0,100% 100%)}
+ul.ticks .ua{display:block;font-size:12.5px}
+
+table.pay{width:100%;border-collapse:collapse;font-size:14.5px;background:var(--card);border:1px solid var(--line);
+  border-radius:14px;overflow:hidden;box-shadow:var(--shadow)}
+table.pay th{text-align:left;background:var(--green);color:#fff;font-size:12px;letter-spacing:.06em;
+  text-transform:uppercase;padding:10px 14px}
+table.pay td{padding:12px 14px;border-top:1px solid var(--line);vertical-align:top}
+table.pay td.amt{white-space:nowrap;font-weight:800;color:var(--green);font-size:15px}
+table.pay .ua{display:block;font-size:12.5px}
+.note{margin-top:12px;font-size:13px;color:var(--muted)}
+.callout{margin-top:14px;background:var(--acid);color:#3a2c00;border-radius:14px;padding:14px 16px;font-weight:700;font-size:14.5px}
+.callout .ua{color:#5b4a12;font-weight:600;display:block;margin-top:3px}
+
+.start{background:var(--card);border:1px dashed var(--green);border-radius:16px;padding:18px}
+.foot{margin-top:44px;padding-top:18px;border-top:1px solid var(--line);font-size:12.5px;color:var(--muted);
+  display:flex;justify-content:space-between;flex-wrap:wrap;gap:8px}
+.foot b{color:var(--green)}
+code{background:var(--chip);border:1px solid var(--line);border-radius:6px;padding:1px 6px;font-size:13px;font-weight:700}
+</style>
+</head>
+<body>
+
+<div class="wrap">
+
+  <div class="hero">
+    <div class="brand">
+      <div class="mark">🧭</div>
+      <div><b>Lviv Second Hand</b><span>lvivsecondhand.com · секонд-хенди Львова на карті</span></div>
+    </div>
+    <span class="eyebrow">Job opportunity · Вакансія</span>
+    <h1 class="disp">Field Sales <span class="k">Rep</span><br><span class="ua" style="font-size:.62em">Польовий торговий представник</span></h1>
+    <p class="tag">Help Lviv's second-hand shoppers and stores find each other — on foot, with your phone.
+      <span class="ua"><br>Допомагайте покупцям і магазинам секонд-хенду Львова знаходити одне одного — пішки, зі смартфоном.</span></p>
+    <div class="chips">
+      <span class="chip">📍 Lviv · Львів</span>
+      <span class="chip">🚶 Field work · робота в місті</span>
+      <span class="chip">🕒 Flexible · гнучкий графік</span>
+      <span class="chip">💬 Ukrainian · українська</span>
+      <span class="chip">💵 Pay: <b>per visit + bonuses + commission</b></span>
+    </div>
+  </div>
+
+  <section>
+    <h2>What we're selling <span class="ua">· Що ми пропонуємо</span></h2>
+    <div class="rule"></div>
+    <p class="lead">Two things — one free, one paid. Your work drives both.
+      <span class="ua"> · Дві речі — одна безкоштовна, друга платна. Ваша робота рухає обидві.</span></p>
+    <div class="cards">
+      <div class="card">
+        <div class="n">Free · для покупців</div>
+        <h3>The app</h3>
+        <p>A free map of every second-hand store in Lviv — hours, by-weight &amp; itemized prices, and restock days so shoppers know when it's cheapest.
+          <span class="ua">Безкоштовна карта всіх секонд-хендів Львова — години, ціни на вагу та поштучно, дні завезення.</span></p>
+      </div>
+      <div class="card">
+        <div class="n">Paid · для магазинів</div>
+        <h3>Store promotions</h3>
+        <p>Stores pay a monthly fee to stand out on the map — a gold pin, top of the list, their offer shown to shoppers. This is the revenue.
+          <span class="ua">Магазини платять щомісяця, щоб виділятися: золота позначка, перше місце, акція для покупців.</span></p>
+        <div class="pricebar">
+          <span>Verified+ <b>₴250</b></span><span>Featured <b>₴600</b></span><span>Spotlight <b>₴1200</b></span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>The role <span class="ua">· Роль</span></h2>
+    <div class="rule"></div>
+    <ul class="ticks">
+      <li><b>Visit second-hand stores</b> across an assigned zone of the city each day.
+        <span class="ua">Відвідувати секонд-хенди у призначеній зоні міста щодня.</span></li>
+      <li><b>Advertise the free app</b> to shoppers and staff, and place a QR poster in the store.
+        <span class="ua">Рекламувати безкоштовний застосунок покупцям і персоналу, розміщувати QR-плакат.</span></li>
+      <li><b>Record each store</b> — name, address, GPS, hours, restock day, prices, and one storefront photo.
+        <span class="ua">Записувати кожен магазин — назва, адреса, GPS, години, день завезення, ціни, фото вітрини.</span></li>
+      <li><b>Capture interested owners</b> (contact + their consent) — these become our sales leads.
+        <span class="ua">Фіксувати зацікавлених власників (контакт + згода) — це наші потенційні клієнти.</span></li>
+      <li><b>Later — sell promotions.</b> Once you know the ropes, pitch stores on the paid tiers and sign them up.
+        <span class="ua">Згодом — продавати рекламу: пропонувати магазинам платні пакети та підписувати їх.</span></li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>How the work flows <span class="ua">· Як це працює</span></h2>
+    <div class="rule"></div>
+    <ol class="flow">
+      <li><b>Get your zone.</b> Each morning I send you a district and store list in <b>capybara-bot</b> (it translates UA↔EN and keeps our notes).
+        <span class="ua">Щоранку отримуєте район і список магазинів у capybara-bot (перекладає UA↔EN).</span></li>
+      <li><b>At each store (~10 min):</b> look, go in, be polite, tell shoppers about the app, offer a QR poster.
+        <span class="ua">У кожному магазині (~10 хв): огляд, ввічливо зайти, розповісти про застосунок, запропонувати плакат.</span></li>
+      <li><b>Log it in <code>@Secondhandlvivbot</code></b> with <code>/visit</code>: share your location, pick the store, then 📷 photo → a few quick questions. This is what pay is counted from.
+        <span class="ua">Записати у @Secondhandlvivbot через /visit: геолокація → магазин → фото → кілька питань. З цього рахується оплата.</span></li>
+      <li><b>Store data</b> (hours, address, restock) you edit in the app and send for review; <b>photos, chat &amp; live location</b> go through Telegram.
+        <span class="ua">Дані магазину редагуєте в застосунку і надсилаєте на перевірку; фото, спілкування та геолокація — у Telegram.</span></li>
+      <li><b>End of day:</b> a quick summary in capybara-bot — zone done, stores to revisit, hot leads.
+        <span class="ua">Наприкінці дня: короткий підсумок у capybara-bot.</span></li>
+    </ol>
+    <p class="note">You'll need: a smartphone (location + camera on) and Telegram. No GitHub account needed — map submissions go through an in-app approval, not a direct GitHub issue. · Потрібно: смартфон і Telegram. Акаунт GitHub не потрібен.</p>
+  </section>
+
+  <section>
+    <h2>How you get paid <span class="ua">· Оплата</span></h2>
+    <div class="rule"></div>
+    <table class="pay">
+      <tr><th>What</th><th>Pay</th><th>Paid when</th></tr>
+      <tr>
+        <td><b>Visit base</b><span class="ua">База за візит</span></td>
+        <td class="amt">₴80</td>
+        <td>A verified visit: GPS + storefront photo + full questionnaire. One store = one base per restock cycle.
+          <span class="ua">Перевірений візит: GPS + фото + анкета. Один магазин = одна база на цикл завезення.</span></td>
+      </tr>
+      <tr>
+        <td><b>Bonus</b><span class="ua">Бонус</span></td>
+        <td class="amt">₴200 <span style="font-weight:600;color:var(--muted);font-size:12px">each</span></td>
+        <td>QR poster placed (photo proof), or an owner signs up (contact + consent). Both can apply.
+          <span class="ua">Плакат розміщено (фото), або власник зареєструвався. Можуть діяти обидва.</span></td>
+      </tr>
+      <tr>
+        <td><b>Sales commission</b><span class="ua">Комісія з продажу</span><br><span style="font-size:11.5px;color:var(--muted)">Phase 2 · згодом</span></td>
+        <td class="amt">₴300–800</td>
+        <td>One-time, per store you sign up: ₴300–500 Featured, ₴800 Spotlight.
+          <span class="ua">Разово за підписаний магазин: ₴300–500 Featured, ₴800 Spotlight.</span></td>
+      </tr>
+    </table>
+    <div style="margin-top:14px;background:var(--card);border:1px solid var(--line);border-left:4px solid var(--green);border-radius:12px;padding:13px 15px;font-size:14px">
+      <b>Bonus vs. commission.</b> A <b>bonus</b> is paid for the <i>action</i> — placing a poster or signing up a lead — even if that store never buys. A <b>commission</b> is paid only when a store actually <b>subscribes and pays</b>. The bonus is the on-ramp; the commission is the payoff once selling starts.
+      <span class="ua" style="display:block;margin-top:6px">Бонус проти комісії. <b>Бонус</b> — за <i>дію</i> (розміщений плакат або зафіксований лід), навіть якщо магазин ніколи не купить. <b>Комісія</b> — лише коли магазин справді <b>підписується та платить</b>.</span>
+    </div>
+    <div class="callout">🎯 Target 8–12 stores a day ≈ ₴640–₴960 base per day, plus bonuses. Paid weekly (cash or bank transfer).
+      <span class="ua">Ціль 8–12 магазинів/день ≈ ₴640–₴960 бази на день + бонуси. Виплати щотижня.</span></div>
+    <p class="note">Only complete, honest visits count — GPS + photo keep it fair for everyone. You can see your live pay scheme any time in the bot with <code>/pay</code>. · Рахуються лише повні, чесні візити. Схему оплати можна побачити у боті командою /pay.</p>
+  </section>
+
+  <section>
+    <h2>Who we're looking for <span class="ua">· Кого шукаємо</span></h2>
+    <div class="rule"></div>
+    <ul class="ticks">
+      <li>Lives in or near Lviv and gets around the city easily. <span class="ua">Живе у Львові або поруч, легко пересувається містом.</span></li>
+      <li>Comfortable talking to shop staff — friendly, honest, low-pressure. <span class="ua">Вміє спілкуватися з персоналом — доброзичливо, чесно, без тиску.</span></li>
+      <li>Reliable with a smartphone and careful with details. <span class="ua">Впевнено користується смартфоном, уважний до деталей.</span></li>
+      <li>Ukrainian (English a plus). An interest in sales helps for Phase 2. <span class="ua">Українська (англійська — плюс). Інтерес до продажів — перевага.</span></li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>How to start <span class="ua">· Як почати</span></h2>
+    <div class="rule"></div>
+    <div class="start">
+      <ul class="ticks">
+        <li>Open <code>@Secondhandlvivbot</code> in Telegram and send it any message (e.g. <code>/start</code>) — it replies with your Telegram ID since you're not registered yet. Send me that ID.
+          <span class="ua">Відкрийте @Secondhandlvivbot у Telegram, надішліть будь-яке повідомлення (напр. /start) — бот покаже ваш Telegram ID, бо ви ще не зареєстровані. Перешліть мені цей ID.</span></li>
+        <li>Make sure you have Telegram. <span class="ua">Майте Telegram.</span></li>
+        <li>I'll add you, send your first zone, and walk you through <code>/visit</code> together. <span class="ua">Я додам вас, надішлю першу зону і разом пройдемо /visit.</span></li>
+      </ul>
+    </div>
+    <p class="note">Please photograph storefronts and merchandise — <b>not people</b> — and keep every owner contact private. · Фотографуйте вітрини та товар, <b>не людей</b>; контакти власників — конфіденційні.</p>
+  </section>
+
+  <div class="foot">
+    <span><b>Lviv Second Hand</b> · lvivsecondhand.com</span>
+    <span>Survey &amp; advertise now · sell promotions later · Опитування та реклама зараз · продажі згодом</span>
+  </div>
+
+</div>
+</body>
+</html>

--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -1096,7 +1096,7 @@ function notAgentMsg(uid) {
 }
 
 // Job brief for a prospective/onboarding agent to read and review.
-const JOB_BRIEF_URL = 'https://claude.ai/code/artifact/8707b32b-6c47-4df0-9176-7ddccfbe7264';
+const JOB_BRIEF_URL = 'https://www.lvivsecondhand.com/jobs/';
 function jobText() {
   return [
     '📋 <b>Опис вакансії · Job brief</b>',


### PR DESCRIPTION
## Summary
- The field sales rep job brief now lives at `jobs/index.html`, served at `www.lvivsecondhand.com/jobs/` — no longer a public Claude artifact. It's not linked from the app's normal navigation, only reachable by direct link (for the Telegram bot's `/job` command and external recruitment posts).
- Fixed while moving it: the "How to start" section told applicants to send `/whoami` — that command doesn't exist in the bot. Corrected to say to send any message (e.g. `/start`), which is what actually returns a Telegram ID for an unregistered user, matching `notAgentMsg()`.
- Also fixed a translucent `--paper` dark-mode token (`#0c231699`, 8-digit hex with alpha) that only rendered correctly inside the Claude Artifact viewer's own themed shell — as a real standalone page it showed through to a washed-out grey instead of solid green. Now a solid color.
- `telegram-bot/worker.js`'s `JOB_BRIEF_URL` now points at the new page instead of the artifact.
- Added a small **Careers** link to the app's Help sheet footer, directly below Privacy Policy — same quiet, easy-to-miss placement (small muted text at the very bottom), not surfaced anywhere more prominent in the app.

## Test plan
- [x] `node scripts/check-inline-js.mjs`, `node scripts/validate-stores.mjs`, `node --check telegram-bot/worker.js`
- [x] Playwright: opened the Help sheet, confirmed the Careers link renders with the correct `jobs/` href in the same quiet style as Privacy Policy
- [x] Playwright: screenshotted `jobs/index.html` in both light and dark — confirmed the dark-mode background bug and re-verified after the fix
- [x] Confirmed no other reference to the old `claude.ai/code/artifact/...` URL remains in the repo


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_