### PR TITLE
Add /admin fire and rehire to revoke agent access instantly

### DIFF
--- a/docs/FIELD_AGENT.md
+++ b/docs/FIELD_AGENT.md
@@ -245,8 +245,8 @@ One-time enablement of the `/visit` subsystem is documented in
 `OWNER_ID`, `AGENT_IDS`, and the rates). After that:
 
 `/agent` (agent · owner) opens a one-tap menu for the commands below; `/admin`
-(owner only) opens one for `/report`/`/export`. Each command below also still
-works typed directly — the menus are just a shortcut.
+(owner only) opens one for `/report`/`/export`/`/admin agents`. Each command
+below also still works typed directly — the menus are just a shortcut.
 
 | Command | Who | Does |
 |---|---|---|
@@ -259,7 +259,47 @@ works typed directly — the menus are just a shortcut.
 | `/cancel` | agent | abort the current survey |
 | `/report` | owner | totals, per-agent counts, **estimated pay** |
 | `/export` | owner | CSV of every logged visit |
+| `/admin agents` | owner | every configured agent, their tally, payout card, and active/fired status — with a one-tap 🔥 Fire / ♻️ Rehire button per agent |
+| `/admin fire <id>` | owner | revoke an agent's bot access immediately (see §7) |
+| `/admin rehire <id>` | owner | restore a fired agent's access immediately |
 
 Each submitted visit is also **pushed to the owner in real time** (photo +
 summary) for spot-checking. Reconcile `/export` against poster photos and form
 submissions before paying.
+
+---
+
+## 7. Offboarding · Звільнення
+
+Firing someone takes effect immediately — no redeploy, no waiting for a new
+Worker build. It doesn't touch `AGENT_IDS` at all (that's a deployment secret);
+instead a fired id is recorded separately, so it's just as instant to reverse.
+
+**To fire an agent:**
+1. `/admin` → **👥 Агенти · Agents** (or type `/admin agents`) — shows every
+   configured id with their running visit tally, payout card on file, and
+   current status. Use this to get the id and check what you'll still owe
+   *before* firing.
+2. Tap **🔥 Fire** next to their id. The bot shows a confirmation with their
+   final unpaid tally and payout card, so nothing gets missed. Tap **✅ Confirm
+   fire** — or use the direct `/admin fire <id>` if you already know the id and
+   want to skip the confirm step.
+3. That's it. The agent:
+   - immediately loses access to every field-agent command (`/visit`, `/route`,
+     `/card`, …) — they get the same "not a registered agent" message as
+     anyone who was never hired;
+   - is notified automatically by the bot that access was revoked;
+   - keeps their historical visit count in the system (still visible in
+     `/admin agents` and included in `/export`) so the final payout is never lost.
+4. **Settle the final balance** — pay out whatever `/admin agents` showed as
+   their unpaid tally, same as any weekly `/report`/`/export` reconciliation.
+5. **Reclaim materials** — any unused printed QR posters.
+
+**To reverse it:** tap **♻️ Rehire** next to their id in `/admin agents`, or
+`/admin rehire <id>`. Access is restored immediately and they're notified.
+
+*Звільнення діє миттєво. `/admin → 👥 Агенти` показує підсумок і картку кожного
+агента з кнопкою 🔥 Звільнити / ♻️ Відновити. Після звільнення агент одразу
+втрачає доступ до команд і отримує повідомлення від бота; історія його візитів
+зберігається для остаточного розрахунку. Відновлення — кнопкою ♻️ або
+`/admin rehire <id>`, теж миттєво.*

--- a/index.html
+++ b/index.html
@@ -598,8 +598,7 @@ header{ background:linear-gradient(118deg,var(--green2),var(--green)); }
     </div>
     <div class="help-section">
       <h3>🤝 Share & Contribute</h3>
