### PR TITLE
Work through the Dependabot backlog: Actions, wrangler 4, Capacitor 8

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20
 
@@ -30,7 +30,7 @@ jobs:
           java-version: 21
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       - name: Install dependencies
         run: npm install
@@ -48,7 +48,7 @@ jobs:
           ./gradlew assembleDebug --no-daemon
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: lviv-secondhand-debug-apk
           path: native/android/app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20
 
@@ -63,7 +63,7 @@ jobs:
           java-version: 21
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       - name: Fail early if signing secrets are missing
         env:
@@ -148,7 +148,7 @@ jobs:
             | grep -E "SHA256:" || true
 
       - name: Upload .aab artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: lviv-secondhand-release-aab
           path: ${{ runner.temp }}/lviv-secondhand-release.aab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
 

--- a/.github/workflows/deals-image.yml
+++ b/.github/workflows/deals-image.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20
 

--- a/.github/workflows/deploy-bot.yml
+++ b/.github/workflows/deploy-bot.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
 

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Deploy Worker
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/update-map.yml
+++ b/.github/workflows/update-map.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           ref: main
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
 

--- a/native/package.json
+++ b/native/package.json
@@ -13,12 +13,12 @@
     "build:release": "cap sync android && cd android && ./gradlew bundleRelease"
   },
   "dependencies": {
-    "@capacitor/android": "^7.0.0",
-    "@capacitor/core": "^7.0.0",
-    "@capacitor/splash-screen": "^7.0.0"
+    "@capacitor/android": "^8.5.0",
+    "@capacitor/core": "^8.5.0",
+    "@capacitor/splash-screen": "^8.0.2"
   },
   "devDependencies": {
     "@capacitor/assets": "^3.0.5",
-    "@capacitor/cli": "^7.0.0"
+    "@capacitor/cli": "^8.5.0"
   }
 }

--- a/telegram-bot/package.json
+++ b/telegram-bot/package.json
@@ -11,6 +11,6 @@
     "deploy": "node build-data.mjs && wrangler deploy"
   },
   "devDependencies": {
-    "wrangler": "^3.90.0"
+    "wrangler": "^4.120.1"
   }
 }


### PR DESCRIPTION
## Summary

Clears the whole Dependabot backlog (#146–#155) in one branch, superseding all nine remaining PRs. (#150, checkout v4→v7, was merged separately first.)

**They could not be merged individually.** Each group edits the same files, so merging one invalidated the rest — #148 hit a 405 merge conflict immediately after #150 went in, and GitHub couldn't auto-update its branch either (422, real conflict). The four Capacitor packages additionally *must* move together, since core/cli/android/splash-screen have to share a major; merging them one at a time would have left the repo on a broken mixed set in between.

### GitHub Actions — #146, #147, #148, #151
```
actions/setup-node            v4 → v7
actions/upload-artifact       v4 → v7
android-actions/setup-android v3 → v4
cloudflare/wrangler-action    v3 → v4
```

### npm — #152, #149, #153, #154, #155
```
wrangler                  ^3.90.0 → ^4.120.1
@capacitor/core           ^7.0.0  → ^8.5.0
@capacitor/cli            ^7.0.0  → ^8.5.0
@capacitor/android        ^7.0.0  → ^8.5.0
@capacitor/splash-screen  ^7.0.0  → ^8.0.2
```
Neither directory has a lockfile, so these are plain range changes.

## Verification — done by running things, not by reading version numbers

**wrangler 4 (the riskiest — it deploys both Workers):**
- `wrangler deploy` and `wrangler secret put`, the two commands the workflows actually call, both still exist
- **`--dry-run` deploy builds *both* real Workers** from their existing `wrangler.toml`, with every binding resolved: KV (`VISITS`), D1 (`DB`), the `unsafe` rate limiter, and all env vars

**Capacitor 8:**
- Installs as a set — core/cli/android at 8.5.0, splash-screen 8.0.2
- `@capacitor/assets` 3.0.5 still compatible (Dependabot didn't bump it)
- `npx cap --version` runs; npm reports no peer conflicts

**checkout v7 breaking changes** — checked against this repo rather than assumed:
- v7 blocks fork checkouts for `pull_request_target` / `workflow_run`: neither trigger exists here
- v6 moved persisted credentials to a separate file, which matters for `update-map.yml` and `deals-image.yml` since both `git push` with the default token

## What CI here does *not* prove

Only `ci.yml` runs on `pull_request`, and it exercises `checkout` + `setup-node` only. These need a post-merge `workflow_dispatch`:

- [ ] `deals-image.yml` → checkout + setup-node + `git push` with persisted credentials (only rewrites a regenerable PNG)
- [ ] `android-build.yml` → `upload-artifact` v7, `setup-android` v4, and the Capacitor 8 build
- [ ] `deploy-worker.yml` → `wrangler-action` v4
- [ ] `deploy-bot.yml` → `npx wrangler deploy` on v4

## Test plan
- [x] All 8 workflow files still parse as valid YAML; version audit shows no stale references
- [x] wrangler 4 dry-run builds both Workers with correct bindings
- [x] Capacitor 8 set installs and resolves with no peer conflicts
- [x] `validate-stores.mjs`, `check-inline-js.mjs`
