### PR TITLE
Keep the 2-week HUMANA stores off the chain collection calendar

### DIFF
--- a/store/h2/index.html
+++ b/store/h2/index.html
@@ -5,12 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="theme-color" content="#17693a">
 <title>HUMANA — Lyubinska — вул. Любинська, 100 (2 поверх) · Секонд-хенд Львів</title>
-<meta name="description" content="HUMANA — Lyubinska — секонд-хенд у Львові, за адресою вул. Любинська, 100 (2 поверх), поштучно (ціна за річ), останнє завезення: 2026-07-06 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta name="description" content="HUMANA — Lyubinska — секонд-хенд у Львові, за адресою вул. Любинська, 100 (2 поверх), поштучно (ціна за річ). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <link rel="canonical" href="https://www.lvivsecondhand.com/store/h2/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Lviv Second Hand">
 <meta property="og:title" content="HUMANA — Lyubinska — вул. Любинська, 100 (2 поверх) · Секонд-хенд Львів">
-<meta property="og:description" content="HUMANA — Lyubinska — секонд-хенд у Львові, за адресою вул. Любинська, 100 (2 поверх), поштучно (ціна за річ), останнє завезення: 2026-07-06 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta property="og:description" content="HUMANA — Lyubinska — секонд-хенд у Львові, за адресою вул. Любинська, 100 (2 поверх), поштучно (ціна за річ). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <meta property="og:url" content="https://www.lvivsecondhand.com/store/h2/">
 <meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
 <meta property="og:locale" content="uk_UA">
@@ -126,8 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Телефон</th><td><a href="tel:032240440">(032) 24-04-40</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
       <tr><th scope="row">Мережа</th><td>HUMANA</td></tr>
-      <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-07-06 (за офіційним календарем)</td></tr>
-      <tr><th scope="row">Цикл знижок</th><td>35 дн.</td></tr>
+      <tr><th scope="row">Цикл знижок</th><td>14 дн.</td></tr>
     </tbody>
   </table>
 
@@ -144,25 +143,8 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     </tbody>
   </table>
 
-  <h2>Календар завезень 2026</h2>
-  <p class="dim" style="font-size:14px;margin:-4px 0 10px;">Офіційний графік нових колекцій мережі.</p>
-  <table>
-    <tbody>
-      <tr><th scope="row">2026-01-12</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-02-16</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-03-23</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-04-27</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-06-01</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-07-06</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-08-17</th><td>заплановано</td></tr>
-      <tr><th scope="row">2026-09-21</th><td>заплановано</td></tr>
-      <tr><th scope="row">2026-10-26</th><td>заплановано</td></tr>
-      <tr><th scope="row">2026-11-30</th><td>заплановано</td></tr>
-    </tbody>
-  </table>
-
   <h2>Примітки</h2>
-  <p class="note">2nd floor entrance. New collections follow the chain’s 5-week calendar.</p>
+  <p class="note">2nd floor entrance. 2-week inventory cycle.</p>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/h4/index.html
+++ b/store/h4/index.html
@@ -5,12 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="theme-color" content="#17693a">
 <title>HUMANA — Sykhivska — вул. Сиховська, 18 · Секонд-хенд Львів</title>
-<meta name="description" content="HUMANA — Sykhivska — секонд-хенд у Львові, за адресою вул. Сиховська, 18, поштучно (ціна за річ), останнє завезення: 2026-07-06 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta name="description" content="HUMANA — Sykhivska — секонд-хенд у Львові, за адресою вул. Сиховська, 18, поштучно (ціна за річ). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <link rel="canonical" href="https://www.lvivsecondhand.com/store/h4/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Lviv Second Hand">
 <meta property="og:title" content="HUMANA — Sykhivska — вул. Сиховська, 18 · Секонд-хенд Львів">
-<meta property="og:description" content="HUMANA — Sykhivska — секонд-хенд у Львові, за адресою вул. Сиховська, 18, поштучно (ціна за річ), останнє завезення: 2026-07-06 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta property="og:description" content="HUMANA — Sykhivska — секонд-хенд у Львові, за адресою вул. Сиховська, 18, поштучно (ціна за річ). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <meta property="og:url" content="https://www.lvivsecondhand.com/store/h4/">
 <meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
 <meta property="og:locale" content="uk_UA">
