### PR TITLE
Route Worker-to-Worker calls through a service binding, not the public URL

### DIFF
--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -60,6 +60,27 @@ import {
 
 const APP_URL = 'https://www.lvivsecondhand.com/';
 const METRICS_WORKER_URL = 'https://lviv-metrics.lshanalytic.workers.dev';
+
+// Every call from this Worker to the metrics Worker goes through here.
+//
+// Cloudflare blocks a Worker subrequest to another Worker on the same zone: the
+// public lviv-metrics.*.workers.dev URL answers HTTP 404 with "error code:
+// 1042" when the caller is itself a Worker. That silently broke flash-deal
+// subscribe/unsubscribe, edit claim and resolve, and the leaderboard — each sat
+// inside an empty catch, so the bot simply behaved as though the metrics Worker
+// had nothing to say.
+//
+// The METRICS service binding (telegram-bot/wrangler.toml) routes the request
+// inside Cloudflare and sidesteps the restriction. The public-URL path is kept
+// as a fallback for any deploy where the binding is absent, so an older
+// wrangler.toml degrades to the previous behaviour instead of throwing.
+function metricsFetch(env, path, init) {
+  if (env.METRICS && typeof env.METRICS.fetch === 'function') {
+    // The hostname is ignored by a service binding but the URL must be absolute.
+    return env.METRICS.fetch(new Request(`https://metrics.internal${path}`, init));
+  }
+  return fetch(`${METRICS_WORKER_URL}${path}`, init);
+}
 const DAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
 const DAY_NAMES = { mon: 'Monday', tue: 'Tuesday', wed: 'Wednesday', thu: 'Thursday', fri: 'Friday', sat: 'Saturday', sun: 'Sunday' };
 
@@ -445,7 +466,7 @@ async function handleFlashSubStart(env, ctx) {
   if (!/^[a-z0-9]{1,12}$/i.test(storeId)) return false;
   const store = STORES.find((s) => s.id === storeId);
   try {
-    await fetch(`${METRICS_WORKER_URL}/api/sub`, {
+    await metricsFetch(env, '/api/sub', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ storeId, chatId }),
     });
@@ -465,7 +486,7 @@ async function handleStopCommand(env, ctx) {
   const { chatId, text } = ctx;
   if (!/^\/stop\b/i.test(String(text || '').trim())) return false;
   try {
-    await fetch(`${METRICS_WORKER_URL}/api/unsub-all`, {
+    await metricsFetch(env, '/api/unsub-all', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ chatId }),
     });
@@ -486,7 +507,7 @@ async function handleEditStart(env, ctx) {
   const name = (from && (from.first_name || from.username)) || null;
   let out = {};
   try {
-    const res = await fetch(`${METRICS_WORKER_URL}/api/edit/claim`, {
+    const res = await metricsFetch(env, '/api/edit/claim', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: m[1], chatId, name }),
     });
@@ -510,7 +531,7 @@ async function handleLeaderboardCommand(env, ctx) {
   if (!/^\/leaderboard\b/i.test(String(text || '').trim())) return false;
   let rows = [];
   try {
-    const res = await fetch(`${METRICS_WORKER_URL}/api/leaderboard`);
+    const res = await metricsFetch(env, '/api/leaderboard');
     rows = await res.json().catch(() => []);
   } catch (e) {}
   if (!Array.isArray(rows) || !rows.length) {
@@ -683,7 +704,7 @@ async function handleAgentCallback(env, c, cq) {
     if (!env.ADMIN_KEY) { await editPlain(original + '\n\n⚠️ ADMIN_KEY not set on the metrics Worker.'); return; }
     const action = kind === 'editapprove' ? 'approve' : 'reject';
     try {
-      const res = await fetch(`${METRICS_WORKER_URL}/api/edit/resolve`, {
+      const res = await metricsFetch(env, '/api/edit/resolve', {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id: val, action, key: env.ADMIN_KEY }),
       });
@@ -1366,7 +1387,7 @@ async function cmdAdminVisitors(env, chatId) {
   // about whether the request failed, the route is missing, or the key is wrong.
   let s;
   try {
-    const res = await fetch(`${METRICS_WORKER_URL}/api/stats`, {
+    const res = await metricsFetch(env, '/api/stats', {
       headers: { 'X-Admin-Key': env.ADMIN_KEY },
     });
     const raw = await res.text();

--- a/telegram-bot/wrangler.toml
+++ b/telegram-bot/wrangler.toml
@@ -36,6 +36,20 @@ compatibility_date = "2026-08-01"
 binding = "VISITS"
 id = "69158c00d55a4d3ab750cd916afca445"
 
+# Direct binding to the metrics Worker (worker/), which this one calls for
+# flash-deal subscriptions, edit claim/resolve, the leaderboard and the visitor
+# stats behind /admin.
+#
+# This has to be a service binding, not a plain fetch of the public
+# lviv-metrics.*.workers.dev URL. Cloudflare refuses a Worker subrequest to
+# another Worker on the same zone and answers HTTP 404 with "error code: 1042",
+# so every one of those calls failed — silently, because most were wrapped in
+# an empty catch. A service binding routes the request inside Cloudflare
+# instead: no public hop, no DNS, no 1042, and lower latency.
+[[services]]
+binding = "METRICS"
+service = "lviv-metrics"
+
 [vars]
 OWNER_ID   = "1212541015"    # owner — gets /report, /export, and a live push of each visit
 AGENT_IDS  = "1212541015,5677605074"    # agents allowed to run /visit (comma-separated): owner (smoke-test) + field agent.


### PR DESCRIPTION
`/admin` → Visitors returned **HTTP 404, "error code: 1042"**. That is Cloudflare refusing a Worker subrequest to another Worker on the same zone — the bot cannot reach `lviv-metrics` by its public `workers.dev` URL, because the caller is itself a Worker.

## This was never about the visitors view

**Six** calls in `telegram-bot/worker.js` used that pattern:

| Call | Feature it breaks |
|---|---|
| `/api/sub` | Flash-deal subscribe |
| `/api/unsub-all` | `/stop` — unsubscribe from all alerts |
| `/api/edit/claim` | Contributor claiming an edit |
| `/api/leaderboard` | `/leaderboard` |
| `/api/edit/resolve` | Moderator ✅/❌ on an edit suggestion |
| `/api/stats` | The new visitors view |

All six have been failing identically. Only the new one was noticed **because only the new one reports its errors** — the other five sit inside empty `catch` blocks, so the bot behaved as though the metrics Worker simply had nothing to say.

That means `/stop` has been answering *"🔕 Відписано від усіх акцій"* while unsubscribing nobody, and `/leaderboard` has been reporting *"no contributors yet"* regardless of the table's contents. Both look like working features from the outside.

## The fix

A `METRICS` service binding in `telegram-bot/wrangler.toml` routes the request inside Cloudflare: no public hop, no DNS, no 1042, and lower latency. All six call sites go through one `metricsFetch()` helper.

The public URL is kept as a fallback when the binding is absent, so a deploy from an older `wrangler.toml` degrades to the previous behaviour rather than throwing.

## Verification

- `wrangler deploy --dry-run` resolves **`env.METRICS (lviv-metrics) → Worker`**
- With the binding present, the helper uses it and **never touches global `fetch`** (asserted — the stub throws if called)
- With the binding absent, it falls back to the public URL
- The admin key travels as an `X-Admin-Key` header on both paths
- Reproduced the exact failure shape (no binding + a 404 `error code: 1042` body) and confirmed the message names it
- `node --check` passes

## Why this took two attempts

The first fix removed a `cf:` option that was genuinely throwing, and replaced a catch-all error message with one that reports the status and body. That second part is what produced `error code: 1042` and made this diagnosable at all — the original message would have kept saying "could not reach the metrics Worker" indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_