### PR TITLE
Fix the visitors view failing to reach the metrics Worker

### DIFF
--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -1356,12 +1356,30 @@ async function cmdAdminVisitors(env, chatId) {
       text: '⚠️ ADMIN_KEY не налаштовано на metrics Worker. · ADMIN_KEY is not set on the metrics Worker.' });
     return;
   }
+  // Plain fetch with no `cf` options — the same shape as the /api/edit/resolve
+  // call above, which is the one Worker-to-Worker request in this file already
+  // proven in production. A `cf: { cacheTtl }` here threw outright.
+  //
+  // The body is read as text and parsed by hand so that a non-JSON reply (a
+  // Cloudflare error page, an HTML 5xx) reports its status and first line
+  // instead of collapsing into a generic "could not reach", which says nothing
+  // about whether the request failed, the route is missing, or the key is wrong.
   let s;
   try {
-    const res = await fetch(`${METRICS_WORKER_URL}/api/stats?key=${encodeURIComponent(env.ADMIN_KEY)}`, { cf: { cacheTtl: 0 } });
-    s = await res.json();
-  } catch {
-    await tg(env, 'sendMessage', { chat_id: chatId, text: '⚠️ Не вдалося зʼєднатися з metrics Worker. · Could not reach the metrics Worker.' });
+    const res = await fetch(`${METRICS_WORKER_URL}/api/stats`, {
+      headers: { 'X-Admin-Key': env.ADMIN_KEY },
+    });
+    const raw = await res.text();
+    try {
+      s = JSON.parse(raw);
+    } catch {
+      await tg(env, 'sendMessage', { chat_id: chatId,
+        text: `⚠️ Metrics Worker відповів не-JSON (HTTP ${res.status}). · Non-JSON reply (HTTP ${res.status}):\n${esc(raw.slice(0, 200))}` });
+      return;
+    }
+  } catch (e) {
+    await tg(env, 'sendMessage', { chat_id: chatId,
+      text: `⚠️ Не вдалося зʼєднатися з metrics Worker. · Could not reach the metrics Worker.\n${esc(String((e && e.message) || e).slice(0, 200))}` });
     return;
   }
   if (!s || !s.ok) {


### PR DESCRIPTION
`/admin` → Visitors reported *"Could not reach the metrics Worker"* on every attempt, immediately after #182 shipped.

## The cause

The request was not failing on the network. The `fetch` threw **before it was sent**, because it passed a `cf: { cacheTtl: 0 }` option:

```js
await fetch(`${METRICS_WORKER_URL}/api/stats?key=...`, { cf: { cacheTtl: 0 } });
```

It was the only `fetch` in the file carrying a `cf` field. The `/api/edit/resolve` call directly above it — the one Worker-to-Worker request already proven in production — is a plain fetch. The option bought nothing: the response was never cacheable to begin with.

The endpoint itself was fine throughout. Verified against the live Worker: `/api/stats` with a wrong key returns `401 {"ok":false,"reason":"unauthorized"}`, so routing, deployment and gating were all working.

## The change

The call now matches the proven shape, and the admin key moves from the query string to the `X-Admin-Key` header the Worker already accepts — so the key stops appearing in URLs and anything that logs them.

## Why the message was useless, and isn't now

A single `catch` wrapped both the `fetch` and `res.json()`. A network failure, a missing route, an HTML error page and a thrown request all collapsed into the same sentence. That is why the real cause was invisible from the message — the one line I had to go on excluded nothing.

The body is now read as text and parsed deliberately:

- **Non-JSON reply** → reports the HTTP status and the first 200 characters
- **Thrown request** → reports the exception message

Either would have named this bug on sight.

## Verification

Extracted `cmdAdminVisitors` and ran it against stubs for all four paths:

| Case | Result |
|---|---|
| Normal data | Renders the figures and chart |
| Key mismatch (401 JSON) | "ADMIN_KEY does not match between the bot and the metrics Worker" |
| 502 with an HTML body | "Non-JSON reply (HTTP 502): `<!DOCTYPE html>...`" |
| `fetch` throws | Prints the exception — tested with the exact `'cf' field ... is not implemented` error this bug produced |

Bot Worker builds clean under `wrangler 4 deploy --dry-run`. `node --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_