### PR TITLE
Bug hunt phase 2/5: close the schema gap and fence the bug classes found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,14 @@ jobs:
         run: node build-data.mjs
         working-directory: telegram-bot
 
+      # Structural invariants that nothing else covers, each one a bug that
+      # actually shipped: a D1 table written to but never created, a Telegram
+      # menu entry with no handler, and a Worker fetching another Worker by its
+      # public URL (which Cloudflare rejects with error 1042). All three failed
+      # silently in production before this check existed.
+      - name: Check cross-system wiring
+        run: node scripts/check-wiring.mjs
+
       # The per-store pages and sitemap are generated from stores.json but
       # committed (GitHub Pages serves the repo root, so the files ARE the
       # deploy). Regenerate and fail if the committed output differs — that

--- a/scripts/check-wiring.mjs
+++ b/scripts/check-wiring.mjs
@@ -1,0 +1,102 @@
+// Wiring checks — each one encodes a bug that actually shipped.
+//
+// These are structural invariants that no existing check covered, and each was
+// only found by hand during a bug hunt. Automating them is the difference
+// between finding the bug once and never shipping it again.
+//
+//   1. Every D1 table the Worker writes to is created by ensureSchema.
+//      The events table was created by a one-off manual command and never
+//      added to ensureSchema, so recreating the database would have broken
+//      metrics ingestion with nothing in the code to explain it.
+//
+//   2. Every command in the bot's Telegram menu resolves to a real handler.
+//      The menu is published with setMyCommands; an entry with no handler is a
+//      button that silently does nothing.
+//
+//   3. No Worker fetches another Worker by its public URL.
+//      Cloudflare answers such a subrequest with HTTP 404 "error code: 1042".
+//      Six bot features failed this way, invisibly, for months.
+//
+// Exit code 1 on any violation.
+
+import fs from 'node:fs';
+
+const worker = fs.readFileSync('worker/worker.js', 'utf8');
+const bot = fs.readFileSync('telegram-bot/worker.js', 'utf8');
+const errors = [];
+
+// ── 1 · schema coverage ──────────────────────────────────────────────────────
+{
+  const created = new Set([...worker.matchAll(/CREATE TABLE IF NOT EXISTS ([a-z_]+)/g)].map((m) => m[1]));
+  const used = new Set();
+  for (const m of worker.matchAll(/(?:INSERT INTO|UPDATE|DELETE FROM|FROM)\s+([a-z_]+)/g)) used.add(m[1]);
+  for (const t of used) {
+    if (!created.has(t)) errors.push(`worker/worker.js writes to table "${t}" but ensureSchema never creates it.`);
+  }
+  console.log(`schema: ${created.size} tables created, ${used.size} referenced`);
+}
+
+// ── 2 · every menu command has a handler ─────────────────────────────────────
+{
+  const listed = new Set();
+  for (const name of ['PUBLIC_CMDS', 'AGENT_CMDS', 'OWNER_CMDS']) {
+    const i = bot.indexOf(`const ${name} = [`);
+    if (i < 0) { errors.push(`telegram-bot/worker.js: ${name} not found — the menu lists were renamed or removed.`); continue; }
+    const block = bot.slice(i, bot.indexOf('];', i));
+    for (const m of block.matchAll(/command:\s*'([a-z0-9_]+)'/g)) listed.add(m[1]);
+  }
+  const handled = new Set();
+  for (const m of bot.matchAll(/command === '([a-z0-9_]+)'/g)) handled.add(m[1]);
+  for (const m of bot.matchAll(/case '([a-z0-9_]+)':/g)) handled.add(m[1]);
+  for (const m of bot.matchAll(/\^\\\/([a-z0-9_]+)\\b/g)) handled.add(m[1]);
+  for (const c of listed) {
+    if (!handled.has(c)) errors.push(`Telegram menu lists /${c} but no handler in telegram-bot/worker.js answers it.`);
+  }
+  // Telegram rejects the whole call if any entry is malformed, and a rejected
+  // call used to still mark the menu version as synced.
+  for (const c of listed) {
+    if (!/^[a-z0-9_]{1,32}$/.test(c)) errors.push(`Menu command "/${c}" is not a legal Telegram command name.`);
+  }
+  console.log(`bot menu: ${listed.size} commands listed, all resolved against ${handled.size} handlers`);
+}
+
+// ── 3 · no Worker-to-Worker call by public URL ───────────────────────────────
+{
+  // metricsFetch() keeps one documented public-URL fallback for deploys without
+  // the service binding. That single call is exempt — every other one is the
+  // 1042 bug returning.
+  //
+  // The exemption is applied by cutting metricsFetch's body out of the source
+  // before scanning, rather than by testing whether the helper exists somewhere
+  // in the file. The latter reads as equivalent and is not: it whitelists every
+  // occurrence in the file at once, so a new offending call elsewhere passes
+  // unnoticed. (Found by trying to smuggle exactly such a call past it.)
+  const cutFn = (src, name) => {
+    const i = src.indexOf(`function ${name}(`);
+    if (i < 0) return src;
+    let d = 0, k = src.indexOf('{', i);
+    for (; k < src.length; k++) {
+      if (src[k] === '{') d++;
+      else if (src[k] === '}' && --d === 0) break;
+    }
+    return src.slice(0, i) + src.slice(k + 1);
+  };
+
+  for (const [file, raw] of [['worker/worker.js', worker], ['telegram-bot/worker.js', bot]]) {
+    const src = cutFn(raw, 'metricsFetch');
+    for (const m of src.matchAll(/fetch\(\s*[`'"]([^`'"]*workers\.dev[^`'"]*)/g)) {
+      errors.push(`${file} fetches a Worker by public URL (${m[1]}) — Cloudflare rejects this with error 1042. Use a service binding.`);
+    }
+    for (const m of src.matchAll(/fetch\(\s*`\$\{([A-Z_]*WORKER_URL)\}/g)) {
+      errors.push(`${file} fetches \${${m[1]}} outside the metricsFetch fallback — use the service binding.`);
+    }
+  }
+  console.log('worker-to-worker: no unbound public-URL calls');
+}
+
+if (errors.length) {
+  console.error('\nWiring check FAILED:');
+  for (const e of errors) console.error('  ✗ ' + e);
+  process.exit(1);
+}
+console.log('\nWiring OK.');

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -129,6 +129,13 @@ async function ensureSchema(env) {
   await env.DB.prepare(
     "CREATE TABLE IF NOT EXISTS visits (day TEXT NOT NULL, vid TEXT NOT NULL, PRIMARY KEY (day, vid))"
   ).run();
+  // The usage-metrics table the root POST writes to. It was created by hand when
+  // the collector shipped and never added here, so it worked only because that
+  // one manual command had been run: recreate the D1 database and every beacon
+  // would 500 with nothing in the code to explain why.
+  await env.DB.prepare(
+    "CREATE TABLE IF NOT EXISTS events (id INTEGER PRIMARY KEY AUTOINCREMENT, day TEXT NOT NULL, type TEXT NOT NULL, key TEXT, lang TEXT)"
+  ).run();
   _schemaReady = true;
 }
 


### PR DESCRIPTION
## Phase 2 — data integrity

**Clean:** `store/` and `qr/` have no orphans and no missing directories, `sitemap.xml` lists exactly the 92 live stores, and the `wm1` copyright-trap watermark does not leak into it.

**One real gap:** the `events` table — written on *every* metrics beacon — was created by a one-off manual command when the collector shipped in #46 and never added to `ensureSchema`. It worked only because that command had been run. Recreate the D1 database and every beacon would 500 with nothing in the code to explain why. Now created like every other table.

## Phase 4 — a negative result worth recording

I flagged the 8 HUMANA flash deals expiring at 21:00 UTC tonight as possibly urgent. **It isn't.** Nothing prunes them from `stores.json`, but nothing renders them either:

- `build-store-pages.mjs` never mentions `flashDeal` — static pages don't show it
- the bot and `deals-image.mjs` never read it
- the live app checks `expiresAt` before displaying

So expired deals are dead weight in the data, not a wrong page. No fix needed tonight.

## Phase 5 — fences

New `scripts/check-wiring.mjs`, wired into CI, asserting three invariants nothing else covered — each one a bug that cost real production time today:

| # | Invariant | The bug it prevents |
|---|---|---|
| 1 | Every D1 table written to is created by `ensureSchema` | `events`, above |
| 2 | Every Telegram menu command resolves to a handler | A menu button that silently does nothing |
| 3 | No Worker fetches another Worker by public URL | Error 1042 — six bot features broken invisibly |

### Each check was verified by reintroducing its bug

Not just by passing on clean code. I re-added each defect and confirmed CI would now fail:

```
── inject literal form ──
  ✗ telegram-bot/worker.js fetches a Worker by public URL (…workers.dev/api/leaderboard)
── inject templated form ──
  ✗ telegram-bot/worker.js fetches ${METRICS_WORKER_URL} outside the metricsFetch fallback
```

**That process found a defect in check 3 itself.** Its exemption for `metricsFetch`'s documented fallback tested whether the helper existed *anywhere in the file* — which whitelisted every occurrence at once, so a newly added offending call passed unnoticed. The templated form sailed straight through on the first attempt. It now cuts the helper's body out of the source before scanning, and catches both forms.

A check that only ever runs against correct code proves nothing about whether it works.

## Verification

`validate-stores`, `check-inline-js`, `node --check` on both Workers, `check-wiring`, and `wrangler 4 deploy --dry-run` all pass.

## Remaining

Phase 2 has findings that need **your** decision (store identity isn't mine to guess): 16 close pairs including `c12`/`c25` at 1 m and `c13`/`c28` at 5 m, plus two unprocessed contribution issues. Phase 3 (four workflows never exercised) is still open. I'll summarise both rather than act unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_