### PR TITLE
Remove capybara-bot, add payout cards, translate jobs page to Ukrainian

### DIFF
--- a/docs/FIELD_AGENT.md
+++ b/docs/FIELD_AGENT.md
@@ -11,18 +11,16 @@ each visit, and gets paid. Sections that the agent uses day-to-day are bilingual
 
 ---
 
-## 1. The two bots · Два боти
+## 1. The bot · Бот
 
-| Bot | Purpose | Who |
-|---|---|---|
-| **@Secondhandlvivbot** | Log each store visit: `/visit` walks through GPS → store → photo → questionnaire. This is the record that pay is calculated from. | Agent |
-| **capybara-bot** (private) | Day-to-day communication & notes between owner and agent. It translates English ↔ Ukrainian both ways, handles voice notes, and keeps a searchable memory (`/remember`, `/pin`, `/recap`). | Owner ↔ Agent |
+**@Secondhandlvivbot** — log each store visit: `/visit` walks through GPS →
+store → photo → questionnaire. This is the record that pay is calculated
+from.
 
-**Rule of thumb:** *work* (each store) is recorded in **@Secondhandlvivbot**;
-*talking* (questions, coordination, daily plan) happens in **capybara-bot**.
+Questions, coordination, and the daily plan — message the owner directly on
+Telegram.
 
-**Правило:** *робота* (кожен магазин) — у **@Secondhandlvivbot**; *спілкування*
-(питання, координація, план на день) — у **capybara-bot**.
+*Питання, координація та план на день — пишіть власнику напряму в Telegram.*
 
 ---
 
@@ -57,7 +55,7 @@ uses the same numbers.
   before it's sent.
 - **Pay cadence:** weekly. The owner runs `/report` (totals + estimated pay) and
   `/export` (full CSV), reconciles against poster photos / form submissions, and
-  pays by the agreed method (cash or bank transfer, ₴ UAH).
+  pays by bank transfer (₴ UAH) to the card the agent has set with `/card`.
 
 *Оплата: **₴80** за перевірений візит (GPS + фото + анкета) + **₴200** бонус за
 результат (плакат розміщено або власник зареєструвався). Ціль: 8–12 магазинів/день.
@@ -78,9 +76,9 @@ shows the live rates from `RATE_VISIT` / `RATE_BONUS`).
 ## 3. Standard operating procedure · Порядок роботи
 
 **Before the day / Перед виходом**
-1. Owner sends the day's target area/list in **capybara-bot**.
-2. Agent brings a charged phone with location on, and printed **QR posters**
-   (`marketing/qr-poster.pdf`).
+1. Owner sends the day's target area/list directly on Telegram.
+2. Agent brings a charged phone with location on, and printed **QR posters** —
+   pick these up from the owner in the city center.
 3. In **@Secondhandlvivbot** send **/route** (or **/agent → 🧭 Route**), share
    your location, and get a walking order through the nearest stores — with a
    map link and turn-by-turn Google Maps directions. Optional, but it plans
@@ -101,7 +99,7 @@ shows the live rates from `RATE_VISIT` / `RATE_BONUS`).
    in-app **owner form** (or `/submit` in the bot) → that's a **bonus**.
 
 **End of day / Наприкінці дня**
-- Agent: quick summary in **capybara-bot** (areas done, issues, stores to revisit).
+- Agent: quick summary message to the owner directly (areas done, issues, stores to revisit).
 - Owner: `/report` to see the running total; `/export` weekly for the CSV.
 
 ---
@@ -132,8 +130,8 @@ same way (Telegram approval → auto-filed GitHub issue):
 
 **Photos, communication & live location → Telegram.** The app can't take photos,
 chat, or share live position — Telegram does. Storefront photos and the GPS check-in
-go through **/visit** in @Secondhandlvivbot; day-to-day questions, translation, voice
-notes, and live-location sharing go through **capybara-bot**.
+go through **/visit** in @Secondhandlvivbot; day-to-day questions and coordination
+go directly to the owner on Telegram.
 
 *Дані магазину (завезення, години, назва, адреса, GPS, нотатки) редагуються у
 застосунку → **🤝 → 🗺️ Додати до офіційної карти** → власник отримує сповіщення в
@@ -179,8 +177,8 @@ app step below so the store actually appears for shoppers.
 
 ## The sales pipeline (why Phase 1 matters) · Воронка продажів
 
-Every survey is quietly building a sales funnel. Track each store's stage in
-**capybara-bot** (`/remember`, `/pin`):
+Every survey is quietly building a sales funnel. The owner tracks each store's
+stage from the `/visit` notes and `/export` CSV:
 
 `Prospected → Surveyed → Advertised (poster) → Interested (lead) → [owner closes] → Paying → Renewing/Churned`
 
