### PR TITLE
Put the bot's missing commands into the Telegram menu

### DIFF
--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -780,13 +780,36 @@ async function handleAgentCallback(env, c, cq) {
 // owner also gets /admin (see cmdAdminMenu), instead of every task getting its
 // own top-level command. Bump CMD_VER to force a re-sync after editing the
 // lists. Self-managing → no BotFather /setcommands needed.
-const CMD_VER = 'v5';
+const CMD_VER = 'v6';
+// Everything the router answers for an ordinary user. /stop and /leaderboard
+// are ungated commands that were missing from this list, so they existed and
+// worked but could not be discovered from the menu — only by reading /help.
 const PUBLIC_CMDS = [
   { command: 'today', description: 'Магазини із завезенням сьогодні' },
   { command: 'cheap', description: 'Найкращі ціни на вагу зараз' },
   { command: 'submit', description: 'Додати свій магазин (власникам)' },
   { command: 'materials', description: 'Матеріали для друку: флаєри, наліпки' },
+  { command: 'leaderboard', description: 'Топ учасників за балами' },
+  { command: 'stop', description: 'Відписатися від усіх сповіщень' },
   { command: 'help', description: 'Команди та інформація' },
+];
+// Agents additionally get the field-work commands. These are all gated on
+// isAgent in the router, so listing them for anyone else would only advertise a
+// refusal.
+const AGENT_CMDS = [
+  { command: 'agent', description: '🧭 Меню агента · Agent menu' },
+  { command: 'visit', description: 'Записати відвідування магазину' },
+  { command: 'route', description: 'Маршрут обходу від вашої локації' },
+  { command: 'myvisits', description: 'Мої відвідування та заробіток' },
+  { command: 'pay', description: 'Ставки оплати' },
+  { command: 'card', description: 'Картка для виплат' },
+  { command: 'job', description: 'Опис роботи' },
+  { command: 'cancel', description: 'Скасувати активну дію' },
+];
+const OWNER_CMDS = [
+  { command: 'admin', description: '⚙️ Адмін-меню · Admin menu' },
+  { command: 'report', description: 'Звіт: відвідування та оплата' },
+  { command: 'export', description: 'CSV усіх відвідувань' },
 ];
 async function syncBotCommands(env, userId, isOwner, isAgent) {
   // Public default menu — set once globally.
@@ -797,8 +820,7 @@ async function syncBotCommands(env, userId, isOwner, isAgent) {
   // Extended menu — only for owner/agents, scoped to their own chat, once each.
   if (!(isOwner || isAgent)) return;
   if ((await env.VISITS.get('cmds:' + userId)) === CMD_VER) return;
-  const cmds = PUBLIC_CMDS.concat([{ command: 'agent', description: '🧭 Меню агента · Agent menu' }]);
-  if (isOwner) cmds.push({ command: 'admin', description: '⚙️ Адмін-меню · Admin menu' });
+  const cmds = PUBLIC_CMDS.concat(AGENT_CMDS, isOwner ? OWNER_CMDS : []);
   await tg(env, 'setMyCommands', { commands: cmds, scope: { type: 'chat', chat_id: userId } });
   await env.VISITS.put('cmds:' + userId, CMD_VER);
 }


### PR DESCRIPTION
The menu listed **five** commands. The bot answers **eighteen**.

## What was missing

`setMyCommands` was already wired up and KV-gated — the mechanism was fine. The lists it published were not.

**`/stop` and `/leaderboard`** were the visible gap: both ungated, both working, neither in the menu. The only way to discover them was to read `/help`.

The extended owner/agent menu added just `/agent` and `/admin`, so **eight agent commands** and the owner's **`/report`** and **`/export`** were undiscoverable by typing — even though `/agent` and `/admin` lead to the very features they drive.

## The lists, now split by who can use them

| Scope | Commands |
|---|---|
| **Public** | `/today` `/cheap` `/submit` `/materials` **`/leaderboard`** **`/stop`** `/help` |
| **+ Agents** | `/agent` `/visit` `/route` `/myvisits` `/pay` `/card` `/job` `/cancel` |
| **+ Owner** | `/admin` `/report` `/export` |

The agent commands are all gated on `isAgent` in the router, so listing them publicly would only advertise a refusal — they stay in the chat-scoped menu.

## The version bump is the load-bearing part

`syncBotCommands` writes each menu **once per `CMD_VER` per chat** and skips it thereafter. Editing the lists without bumping the version would have changed nothing at all. `CMD_VER` → `v6` is what triggers the re-sync, which happens the next time any command is sent.

## Verification

Parsed the three lists out of the source and checked them against Telegram's `setMyCommands` rules and against the router:

- Every name matches `^[a-z0-9_]{1,32}$`; every description is 1–256 chars
- No duplicates once concatenated for an owner (Telegram rejects them)
- **All 18 resolve to a real handler** in the router — cross-checked against `command === '…'`, `case '…':` and the `^\/…\b` regex dispatchers, so the menu cannot advertise a command that does nothing
- 18 entries, well under Telegram's 100 limit
- `node --check` and `wrangler 4 deploy --dry-run` pass

`/start` is deliberately absent — Telegram surfaces it automatically for a new chat, and it is a first-contact command rather than a menu action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_