### PR TITLE
Move CI workflows to Node 22, required by wrangler 4 and Capacitor 8

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Validate stores.json schema
         run: node scripts/validate-stores.mjs

--- a/.github/workflows/deals-image.yml
+++ b/.github/workflows/deals-image.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install deps + Chromium
         run: |

--- a/.github/workflows/deploy-bot.yml
+++ b/.github/workflows/deploy-bot.yml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Fail early if secrets are missing
         env:

--- a/.github/workflows/update-map.yml
+++ b/.github/workflows/update-map.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
 
       # Step 1 — apply the patch. Reads store_id/updates from the event
       # payload (GITHUB_EVENT_PATH), not a workflow-expression env var, so


### PR DESCRIPTION
## Summary

Dispatching the workflows after #174 caught what CI could not: **both the bot deploy and the Android build failed**, with the same root cause.

```
Deploy Telegram bot   Wrangler requires at least Node.js v22.0.0. You are using v20.20.2.
Build Android         [fatal] The Capacitor CLI requires NodeJS >=22.0.0
```

Both packages declare `engines.node: >=22.0.0`, and every workflow pinned `node-version: 20`. Bumped all six to 22 rather than only the two that broke, so the toolchain is uniform and matches the Node the repo is actually developed against.

### Why the pre-merge checks missed it

My local dry-run of `wrangler deploy` succeeded because this container runs Node 22.22.2 — the version constraint simply never bit. The failure only appears on a runner pinned to Node 20. A dry run on the right Node would have caught it; a dry run on the wrong Node gave false confidence.

### Nothing broke in production

- The **bot Worker is still serving its previous deploy** — a failed deploy doesn't tear down the running one.
- The **Android build is dispatch-only**, so nothing shipped.
- The **metrics Worker deploy passed throughout**, because `wrangler-action` supplies its own runtime instead of using `setup-node`.

### What the dispatches did confirm

- ✅ `deals-image.yml` **succeeded** — checkout v7 + setup-node v7 + `git push` with persisted credentials all work. That was the change I was most worried about, since `update-map.yml` depends on the same path for the automated map-patch pipeline.
- ✅ `Deploy metrics Worker` succeeded on `wrangler-action` v4.

## Test plan
- [x] All six `node-version` pins updated; workflows still parse as valid YAML
- [x] Confirmed `engines.node >= 22.0.0` on both `wrangler` and `@capacitor/cli`
- [ ] Post-merge: `deploy-bot.yml` auto-triggers (this PR touches `.github/`, not `telegram-bot/`, so it needs a dispatch) — verify wrangler 4 deploys on Node 22
- [ ] Post-merge: dispatch `android-build.yml` — verify Capacitor 8 builds on Node 22


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_