@@ -255,6 +253,7 @@ works typed directly — the menus are just a shortcut.
 | `/route` | agent | plan a walking route through the nearest stores (map link + Google Maps directions) |
 | `/visit` | agent | start a survey |
 | `/myvisits` | agent | their running visit count |
+| `/card` | agent | set/view the payout card or IBAN `/report` pays out to |
 | `/pay` | agent · owner | show the pay scheme (live rates from `RATE_VISIT`/`RATE_BONUS`) |
 | `/job` | agent · owner | this handbook, as a link |
 | `/cancel` | agent | abort the current survey |

--- a/jobs/index.html
+++ b/jobs/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="uk">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="theme-color" content="#17693a">
-<title>Field Sales Rep — Lviv Second Hand</title>
-<meta name="description" content="Job brief for Lviv Second Hand's field sales rep role in Lviv, Ukraine — pay scheme, daily flow, and how to apply.">
+<title>Польовий торговий представник — Lviv Second Hand</title>
+<meta name="description" content="Вакансія польового торгового представника Lviv Second Hand у Львові — схема оплати, робочий процес і як податися.">
 <link rel="icon" href="../favicon.svg" type="image/svg+xml">
 <link rel="icon" href="../favicon-32.png" sizes="32x32" type="image/png">
 <link rel="apple-touch-icon" href="../apple-touch-icon.png">
@@ -37,7 +37,6 @@ body{
 }
 .wrap{max-width:820px;margin:0 auto;padding:clamp(20px,5vw,52px) clamp(18px,5vw,40px) 64px}
 .disp{font-weight:800;letter-spacing:-.01em;line-height:1.05}