-      <p>Tap the <strong>🤝</strong> button in the top-right to share the stores you've added or edited. <strong>Copy share link</strong> gives you a link — anyone who opens it gets your stores merged onto their map. You can also download a file, or paste in a link/file someone sent you to import theirs. Duplicates are skipped automatically.</p>
-      <p style="margin-top:8px;">To help everyone, tap <strong>🌍 Contribute to the official map</strong> — it opens a pre-filled GitHub form with your additions and corrections so they can be merged into the map that ships with the app.</p>
+      <p>Tap the <strong>🤝</strong> button in the top-right to share the app with a link or QR code, submit your additions and corrections to the official map, register your store if you own one, or save a backup of everything you've recorded on this device.</p>
     </div>
     <div class="help-section">
       <h3>📍 Open in Maps.me / Google Maps</h3>
@@ -2871,7 +2870,7 @@ const HELP = {
     ['✅ Visited','Tap the big green <strong>"Mark as Visited"</strong> button inside any store. It turns into a checkmark and the card gets a green border in the list.'],
     ['✏️ Edit or remove a store','Open any store and tap <strong>Edit Store</strong> to fix its details, or <strong>🗑️ Remove this store</strong> at the bottom. Stores <em>you</em> added are deleted; built-in stores are just hidden on your device — a <strong>"Restore all"</strong> link at the bottom of the list brings them back anytime.'],
     ['⚖️ KG vs Itemized','<strong>By KG</strong> stores charge by weight — you fill a bag and pay per kilogram, and prices drop every day. <strong>Itemized</strong> stores price each item individually.'],
-    ['🤝 Share & Contribute','Tap <strong>🤝</strong> to share the stores you\'ve added or edited via a link, file, or code — anyone who opens it merges them onto their map (duplicates are skipped). Tap <strong>🌍 Contribute to the official map</strong> to open a pre-filled GitHub form so your changes can ship with the app.'],
+    ['🤝 Share & Contribute','Tap <strong>🤝</strong> to share the app with a link or QR code, submit your additions and corrections to the official map, register your store if you own one, or save a backup of everything you\'ve recorded on this device.'],
     ['📍 Directions','Inside any store, tap <strong>📍 Maps.me</strong> or <strong>🗺️ Google Maps</strong> to jump straight to it for directions.'],
     ['💬 Telegram bot','Prefer chat? Message <strong><a href="https://t.me/Secondhandlvivbot" target="_blank" rel="noopener" style="color:var(--green);">@Secondhandlvivbot</a></strong> and send <strong>/today</strong> for stores restocking today, or <strong>/cheap</strong> for the best by-weight deals right now — each result links back here.'] ] },
   ua: { title:'Як користуватися додатком', got:'Зрозуміло!', sections:[
@@ -2881,7 +2880,7 @@ const HELP = {
     ['✅ Відвідані','Натисніть велику зелену кнопку <strong>«Відмітити як відвідане»</strong> у магазині. Вона стане галочкою, а картка отримає зелену рамку у списку.'],
     ['✏️ Редагувати чи видалити','Відкрийте магазин і натисніть <strong>«Редагувати»</strong>, щоб змінити деталі, або <strong>🗑️ Видалити магазин</strong> внизу. Магазини, <em>додані вами</em>, видаляються; вбудовані просто ховаються на вашому пристрої — посилання <strong>«Відновити всі»</strong> внизу списку поверне їх будь-коли.'],
     ['⚖️ На вагу чи поштучно','Магазини <strong>на вагу</strong> рахують за кілограм — наповнюєте пакет і платите за кг, ціни падають щодня. <strong>Поштучні</strong> оцінюють кожну річ окремо.'],
-    ['🤝 Обмін і внесок','Натисніть <strong>🤝</strong>, щоб поділитися доданими чи зміненими магазинами через посилання, файл або код — хто відкриє, додасть їх на свою карту (дублікати пропускаються). Натисніть <strong>🌍 Внести до офіційної карти</strong>, щоб відкрити заповнену форму GitHub і додати зміни до додатка.'],
+    ['🤝 Обмін і внесок','Натисніть <strong>🤝</strong>, щоб поділитися застосунком через посилання чи QR-код, надіслати доповнення й виправлення до офіційної карти, зареєструвати свій магазин або зберегти резервну копію всього записаного на цьому пристрої.'],
     ['📍 Маршрут','У магазині натисніть <strong>📍 Maps.me</strong> або <strong>🗺️ Google Maps</strong>, щоб одразу прокласти маршрут.'],
     ['💬 Телеграм-бот','Надаєте перевагу чату? Напишіть <strong><a href="https://t.me/Secondhandlvivbot" target="_blank" rel="noopener" style="color:var(--green);">@Secondhandlvivbot</a></strong> і надішліть <strong>/today</strong> — магазини із завезенням сьогодні, або <strong>/cheap</strong> — найкращі ціни на вагу зараз. Кожен результат посилається сюди.'] ] }
 };