@@ -126,8 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Телефон</th><td><a href="tel:0322210140">(032) 221-01-40</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
       <tr><th scope="row">Мережа</th><td>HUMANA</td></tr>
-      <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-07-06 (за офіційним календарем)</td></tr>
-      <tr><th scope="row">Цикл знижок</th><td>35 дн.</td></tr>
+      <tr><th scope="row">Цикл знижок</th><td>14 дн.</td></tr>
     </tbody>
   </table>
 
@@ -144,25 +143,8 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     </tbody>
   </table>
 
-  <h2>Календар завезень 2026</h2>
-  <p class="dim" style="font-size:14px;margin:-4px 0 10px;">Офіційний графік нових колекцій мережі.</p>
-  <table>
-    <tbody>
-      <tr><th scope="row">2026-01-12</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-02-16</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-03-23</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-04-27</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-06-01</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-07-06</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-08-17</th><td>заплановано</td></tr>
-      <tr><th scope="row">2026-09-21</th><td>заплановано</td></tr>
-      <tr><th scope="row">2026-10-26</th><td>заплановано</td></tr>
-      <tr><th scope="row">2026-11-30</th><td>заплановано</td></tr>
-    </tbody>
-  </table>
-
   <h2>Примітки</h2>
-  <p class="note">Sykhiv district. New collections follow the chain’s 5-week calendar.</p>
+  <p class="note">Sykhiv district. 2-week inventory cycle.</p>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/h5/index.html
+++ b/store/h5/index.html
@@ -5,12 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="theme-color" content="#17693a">
 <title>HUMANA — Shyroka — вул. Широка, 81а · Секонд-хенд Львів</title>
-<meta name="description" content="HUMANA — Shyroka — секонд-хенд у Львові, за адресою вул. Широка, 81а, поштучно (ціна за річ), останнє завезення: 2026-07-06 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta name="description" content="HUMANA — Shyroka — секонд-хенд у Львові, за адресою вул. Широка, 81а, поштучно (ціна за річ). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <link rel="canonical" href="https://www.lvivsecondhand.com/store/h5/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Lviv Second Hand">
 <meta property="og:title" content="HUMANA — Shyroka — вул. Широка, 81а · Секонд-хенд Львів">
-<meta property="og:description" content="HUMANA — Shyroka — секонд-хенд у Львові, за адресою вул. Широка, 81а, поштучно (ціна за річ), останнє завезення: 2026-07-06 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta property="og:description" content="HUMANA — Shyroka — секонд-хенд у Львові, за адресою вул. Широка, 81а, поштучно (ціна за річ). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <meta property="og:url" content="https://www.lvivsecondhand.com/store/h5/">
 <meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
 <meta property="og:locale" content="uk_UA">
@@ -126,8 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Телефон</th><td><a href="tel:0322458780">(032) 245-87-80</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
       <tr><th scope="row">Мережа</th><td>HUMANA</td></tr>
-      <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-07-06 (за офіційним календарем)</td></tr>
-      <tr><th scope="row">Цикл знижок</th><td>35 дн.</td></tr>
+      <tr><th scope="row">Цикл знижок</th><td>14 дн.</td></tr>
     </tbody>
   </table>
 
@@ -144,25 +143,8 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     </tbody>
   </table>
 
-  <h2>Календар завезень 2026</h2>
-  <p class="dim" style="font-size:14px;margin:-4px 0 10px;">Офіційний графік нових колекцій мережі.</p>
-  <table>
-    <tbody>
-      <tr><th scope="row">2026-01-12</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-02-16</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-03-23</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-04-27</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-06-01</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-07-06</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-08-17</th><td>заплановано</td></tr>
-      <tr><th scope="row">2026-09-21</th><td>заплановано</td></tr>
-      <tr><th scope="row">2026-10-26</th><td>заплановано</td></tr>
-      <tr><th scope="row">2026-11-30</th><td>заплановано</td></tr>
-    </tbody>
-  </table>
-
   <h2>Примітки</h2>
