### PR TITLE
Fix stale help text; add ctx.waitUntil to bot webhook

### DIFF
--- a/index.html
+++ b/index.html
@@ -598,8 +598,7 @@ header{ background:linear-gradient(118deg,var(--green2),var(--green)); }
     </div>
     <div class="help-section">
       <h3>🤝 Share & Contribute</h3>
-      <p>Tap the <strong>🤝</strong> button in the top-right to share the stores you've added or edited. <strong>Copy share link</strong> gives you a link — anyone who opens it gets your stores merged onto their map. You can also download a file, or paste in a link/file someone sent you to import theirs. Duplicates are skipped automatically.</p>
-      <p style="margin-top:8px;">To help everyone, tap <strong>🌍 Contribute to the official map</strong> — it opens a pre-filled GitHub form with your additions and corrections so they can be merged into the map that ships with the app.</p>
+      <p>Tap the <strong>🤝</strong> button in the top-right to share the app with a link or QR code, submit your additions and corrections to the official map, register your store if you own one, or save a backup of everything you've recorded on this device.</p>
     </div>
     <div class="help-section">
       <h3>📍 Open in Maps.me / Google Maps</h3>
@@ -2871,7 +2870,7 @@ const HELP = {
     ['✅ Visited','Tap the big green <strong>"Mark as Visited"</strong> button inside any store. It turns into a checkmark and the card gets a green border in the list.'],
     ['✏️ Edit or remove a store','Open any store and tap <strong>Edit Store</strong> to fix its details, or <strong>🗑️ Remove this store</strong> at the bottom. Stores <em>you</em> added are deleted; built-in stores are just hidden on your device — a <strong>"Restore all"</strong> link at the bottom of the list brings them back anytime.'],
     ['⚖️ KG vs Itemized','<strong>By KG</strong> stores charge by weight — you fill a bag and pay per kilogram, and prices drop every day. <strong>Itemized</strong> stores price each item individually.'],
-    ['🤝 Share & Contribute','Tap <strong>🤝</strong> to share the stores you\'ve added or edited via a link, file, or code — anyone who opens it merges them onto their map (duplicates are skipped). Tap <strong>🌍 Contribute to the official map</strong> to open a pre-filled GitHub form so your changes can ship with the app.'],
+    ['🤝 Share & Contribute','Tap <strong>🤝</strong> to share the app with a link or QR code, submit your additions and corrections to the official map, register your store if you own one, or save a backup of everything you\'ve recorded on this device.'],
     ['📍 Directions','Inside any store, tap <strong>📍 Maps.me</strong> or <strong>🗺️ Google Maps</strong> to jump straight to it for directions.'],
     ['💬 Telegram bot','Prefer chat? Message <strong><a href="https://t.me/Secondhandlvivbot" target="_blank" rel="noopener" style="color:var(--green);">@Secondhandlvivbot</a></strong> and send <strong>/today</strong> for stores restocking today, or <strong>/cheap</strong> for the best by-weight deals right now — each result links back here.'] ] },
   ua: { title:'Як користуватися додатком', got:'Зрозуміло!', sections:[
@@ -2881,7 +2880,7 @@ const HELP = {
     ['✅ Відвідані','Натисніть велику зелену кнопку <strong>«Відмітити як відвідане»</strong> у магазині. Вона стане галочкою, а картка отримає зелену рамку у списку.'],
     ['✏️ Редагувати чи видалити','Відкрийте магазин і натисніть <strong>«Редагувати»</strong>, щоб змінити деталі, або <strong>🗑️ Видалити магазин</strong> внизу. Магазини, <em>додані вами</em>, видаляються; вбудовані просто ховаються на вашому пристрої — посилання <strong>«Відновити всі»</strong> внизу списку поверне їх будь-коли.'],
     ['⚖️ На вагу чи поштучно','Магазини <strong>на вагу</strong> рахують за кілограм — наповнюєте пакет і платите за кг, ціни падають щодня. <strong>Поштучні</strong> оцінюють кожну річ окремо.'],
-    ['🤝 Обмін і внесок','Натисніть <strong>🤝</strong>, щоб поділитися доданими чи зміненими магазинами через посилання, файл або код — хто відкриє, додасть їх на свою карту (дублікати пропускаються). Натисніть <strong>🌍 Внести до офіційної карти</strong>, щоб відкрити заповнену форму GitHub і додати зміни до додатка.'],
+    ['🤝 Обмін і внесок','Натисніть <strong>🤝</strong>, щоб поділитися застосунком через посилання чи QR-код, надіслати доповнення й виправлення до офіційної карти, зареєструвати свій магазин або зберегти резервну копію всього записаного на цьому пристрої.'],
     ['📍 Маршрут','У магазині натисніть <strong>📍 Maps.me</strong> або <strong>🗺️ Google Maps</strong>, щоб одразу прокласти маршрут.'],
     ['💬 Телеграм-бот','Надаєте перевагу чату? Напишіть <strong><a href="https://t.me/Secondhandlvivbot" target="_blank" rel="noopener" style="color:var(--green);">@Secondhandlvivbot</a></strong> і надішліть <strong>/today</strong> — магазини із завезенням сьогодні, або <strong>/cheap</strong> — найкращі ціни на вагу зараз. Кожен результат посилається сюди.'] ] }
 };