@@ -2985,7 +2984,7 @@ if ('serviceWorker' in navigator) {
 // UPDATE CHECK — notify when a newer build is deployed, so nobody is stuck on
 // a cached version (no reinstall needed). Bump APP_VERSION on each deploy.
 // ─────────────────────────────────────────────
-const APP_VERSION = '2026-08-14.1';
+const APP_VERSION = '2026-08-14.2';
 
 // ─────────────────────────────────────────────
 // DONATIONS — points at a Stripe Payment Link (hosted checkout). No API keys

--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -1482,7 +1482,7 @@ async function handleQuestionsStart(env, uid, chatId, session) {
 }
 
 export default {
-  async fetch(request, env) {
+  async fetch(request, env, ctx) {
     // Health check.
     if (request.method === 'GET') {
       return ok('Lviv Second Hand Telegram bot is running.');
@@ -1507,8 +1507,13 @@ export default {
     const c = cfg(env);
 
     // Inline-keyboard taps (bounty flow) arrive as callback_query, not message.
+    // Ack Telegram immediately and finish in the background: dispatchMapPatch
+    // (GitHub) inside handleAgentCallback can be slow, and a slow webhook
+    // response makes Telegram redeliver the same tap — that double-processed
+    // an edit-review approval, fixed in #135. ctx.waitUntil keeps the Worker
+    // alive to finish the call after the response is already sent.
     if (update.callback_query) {
-      try { await handleAgentCallback(env, c, update.callback_query); } catch (e) {}
+      ctx.waitUntil(handleAgentCallback(env, c, update.callback_query).catch(() => {}));
       return ok();
     }
 
@@ -1517,26 +1522,26 @@ export default {
     const from = msg.from || {};
     const chatId = msg.chat.id;
     const text = typeof msg.text === 'string' ? msg.text : null;
-    const ctx = { userId: from.id, chatId, text, from };
+    const mctx = { userId: from.id, chatId, text, from };
 
     // Flash-deal subscribe/unsubscribe (Feature 5). Only needs BOT_TOKEN.
     try {
-      if (await handleFlashSubStart(env, ctx)) return ok();
-      if (await handleStopCommand(env, ctx)) return ok();
+      if (await handleFlashSubStart(env, mctx)) return ok();
+      if (await handleStopCommand(env, mctx)) return ok();
     } catch (e) {}
 
     // Crowdsourced moderation (Feature 6). Only needs BOT_TOKEN.
     try {
-      if (await handleEditStart(env, ctx)) return ok();
-      if (await handleLeaderboardCommand(env, ctx)) return ok();
+      if (await handleEditStart(env, mctx)) return ok();
+      if (await handleLeaderboardCommand(env, mctx)) return ok();
     } catch (e) {}
 
     // Field-agent subsystems (stateful). Only when BOT_TOKEN + VISITS are set.
     if (c.enabled) {
       try {
-        if (await handleBountyStart(env, c, ctx)) return ok();
-        if (await handleBountyText(env, c, ctx)) return ok();
-        const consumed = await handleVisit(env, c, msg, ctx);
+        if (await handleBountyStart(env, c, mctx)) return ok();
+        if (await handleBountyText(env, c, mctx)) return ok();
+        const consumed = await handleVisit(env, c, msg, mctx);
         if (consumed) return ok();
       } catch (e) {
         // Never let the field flow break the public bot; ack and move on.

--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -34,6 +34,10 @@
 //   /cancel       — abort an in-progress /visit
 //   /report       — OWNER only: totals, per-agent counts, estimated pay
 //   /export       — OWNER only: CSV of all logged visits
+//   /admin agents — OWNER only: every agent's tally/card/status + fire/rehire buttons
+//   /admin fire <id>, /admin rehire <id> — OWNER only: revoke/restore an
+//                    agent's access instantly (KV-backed, no redeploy — see
+//                    docs/FIELD_AGENT.md §7)
 //
 // The survey the agent fills in is the field questionnaire from
 // docs/FIELD_AGENT.md — that doc is the single source of truth for the process,
@@ -283,11 +287,29 @@ const QUESTIONS = [
   { key: 'notes', q: '9️⃣ Нотатки? (або «-») · Notes? (or "-")', kb: null },
 ];
 
-function cfg(env) {
+// Firing an agent doesn't touch AGENT_IDS (that's a Worker secret — editing it
+// needs a redeploy). Instead a fired id is recorded in KV and subtracted from
+// agentIds below, so /admin fire takes effect immediately and /admin rehire
+// reverses it just as fast, no redeploy either way.
+const FIRED_KEY = 'fired_agents';
+async function getFiredIds(env) {
+  if (!env.VISITS) return [];
+  try { return (await env.VISITS.get(FIRED_KEY, { type: 'json' })) || []; } catch { return []; }
+}
+async function setFiredIds(env, ids) {
+  await env.VISITS.put(FIRED_KEY, JSON.stringify(ids));
+}
+
+async function cfg(env) {
+  const allAgentIds = String(env.AGENT_IDS || '').split(',').map((s) => s.trim()).filter(Boolean);
+  const firedIds = await getFiredIds(env);
+  const firedSet = new Set(firedIds.map(String));
   return {
     enabled: Boolean(env.BOT_TOKEN && env.VISITS),
     ownerId: String(env.OWNER_ID || ''),
-    agentIds: String(env.AGENT_IDS || '').split(',').map((s) => s.trim()).filter(Boolean),
+    agentIds: allAgentIds.filter((id) => !firedSet.has(id)),
+    allAgentIds, // unfiltered — /admin agents needs to show fired ones too
+    firedIds,
     rateVisit: Number(env.RATE_VISIT || 80),
     rateBonus: Number(env.RATE_BONUS || 200),
   };
@@ -601,6 +623,11 @@ async function handleAgentCallback(env, c, cq) {
     if (!isOwner2) return;
     if (val === 'report') { await ownerReport(env, c, chatId); return; }
     if (val === 'export') { await ownerExport(env, chatId); return; }
+    if (val === 'agents') { await cmdAdminAgents(env, c, chatId); return; }
+    if (val === 'fireabort') { await tg(env, 'sendMessage', { chat_id: chatId, text: 'Скасовано. · Cancelled.' }); return; }
+    if (val.startsWith('firereq:')) { await cmdFireRequest(env, c, chatId, val.slice(8)); return; }
+    if (val.startsWith('firedo:')) { await cmdFireDo(env, c, chatId, val.slice(7)); return; }
+    if (val.startsWith('rehire:')) { await cmdRehire(env, c, chatId, val.slice(7)); return; }
     return;
   }
 
@@ -1236,7 +1263,100 @@ async function cmdAdminMenu(env, chatId) {
     text: '⚙️ <b>Адмін-меню · Admin menu</b>', reply_markup: { inline_keyboard: [
       [{ text: '📈 Звіт · Report', callback_data: 'ad:report' }],
       [{ text: '📤 Експорт · Export', callback_data: 'ad:export' }],
+      [{ text: '👥 Агенти · Agents', callback_data: 'ad:agents' }],
     ] } });
+}
+
+// Lists every id in AGENT_IDS (owner included, marked separately) with their
+// running tally, payout card, and active/fired status — plus a one-tap
+// fire/rehire button per agent. This is the "who has access" view an owner
+// checks before firing someone, so the final tally is right there.
+async function cmdAdminAgents(env, c, chatId) {
+  if (!c.allAgentIds.length) {
+    await tg(env, 'sendMessage', { chat_id: chatId, text: 'Немає налаштованих агентів (AGENT_IDS порожній). · No agents configured (AGENT_IDS is empty).' });
+    return;
+  }
+  const firedSet = new Set(c.firedIds.map(String));
+  const lines = ['👥 <b>Агенти · Agents</b>'];
+  const rows = [];
+  for (const id of c.allAgentIds) {
+    const isOwnerId = Boolean(c.ownerId) && id === c.ownerId;
+    const fired = firedSet.has(id);
+    const n = Number((await env.VISITS.get('count:agent:' + id)) || 0);
+    const card = await env.VISITS.get(cardKey(id));
+    const status = isOwnerId ? '👑 owner' : fired ? '🔴 fired' : '🟢 active';
+    lines.push(`• <code>${id}</code> ${status} — ${n} visits${card ? ` · 💳 <code>${esc(card)}</code>` : ' · ⚠️ no card'}`);
+    if (!isOwnerId) {
+      rows.push([fired
+        ? { text: `♻️ Rehire ${id}`, callback_data: `ad:rehire:${id}` }
+        : { text: `🔥 Fire ${id}`, callback_data: `ad:firereq:${id}` }]);
+    }
+  }
+  await tg(env, 'sendMessage', { chat_id: chatId, parse_mode: 'HTML', text: lines.join('\n'),
+    reply_markup: rows.length ? { inline_keyboard: rows } : undefined });
+}
+
+// 🔥 Fire tap → a confirm step (firing is consequential and hard to notice if
+// mistapped). The typed /admin fire <id> command skips straight to
+// cmdFireDo — typing the exact id out is itself the deliberate act.
+async function cmdFireRequest(env, c, chatId, targetId) {
+  if (!c.allAgentIds.includes(targetId) || targetId === c.ownerId) {
+    await tg(env, 'sendMessage', { chat_id: chatId, text: '⚠️ Invalid agent id.' });
+    return;
+  }
+  const n = Number((await env.VISITS.get('count:agent:' + targetId)) || 0);
+  const card = await env.VISITS.get(cardKey(targetId));
+  await tg(env, 'sendMessage', { chat_id: chatId, parse_mode: 'HTML',
+    text: `⚠️ Fire agent <code>${targetId}</code>?\nThey lose bot access immediately.\n` +
+      `Final tally: <b>${n} visits</b>${card ? ` · payout card <code>${esc(card)}</code>` : ' · no payout card on file'}.\n` +
+      `Settle any unpaid balance before/with this.`,
+    reply_markup: { inline_keyboard: [[
+      { text: '✅ Confirm fire', callback_data: `ad:firedo:${targetId}` },
+      { text: '❌ Cancel', callback_data: 'ad:fireabort' },
+    ]] } });
+}
+async function cmdFireDo(env, c, chatId, targetId) {
+  if (!c.allAgentIds.includes(targetId) || targetId === c.ownerId) {
+    await say(env, chatId, '⚠️ Invalid agent id.');
+    return;
+  }
+  const fired = new Set((await getFiredIds(env)).map(String));
+  fired.add(targetId);
+  await setFiredIds(env, [...fired]);
+  const n = Number((await env.VISITS.get('count:agent:' + targetId)) || 0);
+  await say(env, chatId,
+    `🔥 Звільнено · Fired <code>${targetId}</code>. Доступ скасовано негайно · Bot access revoked immediately.\n` +
+    `Останній непроплачений підсумок · Final unpaid tally: <b>${n} visits</b> — settle before closing the books.\n` +
+    `Заберіть невикористані QR-плакати · Reclaim any unused QR posters.\n` +
+    `Можна скасувати будь-коли · Reversible anytime: ♻️ Rehire, or <code>/admin rehire ${targetId}</code>.`);
+  // A failed DM (blocked the bot, chat never started) shouldn't hide the
+  // owner's confirmation above — the firing itself already took effect.
+  try {
+    await say(env, targetId,
+      '🔒 Ваш доступ до бота польового агента скасовано власником. Дякуємо за роботу. · ' +
+      'Your field-agent bot access has been revoked by the owner. Thanks for the work.');
+    // Drop /agent from their command list right away; without this it lingers
+    // in the Telegram UI (harmlessly — tapping it still hits notAgentMsg) until
+    // the next CMD_VER bump. Clear the sync cache too so a later rehire re-adds it.
+    await tg(env, 'setMyCommands', { commands: PUBLIC_CMDS, scope: { type: 'chat', chat_id: targetId } });
+    await env.VISITS.delete('cmds:' + targetId);
+  } catch (e) {}
+}
+async function cmdRehire(env, c, chatId, targetId) {
+  if (!c.allAgentIds.includes(targetId)) {
+    await say(env, chatId, '⚠️ Invalid agent id.');
+    return;
+  }
+  const fired = (await getFiredIds(env)).map(String).filter((id) => id !== targetId);
+  await setFiredIds(env, fired);
+  await say(env, chatId, `♻️ Rehired <code>${targetId}</code>. Access restored.`);
+  try {
+    await say(env, targetId,
+      '✅ Ваш доступ до бота польового агента відновлено. Ласкаво просимо назад! · ' +
+      'Your field-agent bot access has been restored. Welcome back!');
+    // Force a re-sync so /agent reappears in their command list next message.
+    await env.VISITS.delete('cmds:' + targetId);
+  } catch (e) {}
 }
 
 // Handle an update for the visit subsystem. Returns true if it consumed the update.
@@ -1257,6 +1377,19 @@ async function handleVisit(env, c, msg, ctx) {
   }
   if (command === 'admin') {
     if (!isOwner) { await say(env, chatId, notAgentMsg(userId)); return true; }
+    // Subcommands typed directly, e.g. "/admin fire 123456" — the menu button
+    // path (ad:agents → ad:firereq: → confirm) is for browsing/one-tap use;
+    // typing the exact id out is itself the deliberate act, so this skips
+    // the confirm step and fires/rehires immediately.
+    const rest = (text || '').replace(/^\/admin(?:@\w+)?\s*/i, '').trim();
+    const m = /^(fire|rehire)\s+(\S+)/i.exec(rest);
+    if (m) {
+      const targetId = m[2].replace(/\D/g, '');
+      if (m[1].toLowerCase() === 'fire') await cmdFireDo(env, c, chatId, targetId);
+      else await cmdRehire(env, c, chatId, targetId);
+      return true;
+    }
+    if (/^agents$/i.test(rest)) { await cmdAdminAgents(env, c, chatId); return true; }
     await cmdAdminMenu(env, chatId);
     return true;
   }
@@ -1504,7 +1637,7 @@ export default {
       return ok(); // Malformed body — ack so Telegram doesn't retry forever.
     }
 
-    const c = cfg(env);
+    const c = await cfg(env);
 
     // Inline-keyboard taps (bounty flow) arrive as callback_query, not message.
     // Ack Telegram immediately and finish in the background: dispatchMapPatch


### PR DESCRIPTION
## Summary
- `telegram-bot/worker.js`: `cfg()` now subtracts a KV-backed "fired agents" list from `AGENT_IDS` (which stays a Worker secret, unchanged). This makes firing/rehiring instant with no redeploy:
  - `/admin agents` (or the 👥 button in `/admin`) lists every configured agent with their visit tally, payout card, and active/fired status, plus a one-tap 🔥 Fire / ♻️ Rehire button per agent.
  - Tapping 🔥 Fire shows a confirm step with the agent's final unpaid tally before acting — mistaps are recoverable. `/admin fire <id>` typed directly skips the confirm step (typing the exact id is itself the deliberate act).
  - Firing revokes every field-agent command instantly (same "not a registered agent" message anyone-never-hired gets), notifies the fired agent automatically, and drops `/agent` from their Telegram command list. Their historical visit count is preserved (still visible in `/admin agents` and `/export`) so the final payout is never lost.
  - `/admin rehire <id>` (or the ♻️ button) restores access immediately and notifies them.
- `docs/FIELD_AGENT.md`: new §7 "Offboarding" documenting the full procedure (check tally → fire → settle final pay → reclaim materials), plus the new commands in the §6 reference table.

## Test plan
- [x] `node --check telegram-bot/worker.js`
- [x] `node scripts/validate-stores.mjs`
- [x] `node scripts/check-inline-js.mjs`
- [x] Local test harness driving the real webhook handler end-to-end: agent has access → owner views `/admin agents` → fires via button confirm flow → fired agent is locked out of `/visit` and notified → `/report` correctly excludes them from the active-agent list while their historical count stays intact → owner rehires via typed `/admin rehire` → agent regains access and is notified → owner cannot fire themselves (rejected)
- [x] Re-ran the existing `/card` + `/agent` menu + `ctx.waitUntil` callback regression suites — all unaffected by making `cfg()` async


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_