-.ua{color:var(--muted);font-weight:400}
 .eyebrow{display:inline-block;font-size:12px;font-weight:800;letter-spacing:.14em;text-transform:uppercase;
   color:var(--green2);background:var(--acid);padding:5px 11px;border-radius:999px}
 @media (prefers-color-scheme:dark){:root:not([data-theme="light"]) .eyebrow{color:#0c2316}}
@@ -52,11 +51,10 @@ body{
   display:flex;align-items:center;justify-content:center;font-size:19px;flex:none}
 .brand b{font-weight:800;letter-spacing:.01em;font-size:15px}
 .brand span{display:block;font-size:11.5px;color:#bfe0cd;font-weight:500}
-h1{margin:0;font-size:clamp(30px,6.4vw,50px)}
+h1{margin:0;font-size:clamp(28px,6vw,46px)}
 h1 .k{color:var(--acid)}
 .tag{font-family:Georgia,"Times New Roman",serif;font-size:clamp(16px,2.5vw,20px);line-height:1.4;
   margin:16px 0 4px;max-width:52ch;color:#eaf3ea}
-.tag .ua{color:#bcd8c6}
 .chips{display:flex;flex-wrap:wrap;gap:8px;margin-top:20px}
 .chip{font-size:12.5px;font-weight:700;color:#eaf3ea;background:rgba(255,255,255,.10);
   border:1px solid rgba(255,255,255,.16);padding:6px 11px;border-radius:999px}
@@ -65,8 +63,7 @@ h1 .k{color:var(--acid)}
 /* Sections */
 section{margin-top:40px}
 h2{font-size:12.5px;font-weight:800;letter-spacing:.13em;text-transform:uppercase;color:var(--green);
-  margin:0 0 4px;display:flex;align-items:baseline;gap:9px}
-h2 .ua{font-size:11.5px;letter-spacing:.04em}
+  margin:0 0 4px}
 .rule{height:2px;background:linear-gradient(90deg,var(--acid),transparent);border-radius:2px;margin:10px 0 18px;max-width:120px}
 .lead{font-size:16px;margin:0 0 14px}
 
@@ -76,25 +73,22 @@ h2 .ua{font-size:11.5px;letter-spacing:.04em}
 .card .n{font-size:12px;font-weight:800;letter-spacing:.1em;text-transform:uppercase;color:var(--muted)}
 .card h3{margin:8px 0 6px;font-size:18px;font-weight:800}
 .card p{margin:0;font-size:14.5px;color:var(--ink)}
-.card .ua{font-size:13px}
 .pricebar{display:flex;flex-wrap:wrap;gap:6px;margin-top:12px}
 .pricebar span{font-size:12.5px;font-weight:700;background:var(--chip);border:1px solid var(--line);
   padding:4px 9px;border-radius:8px}
 .pricebar span b{color:var(--green)}
 
 ol.flow{list-style:none;counter-reset:s;margin:0;padding:0;display:grid;gap:11px}
-ol.flow li{position:relative;padding:2px 0 2px 44px;min-height:30px}
+ol.flow li{position:relative;padding:2px 0 2px 44px;min-height:30px;font-size:14.5px}
 ol.flow li::before{counter-increment:s;content:counter(s);position:absolute;left:0;top:0;width:30px;height:30px;
   border-radius:50%;background:var(--green);color:#fff;font-weight:800;font-size:14px;display:flex;
   align-items:center;justify-content:center}
 ol.flow b{font-weight:800}
-ol.flow .ua{display:block;font-size:13px}
 
 ul.ticks{list-style:none;margin:0;padding:0;display:grid;gap:9px}
 ul.ticks li{position:relative;padding-left:26px;font-size:14.5px}
 ul.ticks li::before{content:"";position:absolute;left:2px;top:7px;width:9px;height:9px;background:var(--acid);
   clip-path:polygon(0 0,100% 0,100% 100%)}
-ul.ticks .ua{display:block;font-size:12.5px}
 
 table.pay{width:100%;border-collapse:collapse;font-size:14.5px;background:var(--card);border:1px solid var(--line);
   border-radius:14px;overflow:hidden;box-shadow:var(--shadow)}
@@ -102,10 +96,8 @@ table.pay th{text-align:left;background:var(--green);color:#fff;font-size:12px;l
   text-transform:uppercase;padding:10px 14px}
 table.pay td{padding:12px 14px;border-top:1px solid var(--line);vertical-align:top}
 table.pay td.amt{white-space:nowrap;font-weight:800;color:var(--green);font-size:15px}
-table.pay .ua{display:block;font-size:12.5px}
 .note{margin-top:12px;font-size:13px;color:var(--muted)}
 .callout{margin-top:14px;background:var(--acid);color:#3a2c00;border-radius:14px;padding:14px 16px;font-weight:700;font-size:14.5px}
-.callout .ua{color:#5b4a12;font-weight:600;display:block;margin-top:3px}
 
 .start{background:var(--card);border:1px dashed var(--green);border-radius:16px;padding:18px}
 .foot{margin-top:44px;padding-top:18px;border-top:1px solid var(--line);font-size:12.5px;color:var(--muted);
@@ -123,36 +115,32 @@ code{background:var(--chip);border:1px solid var(--line);border-radius:6px;paddi
       <div class="mark">🧭</div>
       <div><b>Lviv Second Hand</b><span>lvivsecondhand.com · секонд-хенди Львова на карті</span></div>
     </div>
-    <span class="eyebrow">Job opportunity · Вакансія</span>
-    <h1 class="disp">Field Sales <span class="k">Rep</span><br><span class="ua" style="font-size:.62em">Польовий торговий представник</span></h1>
-    <p class="tag">Help Lviv's second-hand shoppers and stores find each other — on foot, with your phone.
-      <span class="ua"><br>Допомагайте покупцям і магазинам секонд-хенду Львова знаходити одне одного — пішки, зі смартфоном.</span></p>
+    <span class="eyebrow">Вакансія</span>
+    <h1 class="disp">Польовий торговий <span class="k">представник</span></h1>
+    <p class="tag">Допомагайте покупцям і магазинам секонд-хенду Львова знаходити одне одного — пішки, зі смартфоном.</p>
     <div class="chips">
-      <span class="chip">📍 Lviv · Львів</span>
-      <span class="chip">🚶 Field work · робота в місті</span>
-      <span class="chip">🕒 Flexible · гнучкий графік</span>
-      <span class="chip">💬 Ukrainian · українська</span>
-      <span class="chip">💵 Pay: <b>per visit + bonuses + commission</b></span>
+      <span class="chip">📍 Львів</span>
+      <span class="chip">🚶 Робота в місті</span>
+      <span class="chip">🕒 Гнучкий графік</span>
+      <span class="chip">💬 Українська</span>
+      <span class="chip">💵 Оплата: <b>за візит + бонуси + комісія</b></span>
     </div>
   </div>
 
   <section>
-    <h2>What we're selling <span class="ua">· Що ми пропонуємо</span></h2>
+    <h2>Що ми пропонуємо</h2>
     <div class="rule"></div>
-    <p class="lead">Two things — one free, one paid. Your work drives both.
-      <span class="ua"> · Дві речі — одна безкоштовна, друга платна. Ваша робота рухає обидві.</span></p>
+    <p class="lead">Дві речі — одна безкоштовна, друга платна. Ваша робота рухає обидві.</p>
     <div class="cards">
       <div class="card">
-        <div class="n">Free · для покупців</div>
-        <h3>The app</h3>
-        <p>A free map of every second-hand store in Lviv — hours, by-weight &amp; itemized prices, and restock days so shoppers know when it's cheapest.
-          <span class="ua">Безкоштовна карта всіх секонд-хендів Львова — години, ціни на вагу та поштучно, дні завезення.</span></p>
+        <div class="n">Безкоштовно · для покупців</div>
+        <h3>Застосунок</h3>
+        <p>Безкоштовна карта всіх секонд-хендів Львова — години роботи, ціни на вагу та поштучно, дні завезення, щоб покупці знали, коли найдешевше.</p>
       </div>
       <div class="card">
-        <div class="n">Paid · для магазинів</div>
-        <h3>Store promotions</h3>
-        <p>Stores pay a monthly fee to stand out on the map — a gold pin, top of the list, their offer shown to shoppers. This is the revenue.
-          <span class="ua">Магазини платять щомісяця, щоб виділятися: золота позначка, перше місце, акція для покупців.</span></p>
+        <div class="n">Платно · для магазинів</div>
+        <h3>Реклама для магазинів</h3>
+        <p>Магазини платять щомісяця, щоб виділятися на карті — золота позначка, перше місце у списку, акція показана покупцям. Це і є дохід проєкту.</p>
         <div class="pricebar">
           <span>Verified+ <b>₴250</b></span><span>Featured <b>₴600</b></span><span>Spotlight <b>₴1200</b></span>
         </div>
@@ -161,101 +149,85 @@ code{background:var(--chip);border:1px solid var(--line);border-radius:6px;paddi
   </section>
 
   <section>
-    <h2>The role <span class="ua">· Роль</span></h2>
+    <h2>Роль</h2>
     <div class="rule"></div>
     <ul class="ticks">
-      <li><b>Visit second-hand stores</b> across an assigned zone of the city each day.
-        <span class="ua">Відвідувати секонд-хенди у призначеній зоні міста щодня.</span></li>
-      <li><b>Advertise the free app</b> to shoppers and staff, and place a QR poster in the store.
-        <span class="ua">Рекламувати безкоштовний застосунок покупцям і персоналу, розміщувати QR-плакат.</span></li>
-      <li><b>Record each store</b> — name, address, GPS, hours, restock day, prices, and one storefront photo.
-        <span class="ua">Записувати кожен магазин — назва, адреса, GPS, години, день завезення, ціни, фото вітрини.</span></li>
-      <li><b>Capture interested owners</b> (contact + their consent) — these become our sales leads.
-        <span class="ua">Фіксувати зацікавлених власників (контакт + згода) — це наші потенційні клієнти.</span></li>
-      <li><b>Later — sell promotions.</b> Once you know the ropes, pitch stores on the paid tiers and sign them up.
-        <span class="ua">Згодом — продавати рекламу: пропонувати магазинам платні пакети та підписувати їх.</span></li>
+      <li><b>Відвідувати секонд-хенди</b> у призначеній зоні міста щодня.</li>
+      <li><b>Рекламувати безкоштовний застосунок</b> покупцям і персоналу, розміщувати QR-плакат у магазині.</li>
+      <li><b>Фіксувати кожен магазин</b> — назва, адреса, GPS, години, день завезення, ціни, одне фото вітрини.</li>
+      <li><b>Фіксувати зацікавлених власників</b> (контакт + згода) — це наші потенційні клієнти.</li>
+      <li><b>Згодом — продавати рекламу.</b> Коли освоїтесь, пропонуйте магазинам платні пакети та підписуйте їх.</li>
     </ul>
   </section>
 
   <section>
-    <h2>How the work flows <span class="ua">· Як це працює</span></h2>
+    <h2>Як це працює</h2>
     <div class="rule"></div>
     <ol class="flow">
-      <li><b>Get your zone.</b> Each morning I send you a district and store list in <b>capybara-bot</b> (it translates UA↔EN and keeps our notes).
-        <span class="ua">Щоранку отримуєте район і список магазинів у capybara-bot (перекладає UA↔EN).</span></li>
-      <li><b>At each store (~10 min):</b> look, go in, be polite, tell shoppers about the app, offer a QR poster.
-        <span class="ua">У кожному магазині (~10 хв): огляд, ввічливо зайти, розповісти про застосунок, запропонувати плакат.</span></li>
-      <li><b>Log it in <code>@Secondhandlvivbot</code></b> with <code>/visit</code>: share your location, pick the store, then 📷 photo → a few quick questions. This is what pay is counted from.
-        <span class="ua">Записати у @Secondhandlvivbot через /visit: геолокація → магазин → фото → кілька питань. З цього рахується оплата.</span></li>
-      <li><b>Store data</b> (hours, address, restock) you edit in the app and send for review; <b>photos, chat &amp; live location</b> go through Telegram.
-        <span class="ua">Дані магазину редагуєте в застосунку і надсилаєте на перевірку; фото, спілкування та геолокація — у Telegram.</span></li>
-      <li><b>End of day:</b> a quick summary in capybara-bot — zone done, stores to revisit, hot leads.
-        <span class="ua">Наприкінці дня: короткий підсумок у capybara-bot.</span></li>
+      <li><b>Отримайте свою зону.</b> Щоранку я надсилаю район і список магазинів напряму в Telegram; QR-плакати забираєте у мене в центрі міста.</li>
+      <li><b>У кожному магазині (~10 хв):</b> огляньтеся, ввічливо зайдіть, розкажіть покупцям про застосунок, запропонуйте розмістити QR-плакат.</li>
+      <li><b>Запишіть це у <code>@Secondhandlvivbot</code></b> командою <code>/visit</code>: геолокація → магазин → 📷 фото → кілька коротких питань. Саме з цього рахується оплата.</li>
+      <li><b>Дані магазину</b> (години, адреса, завезення) редагуєте в застосунку і надсилаєте на перевірку; <b>фото, спілкування та жива геолокація</b> — у Telegram.</li>
+      <li><b>Наприкінці дня:</b> короткий підсумок напряму мені — що зроблено, які магазини повернутись перевірити, гарячі ліди.</li>
     </ol>
-    <p class="note">You'll need: a smartphone (location + camera on) and Telegram. No GitHub account needed — map submissions go through an in-app approval, not a direct GitHub issue. · Потрібно: смартфон і Telegram. Акаунт GitHub не потрібен.</p>
+    <p class="note">Знадобиться: смартфон (з увімкненою геолокацією й камерою) і Telegram. Акаунт GitHub не потрібен — зміни на карту надсилаються через схвалення в застосунку, а не напряму через GitHub.</p>
   </section>
 
   <section>
-    <h2>How you get paid <span class="ua">· Оплата</span></h2>
+    <h2>Оплата</h2>
     <div class="rule"></div>
     <table class="pay">
-      <tr><th>What</th><th>Pay</th><th>Paid when</th></tr>
+      <tr><th>Що</th><th>Сума</th><th>Коли платимо</th></tr>
       <tr>
-        <td><b>Visit base</b><span class="ua">База за візит</span></td>
+        <td><b>База за візит</b></td>
         <td class="amt">₴80</td>
-        <td>A verified visit: GPS + storefront photo + full questionnaire. One store = one base per restock cycle.
-          <span class="ua">Перевірений візит: GPS + фото + анкета. Один магазин = одна база на цикл завезення.</span></td>
+        <td>Перевірений візит: GPS + фото вітрини + повна анкета. Один магазин = одна база на цикл завезення.</td>
       </tr>
       <tr>
-        <td><b>Bonus</b><span class="ua">Бонус</span></td>
-        <td class="amt">₴200 <span style="font-weight:600;color:var(--muted);font-size:12px">each</span></td>
-        <td>QR poster placed (photo proof), or an owner signs up (contact + consent). Both can apply.
-          <span class="ua">Плакат розміщено (фото), або власник зареєструвався. Можуть діяти обидва.</span></td>
+        <td><b>Бонус</b></td>
+        <td class="amt">₴200 <span style="font-weight:600;color:var(--muted);font-size:12px">за кожен</span></td>
+        <td>Плакат розміщено (фото-підтвердження), або власник зареєструвався (контакт + згода). Можуть діяти обидва бонуси разом.</td>
       </tr>
       <tr>
-        <td><b>Sales commission</b><span class="ua">Комісія з продажу</span><br><span style="font-size:11.5px;color:var(--muted)">Phase 2 · згодом</span></td>
+        <td><b>Комісія з продажу</b><br><span style="font-size:11.5px;color:var(--muted)">Фаза 2 · згодом</span></td>
         <td class="amt">₴300–800</td>
-        <td>One-time, per store you sign up: ₴300–500 Featured, ₴800 Spotlight.
-          <span class="ua">Разово за підписаний магазин: ₴300–500 Featured, ₴800 Spotlight.</span></td>
+        <td>Разово за підписаний магазин: ₴300–500 за Featured, ₴800 за Spotlight.</td>
       </tr>
     </table>
     <div style="margin-top:14px;background:var(--card);border:1px solid var(--line);border-left:4px solid var(--green);border-radius:12px;padding:13px 15px;font-size:14px">
-      <b>Bonus vs. commission.</b> A <b>bonus</b> is paid for the <i>action</i> — placing a poster or signing up a lead — even if that store never buys. A <b>commission</b> is paid only when a store actually <b>subscribes and pays</b>. The bonus is the on-ramp; the commission is the payoff once selling starts.
-      <span class="ua" style="display:block;margin-top:6px">Бонус проти комісії. <b>Бонус</b> — за <i>дію</i> (розміщений плакат або зафіксований лід), навіть якщо магазин ніколи не купить. <b>Комісія</b> — лише коли магазин справді <b>підписується та платить</b>.</span>
+      <b>Бонус проти комісії.</b> <b>Бонус</b> — за саму <i>дію</i> (розміщений плакат або зафіксований лід), навіть якщо магазин ніколи не купить рекламу. <b>Комісія</b> — лише коли магазин справді <b>підписується та платить</b>. Бонус — це старт співпраці, комісія — винагорода за результат продажу.
     </div>
-    <div class="callout">🎯 Target 8–12 stores a day ≈ ₴640–₴960 base per day, plus bonuses. Paid weekly (cash or bank transfer).
-      <span class="ua">Ціль 8–12 магазинів/день ≈ ₴640–₴960 бази на день + бонуси. Виплати щотижня.</span></div>
-    <p class="note">Only complete, honest visits count — GPS + photo keep it fair for everyone. You can see your live pay scheme any time in the bot with <code>/pay</code>. · Рахуються лише повні, чесні візити. Схему оплати можна побачити у боті командою /pay.</p>
+    <div class="callout">🎯 Ціль — 8–12 магазинів на день ≈ ₴640–₴960 бази на день, плюс бонуси. Виплати щотижня — переказом на картку.</div>
+    <p class="note">Зараховуються лише повні, чесні візити — GPS і фото роблять це справедливим для всіх. Актуальну схему оплати завжди можна побачити в боті командою <code>/pay</code>; номер картки для виплат вказуєте командою <code>/card</code> після того, як вас додано до списку агентів.</p>
   </section>
 
   <section>
-    <h2>Who we're looking for <span class="ua">· Кого шукаємо</span></h2>
+    <h2>Кого шукаємо</h2>
     <div class="rule"></div>
     <ul class="ticks">
-      <li>Lives in or near Lviv and gets around the city easily. <span class="ua">Живе у Львові або поруч, легко пересувається містом.</span></li>
-      <li>Comfortable talking to shop staff — friendly, honest, low-pressure. <span class="ua">Вміє спілкуватися з персоналом — доброзичливо, чесно, без тиску.</span></li>
-      <li>Reliable with a smartphone and careful with details. <span class="ua">Впевнено користується смартфоном, уважний до деталей.</span></li>
-      <li>Ukrainian (English a plus). An interest in sales helps for Phase 2. <span class="ua">Українська (англійська — плюс). Інтерес до продажів — перевага.</span></li>
+      <li>Живе у Львові або поруч і легко пересувається містом.</li>
+      <li>Уміє спілкуватися з персоналом магазинів — доброзичливо, чесно, без тиску.</li>
+      <li>Впевнено користується смартфоном і уважний до деталей.</li>
+      <li>Українська мова (англійська — перевага). Інтерес до продажів стане у пригоді на Фазі 2.</li>
     </ul>
   </section>
 
   <section>
-    <h2>How to start <span class="ua">· Як почати</span></h2>
+    <h2>Як почати</h2>
     <div class="rule"></div>
     <div class="start">
       <ul class="ticks">
-        <li>Open <code>@Secondhandlvivbot</code> in Telegram and send it any message (e.g. <code>/start</code>) — it replies with your Telegram ID since you're not registered yet. Send me that ID.
-          <span class="ua">Відкрийте @Secondhandlvivbot у Telegram, надішліть будь-яке повідомлення (напр. /start) — бот покаже ваш Telegram ID, бо ви ще не зареєстровані. Перешліть мені цей ID.</span></li>
-        <li>Make sure you have Telegram. <span class="ua">Майте Telegram.</span></li>
-        <li>I'll add you, send your first zone, and walk you through <code>/visit</code> together. <span class="ua">Я додам вас, надішлю першу зону і разом пройдемо /visit.</span></li>
+        <li>Відкрийте <code>@Secondhandlvivbot</code> у Telegram і надішліть будь-яке повідомлення (наприклад, <code>/start</code>) — оскільки ви ще не зареєстровані, бот покаже ваш Telegram ID. Перешліть цей ID мені.</li>
+        <li>Переконайтеся, що у вас встановлено Telegram.</li>
+        <li>Я додам вас до списку агентів, надішлю першу зону і разом пройдемо перший <code>/visit</code>. Тоді ж командою <code>/card</code> ви вкажете картку для виплат.</li>
       </ul>
     </div>
-    <p class="note">Please photograph storefronts and merchandise — <b>not people</b> — and keep every owner contact private. · Фотографуйте вітрини та товар, <b>не людей</b>; контакти власників — конфіденційні.</p>
+    <p class="note">Фотографуйте вітрини та товар — <b>не людей</b> — і тримайте кожен контакт власника конфіденційним.</p>
   </section>
 
   <div class="foot">
     <span><b>Lviv Second Hand</b> · lvivsecondhand.com</span>
-    <span>Survey &amp; advertise now · sell promotions later · Опитування та реклама зараз · продажі згодом</span>
+    <span>Зараз — опитування та реклама, згодом — продаж просування</span>
   </div>
 
 </div>

--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -22,9 +22,15 @@
 //   /leaderboard     — top contributors by points
 //   ✅/❌ buttons on a moderator-channel edit message — isOwner/isAgent only
 //
-// Field-agent commands (stateful — require BOT_TOKEN + the VISITS KV binding):
-//   /visit        — guided store-survey flow (store → GPS → photo → questionnaire)
+// Field-agent commands (stateful — require BOT_TOKEN + the VISITS KV binding).
+// /agent (agents + owner) and /admin (owner only) group these into a one-tap
+// menu; every command below also still works typed directly:
+//   /route        — plan a walking route through the nearest stores
+//   /visit        — guided store-survey flow (GPS → store → photo → questionnaire)
 //   /myvisits     — an agent's own running visit count
+//   /card         — set/view the payout card or IBAN /report pays out to
+//   /pay          — the live pay scheme (rates from RATE_VISIT/RATE_BONUS)
+//   /job          — link to the job brief
 //   /cancel       — abort an in-progress /visit
 //   /report       — OWNER only: totals, per-agent counts, estimated pay
 //   /export       — OWNER only: CSV of all logged visits
@@ -586,6 +592,7 @@ async function handleAgentCallback(env, c, cq) {
         return;
       }
       if (val === 'myvisits') { if (!isAgent2) return; await cmdMyVisits(env, uid, chatId); return; }
+      if (val === 'card') { if (!isAgent2) return; await cmdCard(env, uid, chatId); return; }
       if (val === 'pay') { await cmdPay(env, c, chatId); return; }
       if (val === 'job') { await cmdJob(env, chatId); return; }
       if (val === 'cancel') { await cmdCancel(env, uid, chatId); return; }
@@ -841,6 +848,16 @@ function readYesNo(t) {
   if (/ні|no|❌/i.test(s)) return false;
   return null;
 }
+// A payout card number (16 digits, spaces/dashes stripped) or a Ukrainian
+// IBAN. Only shape-checked, not a Luhn/bank check — this is a destination the
+// owner pays to by hand, not a card processed by this app.
+function readCardNumber(t) {
+  const raw = String(t || '').trim().replace(/[\s-]/g, '');
+  if (/^\d{13,19}$/.test(raw)) return raw;
+  if (/^UA\d{27}$/i.test(raw)) return raw.toUpperCase();
+  return null;
+}
+const cardKey = (uid) => `card:${uid}`;
 
 const ROUTE_SIZE = 12;        // a day's zone, matching the handbook's 10–15
 const DUP_WINDOW_DAYS = 30;   // fallback when a store's own cycle is unknown
@@ -1060,10 +1077,13 @@ async function ownerReport(env, c, chatId) {
   const ownerVisits = (c.ownerId && c.agentIds.includes(c.ownerId))
     ? Number((await env.VISITS.get('count:agent:' + c.ownerId)) || 0) : 0;
   const lines = ['📊 <b>Field report · Звіт</b>', `Visits logged: <b>${total}</b>`, `Bonus events: <b>${bonus}</b>`];
-  // Per-agent counts.
+  // Per-agent counts, with their payout card if they've set one.
   for (const id of c.agentIds) {
     const n = Number((await env.VISITS.get('count:agent:' + id)) || 0);
-    if (n) lines.push(`• agent <code>${id}</code>${id === c.ownerId ? ' (owner — excluded from pay below)' : ''}: ${n} visits`);
+    if (!n) continue;
+    const card = await env.VISITS.get(cardKey(id));
+    const cardNote = id === c.ownerId ? ' (owner — excluded from pay below)' : (card ? ` 💳 <code>${esc(card)}</code>` : ' ⚠️ no payout card');
+    lines.push(`• agent <code>${id}</code>${cardNote}: ${n} visits`);
   }
   const payableVisits = total - ownerVisits;
   const pay = payableVisits * c.rateVisit + bonus * c.rateBonus;
@@ -1105,7 +1125,7 @@ function jobText() {
     '',
     `👉 <a href="${JOB_BRIEF_URL}">Відкрити опис вакансії · Open the job brief</a>`,
     '',
-    'Питання? Пишіть власнику у capybara-bot. · Questions? Message the owner in capybara-bot.',
+    'Питання? Пишіть власнику напряму. · Questions? Message the owner directly.',
   ].join('\n');
 }
 
@@ -1151,6 +1171,26 @@ async function cmdMyVisits(env, userId, chatId) {
 async function cmdPay(env, c, chatId) {
   await say(env, chatId, payText(c));
 }
+// `arg` is whatever followed "/card " (undefined from the /agent menu button
+// — that variant just shows the current status/instructions).
+async function cmdCard(env, userId, chatId, arg) {
+  const typed = String(arg || '').trim();
+  if (!typed) {
+    const cur = await env.VISITS.get(cardKey(userId));
+    await say(env, chatId, cur
+      ? `💳 Картка для виплат · Payout card: <code>${esc(cur)}</code>\nЩоб змінити · To change: <code>/card 0000000000000000</code>`
+      : '💳 Картку для виплат ще не вказано. · No payout card on file yet.\n' +
+        'Надішліть номер картки (16 цифр) або IBAN · Send your card number (16 digits) or IBAN:\n<code>/card 0000000000000000</code>');
+    return;
+  }
+  const card = readCardNumber(typed);
+  if (!card) {
+    await say(env, chatId, '⚠️ Не розпізнав номер картки. Введіть 16 цифр картки або IBAN (UA...). · Didn’t recognise that — enter a 16-digit card number or a UA IBAN.');
+    return;
+  }
+  await env.VISITS.put(cardKey(userId), card);
+  await say(env, chatId, `✅ Збережено картку для виплат · Payout card saved: <code>${esc(card)}</code>`);
+}
 async function cmdJob(env, chatId) {
   await say(env, chatId, jobText());
 }
@@ -1183,6 +1223,7 @@ async function cmdAgentMenu(env, chatId, isAgent) {
     rows.push([{ text: '🧭 Маршрут · Route', callback_data: 'ag:route' }]);
     rows.push([{ text: '📝 Візит · Visit', callback_data: 'ag:visit' }]);
     rows.push([{ text: '📊 Мої візити · My visits', callback_data: 'ag:myvisits' }]);
+    rows.push([{ text: '💳 Картка для виплат · Payout card', callback_data: 'ag:card' }]);
   }
   rows.push([{ text: '💰 Оплата · Pay', callback_data: 'ag:pay' }]);
   rows.push([{ text: '📋 Вакансія · Job', callback_data: 'ag:job' }]);
@@ -1234,6 +1275,12 @@ async function handleVisit(env, c, msg, ctx) {
   if (command === 'pay') {
     if (!(isAgent || isOwner)) { await say(env, chatId, notAgentMsg(userId)); return true; }
     await cmdPay(env, c, chatId);
+    return true;
+  }
+  if (command === 'card') {
+    if (!isAgent) { await say(env, chatId, notAgentMsg(userId)); return true; }
+    const arg = (text || '').replace(/^\/card(?:@\w+)?\s*/i, '');
+    await cmdCard(env, userId, chatId, arg);
     return true;
   }
   if (command === 'job' || command === 'brief') {


### PR DESCRIPTION
## Summary
- **capybara-bot removed everywhere** (`docs/FIELD_AGENT.md`, `jobs/index.html`, the bot's `/job` reply). Day-to-day coordination between agent and owner is now just a direct Telegram message — no second bot involved.
- **Payment specifics corrected** per the owner: pay is by bank transfer only (was "cash or bank transfer, ₴ UAH"), and printed QR posters are picked up from the owner in the city center rather than agent-printed.
- **New `/card` command** — agent-only, gated the same way every other agent command already is (`isAgent`), so this does **not** change who can become an agent or bypass the existing manual owner-approval step. An already-approved agent sets the card number or IBAN they're paid to; `/report` shows it next to their visit count so the owner has it on hand when paying. Reachable by typing `/card` or from the `/agent` menu.
- **`jobs/index.html` is now fully Ukrainian** (was bilingual, EN-primary) — the actual audience for this page is Ukrainian-speaking, per explicit request.

## Test plan
- [x] `node --check telegram-bot/worker.js`, `node scripts/check-inline-js.mjs`, `node scripts/validate-stores.mjs`
- [x] `grep -rn capybara` across the repo returns nothing
- [x] Local harness driving the real `fetch(request, env)` handler:
  - non-agent `/card` → refused
  - agent `/card` with nothing set → prompts for a card/IBAN
  - garbage input → rejected with a clear message
  - a 16-digit card (with spaces, as typically written) and a UA IBAN both save correctly
  - `/report` shows the agent's saved card next to their visit count; the owner's own row is unaffected
  - the `/agent` menu includes the new card button; tapping it shows the same status as the typed command
- [x] Playwright screenshots of `jobs/index.html` in light and dark — confirmed the Ukrainian copy renders correctly in both


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_