@@ -2985,7 +2984,7 @@ if ('serviceWorker' in navigator) {
 // UPDATE CHECK — notify when a newer build is deployed, so nobody is stuck on
 // a cached version (no reinstall needed). Bump APP_VERSION on each deploy.
 // ─────────────────────────────────────────────
-const APP_VERSION = '2026-08-14.1';
+const APP_VERSION = '2026-08-14.2';
 
 // ─────────────────────────────────────────────
 // DONATIONS — points at a Stripe Payment Link (hosted checkout). No API keys

--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -1482,7 +1482,7 @@ async function handleQuestionsStart(env, uid, chatId, session) {
 }
 
 export default {
-  async fetch(request, env) {
+  async fetch(request, env, ctx) {
     // Health check.
     if (request.method === 'GET') {
       return ok('Lviv Second Hand Telegram bot is running.');
@@ -1507,8 +1507,13 @@ export default {
     const c = cfg(env);
 
     // Inline-keyboard taps (bounty flow) arrive as callback_query, not message.
+    // Ack Telegram immediately and finish in the background: dispatchMapPatch
+    // (GitHub) inside handleAgentCallback can be slow, and a slow webhook
+    // response makes Telegram redeliver the same tap — that double-processed
+    // an edit-review approval, fixed in #135. ctx.waitUntil keeps the Worker
+    // alive to finish the call after the response is already sent.
     if (update.callback_query) {
-      try { await handleAgentCallback(env, c, update.callback_query); } catch (e) {}
+      ctx.waitUntil(handleAgentCallback(env, c, update.callback_query).catch(() => {}));
       return ok();
     }
 
@@ -1517,26 +1522,26 @@ export default {
     const from = msg.from || {};
     const chatId = msg.chat.id;
     const text = typeof msg.text === 'string' ? msg.text : null;
-    const ctx = { userId: from.id, chatId, text, from };
+    const mctx = { userId: from.id, chatId, text, from };
 
     // Flash-deal subscribe/unsubscribe (Feature 5). Only needs BOT_TOKEN.
     try {
-      if (await handleFlashSubStart(env, ctx)) return ok();
-      if (await handleStopCommand(env, ctx)) return ok();
+      if (await handleFlashSubStart(env, mctx)) return ok();
+      if (await handleStopCommand(env, mctx)) return ok();
     } catch (e) {}
 
     // Crowdsourced moderation (Feature 6). Only needs BOT_TOKEN.
     try {
-      if (await handleEditStart(env, ctx)) return ok();
-      if (await handleLeaderboardCommand(env, ctx)) return ok();
+      if (await handleEditStart(env, mctx)) return ok();
+      if (await handleLeaderboardCommand(env, mctx)) return ok();
     } catch (e) {}
 
     // Field-agent subsystems (stateful). Only when BOT_TOKEN + VISITS are set.
     if (c.enabled) {
       try {
-        if (await handleBountyStart(env, c, ctx)) return ok();
-        if (await handleBountyText(env, c, ctx)) return ok();
-        const consumed = await handleVisit(env, c, msg, ctx);
+        if (await handleBountyStart(env, c, mctx)) return ok();
+        if (await handleBountyText(env, c, mctx)) return ok();
+        const consumed = await handleVisit(env, c, msg, mctx);
         if (consumed) return ok();
       } catch (e) {
         // Never let the field flow break the public bot; ack and move on.


### PR DESCRIPTION
## Summary
- `index.html`: the "🤝 Share & Contribute" help text (both the JS-rendered `HELP.en`/`HELP.ua` sheet and the dead static fallback markup) still described the retired peer-to-peer share (link/file/code import) and a "pre-filled GitHub form" contribution flow. Updated to match what the 🤝 sheet actually offers today: share the app (link/QR), submit corrections to the official map, register your store, or save a backup. Bumped `APP_VERSION`.
- `telegram-bot/worker.js`: `handleAgentCallback` (menu taps, edit-review approvals, flash-deal publishes — anything that can call out to `dispatchMapPatch`/GitHub) was fully awaited before the webhook acked Telegram. A slow round trip in that chain can make Telegram time out and redeliver the same tap, double-processing it — this was the root cause of the edit-review failure fixed in #135 ("sub_ and bounty_ share the pattern"). Now the webhook acks immediately and runs the callback handler inside `ctx.waitUntil`, so a slow background call can no longer trigger a Telegram-side retry. The local per-message context object (previously also named `ctx`) was renamed to `mctx` to avoid shadowing the real Workers execution context.

## Test plan
- [x] `node scripts/validate-stores.mjs`
- [x] `node scripts/check-inline-js.mjs`
- [x] `node --check telegram-bot/worker.js`
- [x] Local test harness driving the real `fetch(request, env, ctx)` handler: confirmed the callback_query path now returns its `ok` ack before any Telegram API call fires, and that both calls (`answerCallbackQuery` + the reply) complete correctly once `ctx.waitUntil`'s promise is flushed
- [x] Re-ran the existing `/card` + `/agent` menu + callback-tap regression suite end-to-end — all behavior unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_