### PR TITLE
Move "How to start" above "How the work flows" on the jobs page

### DIFF
--- a/jobs/index.html
+++ b/jobs/index.html
@@ -161,6 +161,19 @@ code{background:var(--chip);border:1px solid var(--line);border-radius:6px;paddi
   </section>
 
   <section>
+    <h2>Як почати</h2>
+    <div class="rule"></div>
+    <div class="start">
+      <ul class="ticks">
+        <li>Відкрийте <code>@Secondhandlvivbot</code> у Telegram і надішліть будь-яке повідомлення (наприклад, <code>/start</code>) — оскільки ви ще не зареєстровані, бот покаже ваш Telegram ID. Перешліть цей ID мені.</li>
+        <li>Переконайтеся, що у вас встановлено Telegram.</li>
+        <li>Я додам вас до списку агентів, надішлю першу зону і разом пройдемо перший <code>/visit</code>. Тоді ж командою <code>/card</code> ви вкажете картку для виплат.</li>
+      </ul>
+    </div>
+    <p class="note">Фотографуйте вітрини та товар — <b>не людей</b> — і тримайте кожен контакт власника конфіденційним.</p>
+  </section>
+
+  <section>
     <h2>Як це працює</h2>
     <div class="rule"></div>
     <ol class="flow">
@@ -210,19 +223,6 @@ code{background:var(--chip);border:1px solid var(--line);border-radius:6px;paddi
       <li>Впевнено користується смартфоном і уважний до деталей.</li>
       <li>Українська мова (англійська — перевага). Інтерес до продажів стане у пригоді на Фазі 2.</li>
     </ul>
-  </section>
-
-  <section>
-    <h2>Як почати</h2>
-    <div class="rule"></div>
-    <div class="start">
-      <ul class="ticks">
-        <li>Відкрийте <code>@Secondhandlvivbot</code> у Telegram і надішліть будь-яке повідомлення (наприклад, <code>/start</code>) — оскільки ви ще не зареєстровані, бот покаже ваш Telegram ID. Перешліть цей ID мені.</li>
-        <li>Переконайтеся, що у вас встановлено Telegram.</li>
-        <li>Я додам вас до списку агентів, надішлю першу зону і разом пройдемо перший <code>/visit</code>. Тоді ж командою <code>/card</code> ви вкажете картку для виплат.</li>
-      </ul>
-    </div>
-    <p class="note">Фотографуйте вітрини та товар — <b>не людей</b> — і тримайте кожен контакт власника конфіденційним.</p>
   </section>
 
   <div class="foot">


### PR DESCRIPTION
## Summary
- Reordered sections on `jobs/index.html`: "Як почати" (How to start) now sits right after "Роль" (The role), before "Як це працює" (How the work flows). Content unchanged, section order only.

## Test plan
- [x] Tag balance check (div/section/table/ul/ol/li etc. all matched)
- [x] Playwright screenshot confirms the new order renders correctly: Що ми пропонуємо → Роль → Як почати → Як це працює → Оплата → Кого шукаємо


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_