-  <p class="note">New collections follow the chain’s 5-week calendar.</p>
+  <p class="note">2-week inventory cycle.</p>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/stores.json
+++ b/stores.json
@@ -82,22 +82,10 @@
       "sat": "10:00–20:00",
       "sun": "10:00–20:00"
     },
-    "cycle": 35,
+    "cycle": 14,
     "lat": 49.822719,
     "lng": 23.973377,
-    "note": "2nd floor entrance. New collections follow the chain’s 5-week calendar.",
-    "restockDates": [
-      "2026-01-12",
-      "2026-02-16",
-      "2026-03-23",
-      "2026-04-27",
-      "2026-06-01",
-      "2026-07-06",
-      "2026-08-17",
-      "2026-09-21",
-      "2026-10-26",
-      "2026-11-30"
-    ]
+    "note": "2nd floor entrance. 2-week inventory cycle."
   },
   {
     "id": "h3",
@@ -152,22 +140,10 @@
       "sat": "10:00–20:00",
       "sun": "10:00–20:00"
     },
-    "cycle": 35,
+    "cycle": 14,
     "lat": 49.794862,
     "lng": 24.063585,
-    "note": "Sykhiv district. New collections follow the chain’s 5-week calendar.",
-    "restockDates": [
-      "2026-01-12",
-      "2026-02-16",
-      "2026-03-23",
-      "2026-04-27",
-      "2026-06-01",
-      "2026-07-06",
-      "2026-08-17",
-      "2026-09-21",
-      "2026-10-26",
-      "2026-11-30"
-    ]
+    "note": "Sykhiv district. 2-week inventory cycle."
   },
   {
     "id": "h5",
@@ -187,22 +163,10 @@
       "sat": "10:00–20:00",
       "sun": "10:00–20:00"
     },
-    "cycle": 35,
+    "cycle": 14,
     "lat": 49.841221,
     "lng": 23.96754,
-    "note": "New collections follow the chain’s 5-week calendar.",
-    "restockDates": [
-      "2026-01-12",
-      "2026-02-16",
-      "2026-03-23",
-      "2026-04-27",
-      "2026-06-01",
-      "2026-07-06",
-      "2026-08-17",
-      "2026-09-21",
-      "2026-10-26",
-      "2026-11-30"
-    ]
+    "note": "2-week inventory cycle."
   },
   {
     "id": "h6",


### PR DESCRIPTION
## Summary

`h2`, `h4` and `h5` are documented from field observation as running a **2-week inventory cycle**. The chain's published calendar tracks new *collections*, which isn't the same event as a delivery — so applying it to those three overrode real observed data with an assumption. Corrects #170.

Reverted to their **exact** pre-change records: `cycle: 14`, no `restockDates`, and the original note wording restored verbatim (verified byte-identical against the commit before the change).

The calendar stays on `h1`, `h3`, `h6` and `h7` — none of which carry a conflicting observation, and whose own notes already describe a 5-week cycle.

### Resulting state

| store | cycle | calendar | tracker |
|---|---|---|---|
| h1, h3, h6, h7 | 35 | 10 dates | day 40/42, next in 2d (`calendar`) |
| h2, h4, h5 | 14 | — | hidden (no anchor date) |

**Worth knowing:** h2, h4 and h5 have a cycle length but no anchor date, so their tracker stays hidden until someone records a delivery. That was already true before any of this — it's honest rather than guessing a start point — but it does mean a single `/visit` recording one delivery date at each would switch on a working 14-day tracker for all three. Good candidate for the next field round.

## Test plan
- [x] h2/h4/h5 verified byte-identical to their records in `b91e3be` (pre-change)
- [x] Browser: h1/h3/h6/h7 compute `day 40/42, next in 2d, source calendar`; h2/h4/h5 correctly show no tracker; zero page errors
- [x] `validate-stores.mjs`, `check-inline-js.mjs`
- [x] Store pages, QR posters, sitemap and bot dataset regenerated so the CI sync guards pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_