### PR TITLE
Add robots.txt, sitemap.xml and schema.org structured data

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,68 @@
 <meta name="twitter:title" content="Секонд-хенди Львова — карта, ціни та завезення">
 <meta name="twitter:description" content="Усі секонд-хенди Львова на одній карті: години, ціни та дні завезення. Безкоштовно, працює офлайн.">
 <meta name="twitter:image" content="https://www.lvivsecondhand.com/og-image.png">
+<!-- Structured data (schema.org / JSON-LD). Describes the app itself; per-store
+     LocalBusiness entries belong with per-store URLs, which don't exist yet —
+     stores are rendered client-side on this one page. Everything here is
+     verifiable from the page: no ratings or review counts, since there is no
+     rating system to source them from. -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "@id": "https://www.lvivsecondhand.com/#website",
+      "url": "https://www.lvivsecondhand.com/",
+      "name": "Секонд-хенди Львова · Lviv Second Hand",
+      "description": "Усі секонд-хенди Львова на одній карті: години роботи, ціни на вагу та поштучно, дні завезення і коли найдешевше.",
+      "inLanguage": ["uk-UA", "en"],
+      "publisher": { "@id": "https://www.lvivsecondhand.com/#org" }
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://www.lvivsecondhand.com/#org",
+      "name": "Lviv Second Hand",
+      "url": "https://www.lvivsecondhand.com/",
+      "logo": "https://www.lvivsecondhand.com/icon-512.png",
+      "sameAs": ["https://t.me/Secondhandlvivbot"]
+    },
+    {
+      "@type": "WebApplication",
+      "@id": "https://www.lvivsecondhand.com/#app",
+      "name": "Секонд-хенди Львова · Lviv Second Hand",
+      "url": "https://www.lvivsecondhand.com/",
+      "description": "Карта секонд-хенд магазинів Львова з годинами роботи, типом цін, датами завезення та трекером циклу знижок. Працює офлайн, без реєстрації.",
+      "applicationCategory": "TravelApplication",
+      "operatingSystem": "Any (web browser)",
+      "browserRequirements": "Requires JavaScript.",
+      "inLanguage": ["uk-UA", "en"],
+      "isAccessibleForFree": true,
+      "offers": { "@type": "Offer", "price": "0", "priceCurrency": "UAH" },
+      "featureList": [
+        "Карта секонд-хендів Львова",
+        "Години роботи та адреси",
+        "Ціни на вагу та поштучно",
+        "Дні завезення нового товару",
+        "Трекер циклу знижок",
+        "Працює офлайн"
+      ],
+      "screenshot": "https://www.lvivsecondhand.com/og-image.png",
+      "publisher": { "@id": "https://www.lvivsecondhand.com/#org" },
+      "about": {
+        "@type": "Place",
+        "name": "Львів",
+        "alternateName": "Lviv",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Львів",
+          "addressCountry": "UA"
+        }
+      }
+    }
+  ]
+}
+</script>
 <link rel="manifest" href="manifest.webmanifest">
 <link rel="icon" href="favicon.svg" type="image/svg+xml">
 <link rel="icon" href="favicon-32.png" sizes="32x32" type="image/png">
@@ -2984,7 +3046,7 @@ if ('serviceWorker' in navigator) {
 // UPDATE CHECK — notify when a newer build is deployed, so nobody is stuck on
 // a cached version (no reinstall needed). Bump APP_VERSION on each deploy.
 // ─────────────────────────────────────────────
-const APP_VERSION = '2026-08-14.2';
+const APP_VERSION = '2026-08-15.1';
 
 // ─────────────────────────────────────────────
 // DONATIONS — points at a Stripe Payment Link (hosted checkout). No API keys

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,18 @@
+# Lviv Second Hand — https://www.lvivsecondhand.com/
+# The app is a single page; store data is fetched from stores.json and rendered
+# client-side. Crawlers are welcome on everything a visitor can reach.
+
+User-agent: *
+Allow: /
+
+# Nothing user-facing lives here — build tooling, the printable marketing pack,
+# and the Worker sources. Excluded to keep the crawl focused on real pages.
+Disallow: /scripts/
+Disallow: /tools/
+Disallow: /vendor/
+Disallow: /worker/
+Disallow: /telegram-bot/
+Disallow: /native/
+Disallow: /marketing/
+
+Sitemap: https://www.lvivsecondhand.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Every public page on the site. This is short by design: the app is a single
+  page that renders all 93 stores client-side, so there is currently one URL to
+  index rather than one per store. Per-store URLs are a separate change.
+-->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://www.lvivsecondhand.com/</loc>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://www.lvivsecondhand.com/jobs/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://www.lvivsecondhand.com/privacy.html</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.1</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary

The site had no `robots.txt`, no `sitemap.xml`, and no structured data, so search engines were finding it by links alone with no machine-readable description of what it is. The existing on-page basics (title, description, canonical, OG/Twitter, `lang`, `<h1>`) were already in good shape.

- **`robots.txt`** — allows everything a visitor can reach and points at the sitemap. Disallows build tooling and Worker sources (`/scripts`, `/tools`, `/vendor`, `/worker`, `/telegram-bot`, `/native`, `/marketing`) so crawl budget goes to real pages.
- **`sitemap.xml`** — the three public URLs: `/`, `/jobs/`, `/privacy.html`. Short by design: all 93 stores render client-side on a single page, so there is currently one indexable URL rather than one per store.
- **`index.html`** — JSON-LD `@graph` with `WebSite`, `Organization`, and `WebApplication` (name, description, free `offers`, `featureList`, `inLanguage`, and the Lviv `Place` it's about).

Two deliberate restraints:
- **No `aggregateRating` or review counts.** The app has no rating system, so any numbers would be fabricated — false, and a well-known spam signal that risks a manual action.
- **No per-store `LocalBusiness` entries.** Those belong with per-store URLs, which don't exist yet; emitting 92 of them against a single URL adds ~18KB for little ranking benefit. That's the follow-up change.

The `wm1` dataset watermark is excluded from everything published here, matching how `allStores()` (`index.html:1399`) filters it out of the app — publishing it would both expose the copyright trap and assert a fake business as real.

## Test plan
- [x] `node scripts/validate-stores.mjs`, `node scripts/check-inline-js.mjs`
- [x] JSON-LD parses as valid JSON; `@graph` resolves to WebSite / Organization / WebApplication
- [x] `sitemap.xml` parses as well-formed XML against the sitemaps.org namespace
- [x] Served locally: `robots.txt` → 200 `text/plain`, `sitemap.xml` → 200 `application/xml`; all three sitemap URLs return 200 (no phantom entries)
- [x] Playwright against the local server: JSON-LD present and parsing in the rendered DOM, title/canonical intact, 460 store cards still render, zero page errors
- [x] Confirmed `wm1` / its name appears in none of the published files
- [x] `APP_VERSION` bumped to `2026-08-15.1`


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_