### PR TITLE
Add Sunday closure and 24 UAH sale notices to the HUMANA stores

### DIFF
--- a/stores.json
+++ b/stores.json
@@ -46,10 +46,10 @@
     "lng": 24.008012,
     "note": "Large store. 5-week inventory cycle. Prices drop every day after delivery. Lucky hours: 30% off all items.",
     "flashDeal": {
+      "text": "НД 16.08: 10:00–14:00 · ВСЕ ПО 24 ₴ · Sun 16.08: 10:00–14:00, everything ₴24",
       "alert": false,
-      "expiresAt": "2026-08-12T23:20:16.029Z",
-      "startsAt": "2026-08-12T20:20:16.029Z",
-      "text": "30% off next week. All summer clothes"
+      "startsAt": "2026-08-15T16:20:00.000Z",
+      "expiresAt": "2026-08-16T21:00:00.000Z"
     },
     "restockDates": [
       "2026-01-12",
@@ -85,7 +85,13 @@
     "cycle": 14,
     "lat": 49.822719,
     "lng": 23.973377,
-    "note": "2nd floor entrance. 2-week inventory cycle."
+    "note": "2nd floor entrance. 2-week inventory cycle.",
+    "flashDeal": {
+      "text": "НД 16.08 зачинено · нова колекція в понеділок 17.08 · Closed Sun 16.08, new collection Mon 17.08",
+      "alert": false,
+      "startsAt": "2026-08-15T16:20:00.000Z",
+      "expiresAt": "2026-08-16T21:00:00.000Z"
+    }
   },
   {
     "id": "h3",
@@ -120,7 +126,13 @@
       "2026-09-21",
       "2026-10-26",
       "2026-11-30"
-    ]
+    ],
+    "flashDeal": {
+      "text": "НД 16.08 зачинено · нова колекція в понеділок 17.08 · Closed Sun 16.08, new collection Mon 17.08",
+      "alert": false,
+      "startsAt": "2026-08-15T16:20:00.000Z",
+      "expiresAt": "2026-08-16T21:00:00.000Z"
+    }
   },
   {
     "id": "h4",
@@ -143,7 +155,13 @@
     "cycle": 14,
     "lat": 49.794862,
     "lng": 24.063585,
-    "note": "Sykhiv district. 2-week inventory cycle."
+    "note": "Sykhiv district. 2-week inventory cycle.",
+    "flashDeal": {
+      "text": "НД 16.08 зачинено · нова колекція в понеділок 17.08 · Closed Sun 16.08, new collection Mon 17.08",
+      "alert": false,
+      "startsAt": "2026-08-15T16:20:00.000Z",
+      "expiresAt": "2026-08-16T21:00:00.000Z"
+    }
   },
   {
     "id": "h5",
@@ -166,7 +184,13 @@
     "cycle": 14,
     "lat": 49.841221,
     "lng": 23.96754,
-    "note": "2-week inventory cycle."
+    "note": "2-week inventory cycle.",
+    "flashDeal": {
+      "text": "НД 16.08 зачинено · нова колекція в понеділок 17.08 · Closed Sun 16.08, new collection Mon 17.08",
+      "alert": false,
+      "startsAt": "2026-08-15T16:20:00.000Z",
+      "expiresAt": "2026-08-16T21:00:00.000Z"
+    }
   },
   {
     "id": "h6",
@@ -201,7 +225,13 @@
       "2026-09-21",
       "2026-10-26",
       "2026-11-30"
-    ]
+    ],
+    "flashDeal": {
+      "text": "НД 16.08 зачинено · нова колекція в понеділок 17.08 · Closed Sun 16.08, new collection Mon 17.08",
+      "alert": false,
+      "startsAt": "2026-08-15T16:20:00.000Z",
+      "expiresAt": "2026-08-16T21:00:00.000Z"
+    }
   },
   {
     "id": "h7",
@@ -236,7 +266,13 @@
       "2026-09-21",
       "2026-10-26",
       "2026-11-30"
-    ]
+    ],
+    "flashDeal": {
+      "text": "НД 16.08 зачинено · нова колекція в понеділок 17.08 · Closed Sun 16.08, new collection Mon 17.08",
+      "alert": false,
+      "startsAt": "2026-08-15T16:20:00.000Z",
+      "expiresAt": "2026-08-16T21:00:00.000Z"
+    }
   },
   {
     "id": "s2",


### PR DESCRIPTION
## Summary

HUMANA Lviv announced that on **Sunday 16 Aug** only Knyahyni Olhy 5A and Shevchenka 31 open, **10:00–14:00**, with **everything at 24 ₴** — the rest are shut. Stored hours say `10:00–20:00` seven days a week, so without this the app would send shoppers to six closed stores tomorrow.

Carried as a `flashDeal` rather than edited into `hours`, deliberately:

- The closure is a **one-off operational notice, not a schedule change.** Editing `hours.sun` would assert a permanent change from a single announcement.
- It isn't on the published calendar either — that calendar's closed-day marks are holidays only (1 Jan, 12 Apr, 25 Dec). So the chain's calendar covers collections and holidays, but **not** changeover closures.
- `flashDeal` auto-expires, so the notice cannot outlive the day it describes.

| store | notice |
|---|---|
| h1 | `НД 16.08: 10:00–14:00 · ВСЕ ПО 24 ₴` (the positive one) |
| h2–h7 | `НД 16.08 зачинено · нова колекція в понеділок 17.08` |

Expiry is `2026-08-16T21:00Z` = midnight Kyiv, so it clears before Monday's collection. `alert` stays `false` — the Telegram broadcast is the paid channel and this is a free in-app notice.

**Also surfaced:** the announcement names a HUMANA at **Shevchenka 31**, which isn't in `stores.json`. That's an eighth Lviv branch, and one important enough to stay open on a changeover Sunday — worth surveying.

## Test plan
- [x] All 7 stores show an active notice; the one-store global toast picks **h1**, i.e. the sale rather than a closure
- [x] Closure banner renders correctly on a closed store's detail page (h4)
- [x] **Fixed-clock verification** across the whole sequence:
  - Sat 15 Aug 19:00 Kyiv → 7 notices, h7 `day 40/42`
  - Sun 16 Aug 11:00 Kyiv → 7 notices, `day 41/42`
  - Sun 16 Aug 23:30 Kyiv → 7 notices still live (expiry is midnight)
  - **Mon 17 Aug 09:00 Kyiv → 0 notices, h7 flips to `day 0/35`** as the new collection lands
- [x] `validate-stores.mjs`, `check-inline-js.mjs`; text within the 120-char `DEAL_MAX`
- [x] Store pages, QR posters and sitemap regenerated for the CI sync guards


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_