### PR TITLE
Redeploy the Telegram bot when stores.json changes

### DIFF
--- a/.github/workflows/deploy-bot.yml
+++ b/.github/workflows/deploy-bot.yml
@@ -22,11 +22,18 @@ name: Deploy Telegram bot
 # This workflow regenerates stores.gen.js from stores.json, deploys the worker, and
 # sets the BOT_TOKEN secret on it. WEBHOOK_SECRET (already set on the worker) and
 # any other existing secrets are preserved — `wrangler deploy` never deletes them.
+#
+# stores.json is in the trigger paths because the bot bundles the dataset: the
+# deploy step regenerates stores.gen.js (which is gitignored, not committed), so
+# a data-only change — a new restock day, corrected hours, an added shop — never
+# reaches the bot until this workflow runs again. Without it, editing stores.json
+# updates the website and silently leaves /today and /materials on stale data.
 on:
   push:
     branches: [main]
     paths:
       - 'telegram-bot/**'
+      - 'stores.json'
       - '.github/workflows/deploy-bot.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
Found while verifying that #176 had actually shipped.

## The gap

The bot bundles its own copy of the dataset. `deploy-bot.yml` regenerates `stores.gen.js` from `stores.json` at deploy time, and that file is gitignored rather than committed — so the bot's data is only ever as fresh as its last deploy.

But the workflow triggered on:

```yaml
paths:
  - 'telegram-bot/**'
  - '.github/workflows/deploy-bot.yml'
```

A data-only commit matches neither. So editing `stores.json` published the website and left the bot serving whatever dataset happened to be current the last time `telegram-bot/` itself changed.

## It already bit us

Merging #176 changed `stores.json`, `store/`, `qr/` and `sitemap.xml` — nothing under `telegram-bot/`. The website got 20 new EconomClass restock days and the bot got none of them. `/today` and `/materials` would have kept answering from the old data indefinitely, with nothing failing and no warning anywhere.

I dispatched `deploy-bot.yml` by hand against `106ce0c` to get the live bot current (run succeeded), but that is a manual step that has to be remembered every single time.

## The fix

Adds `stores.json` to the trigger paths, so the same commit that publishes the website also redeploys the bot. That covers hand-edited data changes and the auto-commits `update-map.yml` makes when a field patch lands — which have the same shape and the same blind spot.

The metrics Worker was checked for the same problem and does not have it: `worker/` contains no dataset and no generation step, and its only reference to store fields renders a user-submitted contribution payload.

## Verification

- Re-read the parsed `paths:` block after editing to confirm all three entries are present and correctly quoted
- Confirmed `telegram-bot/stores.gen.js` is untracked (`git ls-files` finds no match) and gitignored, which is what makes the deploy the only path by which data reaches the bot
- Confirmed `deploy-bot.yml`'s own steps already regenerate the dataset, so no change to the job body is needed
- Manual `deploy-bot.yml` run against `106ce0c` completed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_