### PR TITLE
Categorise the Telegram command menu; refresh date-derived store pages daily

### DIFF
--- a/.github/workflows/refresh-pages.yml
+++ b/.github/workflows/refresh-pages.yml
@@ -1,0 +1,66 @@
+name: Refresh store pages
+
+# The per-store pages are generated from stores.json but some of their content
+# is derived from *today's date*, not from stores.json alone: a store with a
+# published restock calendar renders "Останнє завезення: <most recent past
+# date>", and each calendar row is marked "вже було" or "заплановано". Those
+# flip on their own as dates pass, with no commit involved.
+#
+# Two things go wrong without this workflow:
+#
+#   1. The pages quietly start lying. On 2026-08-17 the committed HUMANA pages
+#      still told Google the last delivery was 2026-07-06, six weeks stale, and
+#      nothing would have corrected them until someone happened to edit
+#      stores.json.
+#
+#   2. CI fails on unrelated work. ci.yml regenerates the pages and fails if the
+#      committed output differs — correctly, since it cannot tell a stale file
+#      from a forgotten one. So the first pull request opened after a calendar
+#      date passes fails on five files it never touched, blaming whoever is
+#      unlucky enough to be next.
+#
+# Running daily keeps main current, so the guard only ever fires for the reason
+# it was written: someone edited stores.json without regenerating.
+on:
+  schedule:
+    - cron: "17 3 * * *" # 03:17 UTC daily — before Kyiv's morning, off the hour
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: refresh-pages
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Rebuild store pages and sitemap
+        run: node scripts/build-store-pages.mjs
+
+      # The QR posters carry no date-derived content, but regenerating them here
+      # costs nothing and keeps the two generators from drifting apart.
+      - name: Rebuild QR posters
+        run: node scripts/build-qr-posters.mjs
+
+      - name: Commit if anything changed
+        run: |
+          git config user.name "lviv-secondhand-bot"
+          git config user.email "actions@users.noreply.github.com"
+          git add store sitemap.xml qr
+          if git diff --cached --quiet; then
+            echo "Nothing changed — no calendar date passed since the last run."
+            exit 0
+          fi
+          git commit -m "Refresh date-derived store pages [skip ci]"
+          git push

--- a/store/h1/index.html
+++ b/store/h1/index.html
@@ -5,12 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="theme-color" content="#17693a">
 <title>HUMANA — Knyahyni Olhy — вул. Княгині Ольги, 5а · Секонд-хенд Львів</title>
-<meta name="description" content="HUMANA — Knyahyni Olhy — секонд-хенд у Львові, за адресою вул. Княгині Ольги, 5а, поштучно (ціна за річ), останнє завезення: 2026-07-06 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta name="description" content="HUMANA — Knyahyni Olhy — секонд-хенд у Львові, за адресою вул. Княгині Ольги, 5а, поштучно (ціна за річ), останнє завезення: 2026-08-17 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <link rel="canonical" href="https://www.lvivsecondhand.com/store/h1/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Lviv Second Hand">
 <meta property="og:title" content="HUMANA — Knyahyni Olhy — вул. Княгині Ольги, 5а · Секонд-хенд Львів">
-<meta property="og:description" content="HUMANA — Knyahyni Olhy — секонд-хенд у Львові, за адресою вул. Княгині Ольги, 5а, поштучно (ціна за річ), останнє завезення: 2026-07-06 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta property="og:description" content="HUMANA — Knyahyni Olhy — секонд-хенд у Львові, за адресою вул. Княгині Ольги, 5а, поштучно (ціна за річ), останнє завезення: 2026-08-17 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <meta property="og:url" content="https://www.lvivsecondhand.com/store/h1/">
 <meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
 <meta property="og:locale" content="uk_UA">
@@ -126,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Телефон</th><td><a href="tel:0322455009">(032) 245-50-09</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
       <tr><th scope="row">Мережа</th><td>HUMANA</td></tr>
-      <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-07-06 (за офіційним календарем)</td></tr>
+      <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-17 (за офіційним календарем)</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>35 дн.</td></tr>
     </tbody>
   </table>
@@ -154,7 +154,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">2026-04-27</th><td class="dim">вже було</td></tr>
       <tr><th scope="row">2026-06-01</th><td class="dim">вже було</td></tr>
       <tr><th scope="row">2026-07-06</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-08-17</th><td>заплановано</td></tr>
+      <tr><th scope="row">2026-08-17</th><td class="dim">вже було</td></tr>
       <tr><th scope="row">2026-09-21</th><td>заплановано</td></tr>
       <tr><th scope="row">2026-10-26</th><td>заплановано</td></tr>
       <tr><th scope="row">2026-11-30</th><td>заплановано</td></tr>

--- a/store/h3/index.html
+++ b/store/h3/index.html
@@ -5,12 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="theme-color" content="#17693a">
 <title>HUMANA — Chornovola — просп. В. Чорновола, 95 · Секонд-хенд Львів</title>
-<meta name="description" content="HUMANA — Chornovola — секонд-хенд у Львові, за адресою просп. В. Чорновола, 95, поштучно (ціна за річ), останнє завезення: 2026-07-06 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta name="description" content="HUMANA — Chornovola — секонд-хенд у Львові, за адресою просп. В. Чорновола, 95, поштучно (ціна за річ), останнє завезення: 2026-08-17 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <link rel="canonical" href="https://www.lvivsecondhand.com/store/h3/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Lviv Second Hand">
 <meta property="og:title" content="HUMANA — Chornovola — просп. В. Чорновола, 95 · Секонд-хенд Львів">
-<meta property="og:description" content="HUMANA — Chornovola — секонд-хенд у Львові, за адресою просп. В. Чорновола, 95, поштучно (ціна за річ), останнє завезення: 2026-07-06 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta property="og:description" content="HUMANA — Chornovola — секонд-хенд у Львові, за адресою просп. В. Чорновола, 95, поштучно (ціна за річ), останнє завезення: 2026-08-17 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <meta property="og:url" content="https://www.lvivsecondhand.com/store/h3/">
 <meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
 <meta property="og:locale" content="uk_UA">
@@ -126,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Телефон</th><td><a href="tel:0322445398">(032) 244-53-98</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
       <tr><th scope="row">Мережа</th><td>HUMANA</td></tr>
-      <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-07-06 (за офіційним календарем)</td></tr>
+      <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-17 (за офіційним календарем)</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>35 дн.</td></tr>
     </tbody>
   </table>
@@ -154,7 +154,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">2026-04-27</th><td class="dim">вже було</td></tr>
       <tr><th scope="row">2026-06-01</th><td class="dim">вже було</td></tr>
       <tr><th scope="row">2026-07-06</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-08-17</th><td>заплановано</td></tr>
+      <tr><th scope="row">2026-08-17</th><td class="dim">вже було</td></tr>
       <tr><th scope="row">2026-09-21</th><td>заплановано</td></tr>
       <tr><th scope="row">2026-10-26</th><td>заплановано</td></tr>
       <tr><th scope="row">2026-11-30</th><td>заплановано</td></tr>

--- a/store/h6/index.html
+++ b/store/h6/index.html
@@ -5,12 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="theme-color" content="#17693a">
 <title>HUMANA — Doroshenka — вул. П. Дорошенка, 1 · Секонд-хенд Львів</title>
-<meta name="description" content="HUMANA — Doroshenka — секонд-хенд у Львові, за адресою вул. П. Дорошенка, 1, поштучно (ціна за річ), останнє завезення: 2026-07-06 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta name="description" content="HUMANA — Doroshenka — секонд-хенд у Львові, за адресою вул. П. Дорошенка, 1, поштучно (ціна за річ), останнє завезення: 2026-08-17 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <link rel="canonical" href="https://www.lvivsecondhand.com/store/h6/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Lviv Second Hand">
 <meta property="og:title" content="HUMANA — Doroshenka — вул. П. Дорошенка, 1 · Секонд-хенд Львів">
-<meta property="og:description" content="HUMANA — Doroshenka — секонд-хенд у Львові, за адресою вул. П. Дорошенка, 1, поштучно (ціна за річ), останнє завезення: 2026-07-06 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta property="og:description" content="HUMANA — Doroshenka — секонд-хенд у Львові, за адресою вул. П. Дорошенка, 1, поштучно (ціна за річ), останнє завезення: 2026-08-17 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <meta property="og:url" content="https://www.lvivsecondhand.com/store/h6/">
 <meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
 <meta property="og:locale" content="uk_UA">
@@ -126,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Телефон</th><td><a href="tel:0322611260">(032) 261-12-60</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
       <tr><th scope="row">Мережа</th><td>HUMANA</td></tr>
-      <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-07-06 (за офіційним календарем)</td></tr>
+      <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-17 (за офіційним календарем)</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>35 дн.</td></tr>
     </tbody>
   </table>
@@ -154,7 +154,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">2026-04-27</th><td class="dim">вже було</td></tr>
       <tr><th scope="row">2026-06-01</th><td class="dim">вже було</td></tr>
       <tr><th scope="row">2026-07-06</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-08-17</th><td>заплановано</td></tr>
+      <tr><th scope="row">2026-08-17</th><td class="dim">вже було</td></tr>
       <tr><th scope="row">2026-09-21</th><td>заплановано</td></tr>
       <tr><th scope="row">2026-10-26</th><td>заплановано</td></tr>
       <tr><th scope="row">2026-11-30</th><td>заплановано</td></tr>

--- a/store/h7/index.html
+++ b/store/h7/index.html
@@ -5,12 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="theme-color" content="#17693a">
 <title>HUMANA Vintage — вул. Валова, 13 · Секонд-хенд Львів</title>
-<meta name="description" content="HUMANA Vintage — секонд-хенд у Львові, за адресою вул. Валова, 13, поштучно (ціна за річ), останнє завезення: 2026-07-06 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta name="description" content="HUMANA Vintage — секонд-хенд у Львові, за адресою вул. Валова, 13, поштучно (ціна за річ), останнє завезення: 2026-08-17 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <link rel="canonical" href="https://www.lvivsecondhand.com/store/h7/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Lviv Second Hand">
 <meta property="og:title" content="HUMANA Vintage — вул. Валова, 13 · Секонд-хенд Львів">
-<meta property="og:description" content="HUMANA Vintage — секонд-хенд у Львові, за адресою вул. Валова, 13, поштучно (ціна за річ), останнє завезення: 2026-07-06 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta property="og:description" content="HUMANA Vintage — секонд-хенд у Львові, за адресою вул. Валова, 13, поштучно (ціна за річ), останнє завезення: 2026-08-17 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <meta property="og:url" content="https://www.lvivsecondhand.com/store/h7/">
 <meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
 <meta property="og:locale" content="uk_UA">
@@ -126,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Телефон</th><td><a href="tel:0322355021">(032) 235-50-21</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
       <tr><th scope="row">Мережа</th><td>HUMANA</td></tr>
-      <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-07-06 (за офіційним календарем)</td></tr>
+      <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-17 (за офіційним календарем)</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>35 дн.</td></tr>
     </tbody>
   </table>
@@ -154,7 +154,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">2026-04-27</th><td class="dim">вже було</td></tr>
       <tr><th scope="row">2026-06-01</th><td class="dim">вже було</td></tr>
       <tr><th scope="row">2026-07-06</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-08-17</th><td>заплановано</td></tr>
+      <tr><th scope="row">2026-08-17</th><td class="dim">вже було</td></tr>
       <tr><th scope="row">2026-09-21</th><td>заплановано</td></tr>
       <tr><th scope="row">2026-10-26</th><td>заплановано</td></tr>
       <tr><th scope="row">2026-11-30</th><td>заплановано</td></tr>

--- a/store/h8/index.html
+++ b/store/h8/index.html
@@ -5,12 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="theme-color" content="#17693a">
 <title>HUMANA — Shevchenka — вул. Тараса Шевченка, 31 · Секонд-хенд Львів</title>
-<meta name="description" content="HUMANA — Shevchenka — секонд-хенд у Львові, за адресою вул. Тараса Шевченка, 31, поштучно (ціна за річ), останнє завезення: 2026-07-06 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta name="description" content="HUMANA — Shevchenka — секонд-хенд у Львові, за адресою вул. Тараса Шевченка, 31, поштучно (ціна за річ), останнє завезення: 2026-08-17 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <link rel="canonical" href="https://www.lvivsecondhand.com/store/h8/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Lviv Second Hand">
 <meta property="og:title" content="HUMANA — Shevchenka — вул. Тараса Шевченка, 31 · Секонд-хенд Львів">
-<meta property="og:description" content="HUMANA — Shevchenka — секонд-хенд у Львові, за адресою вул. Тараса Шевченка, 31, поштучно (ціна за річ), останнє завезення: 2026-07-06 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta property="og:description" content="HUMANA — Shevchenka — секонд-хенд у Львові, за адресою вул. Тараса Шевченка, 31, поштучно (ціна за річ), останнє завезення: 2026-08-17 (за офіційним календарем). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <meta property="og:url" content="https://www.lvivsecondhand.com/store/h8/">
 <meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
 <meta property="og:locale" content="uk_UA">
@@ -88,7 +88,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Адреса</th><td>вул. Тараса Шевченка, 31 <span class="dim">· Shevchenka St, 31</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
       <tr><th scope="row">Мережа</th><td>HUMANA</td></tr>
-      <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-07-06 (за офіційним календарем)</td></tr>
+      <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-17 (за офіційним календарем)</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>35 дн.</td></tr>
     </tbody>
   </table>
@@ -116,7 +116,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">2026-04-27</th><td class="dim">вже було</td></tr>
       <tr><th scope="row">2026-06-01</th><td class="dim">вже було</td></tr>
       <tr><th scope="row">2026-07-06</th><td class="dim">вже було</td></tr>
-      <tr><th scope="row">2026-08-17</th><td>заплановано</td></tr>
+      <tr><th scope="row">2026-08-17</th><td class="dim">вже було</td></tr>
       <tr><th scope="row">2026-09-21</th><td>заплановано</td></tr>
       <tr><th scope="row">2026-10-26</th><td>заплановано</td></tr>
       <tr><th scope="row">2026-11-30</th><td>заплановано</td></tr>

--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -816,36 +816,43 @@ async function handleAgentCallback(env, c, cq) {
 // owner also gets /admin (see cmdAdminMenu), instead of every task getting its
 // own top-level command. Bump CMD_VER to force a re-sync after editing the
 // lists. Self-managing → no BotFather /setcommands needed.
-const CMD_VER = 'v7';
-// Everything the router answers for an ordinary user. /stop and /leaderboard
-// are ungated commands that were missing from this list, so they existed and
-// worked but could not be discovered from the menu — only by reading /help.
+const CMD_VER = 'v8';
+// Telegram renders setMyCommands as one flat list in exactly the order given,
+// with no headers or sections available. So the menu is categorised the only
+// two ways it can be: the order groups related commands into contiguous bands,
+// and a leading emoji per band makes the boundary visible while scrolling.
+// The emoji is chosen per band, not per command, so the eye can pick out a band
+// without reading — which is the whole point of grouping eighteen entries.
+//
+// Public band, in the order a shopper needs them: find stock, then find a
+// bargain, then the two owner-facing entries, then community, then settings.
 const PUBLIC_CMDS = [
-  { command: 'today', description: 'Магазини із завезенням сьогодні' },
-  { command: 'cheap', description: 'Найкращі ціни на вагу зараз' },
-  { command: 'submit', description: 'Додати свій магазин (власникам)' },
-  { command: 'materials', description: 'Матеріали для друку: флаєри, наліпки' },
-  { command: 'leaderboard', description: 'Топ учасників за балами' },
-  { command: 'stop', description: 'Відписатися від усіх сповіщень' },
-  { command: 'help', description: 'Команди та інформація' },
+  { command: 'today', description: '🛍 Магазини із завезенням сьогодні' },
+  { command: 'cheap', description: '🛍 Найкращі ціни на вагу зараз' },
+  { command: 'submit', description: '🏪 Додати свій магазин (власникам)' },
+  { command: 'materials', description: '🏪 Матеріали для друку: флаєри, наліпки' },
+  { command: 'leaderboard', description: '🏆 Топ учасників за балами' },
+  { command: 'stop', description: '🔕 Вимкнути всі сповіщення' },
+  { command: 'help', description: 'ℹ️ Команди та інформація' },
 ];
-// Agents additionally get the field-work commands. These are all gated on
-// isAgent in the router, so listing them for anyone else would only advertise a
-// refusal.
+// Field-work band. All gated on isAgent in the router, so listing them for
+// anyone else would only advertise a refusal. Bilingual here and in the owner
+// band below, unlike the public band: these are read by the owner too.
 const AGENT_CMDS = [
   { command: 'agent', description: '🧭 Меню агента · Agent menu' },
-  { command: 'visit', description: 'Записати відвідування магазину' },
-  { command: 'route', description: 'Маршрут обходу від вашої локації' },
-  { command: 'myvisits', description: 'Мої відвідування та заробіток' },
-  { command: 'pay', description: 'Ставки оплати' },
-  { command: 'card', description: 'Картка для виплат' },
-  { command: 'job', description: 'Опис роботи' },
-  { command: 'cancel', description: 'Скасувати активну дію' },
+  { command: 'visit', description: '🧭 Записати відвідування магазину' },
+  { command: 'route', description: '🧭 Маршрут обходу від вашої локації' },
+  { command: 'myvisits', description: '🧭 Мої відвідування та заробіток' },
+  { command: 'pay', description: '🧭 Ставки оплати · Pay rates' },
+  { command: 'card', description: '🧭 Картка для виплат · Payout card' },
+  { command: 'job', description: '🧭 Опис роботи · Job brief' },
+  { command: 'cancel', description: '🧭 Скасувати активну дію · Cancel' },
 ];
+// Owner band — last, because it is the one nobody else ever sees.
 const OWNER_CMDS = [
   { command: 'admin', description: '⚙️ Адмін-меню · Admin menu' },
-  { command: 'report', description: 'Звіт: відвідування та оплата' },
-  { command: 'export', description: 'CSV усіх відвідувань' },
+  { command: 'report', description: '⚙️ Звіт: відвідування та оплата' },
+  { command: 'export', description: '⚙️ CSV усіх відвідувань' },
 ];
 async function syncBotCommands(env, userId, isOwner, isAgent) {
   // Record the version ONLY when Telegram accepted the menu.


### PR DESCRIPTION
Two things, the second found by the first failing CI.

## 1 · The menu, categorised

Eighteen commands were rendering as one undifferentiated list — only `/agent` and `/admin` carried an emoji.

`setMyCommands` is a **flat list with no headers**, rendered in exactly the order supplied. So there are two levers: **order** groups related commands into contiguous runs, and **a leading emoji per band** makes the boundary visible while scrolling.

```
🛍  /today  /cheap                                          shopping
🏪  /submit  /materials                                     for store owners
🏆  /leaderboard                                            community
🔕  /stop                                                   settings
ℹ️  /help                                                   help
🧭  /agent /visit /route /myvisits /pay /card /job /cancel   field work
⚙️  /admin  /report  /export                                owner
```

The emoji repeats **within** a band rather than being unique per command — that repetition is the grouping. A distinct icon on all eighteen would look tidier and group nothing.

The owner band goes last: it is the one nobody else ever sees. Public entries stay Ukrainian-only (that band is read by shoppers in Lviv); the agent and owner bands are bilingual, because the owner reads those too.

`CMD_VER` → `v8` so the menu re-syncs.

## 2 · The store pages were lying to Google

CI failed on five HUMANA pages this PR never touched. They were not stale through neglect — **parts of a store page are derived from today's date**, not from `stores.json`:

- `Останнє завезення: <most recent past calendar date>`
- each calendar row marked `вже було` or `заплановано`

Those flip on their own as dates pass, with no commit involved. Today is a HUMANA restock day, so overnight the committed pages started advertising a last delivery of **2026-07-06 — six weeks stale** — and nothing would have corrected them until someone happened to edit `stores.json`.

### The structural half

`ci.yml` regenerates and fails if the committed output differs. That is correct: it cannot tell a stale file from a forgotten one. But because the output moves on its own, **the first pull request opened after any calendar date passes fails on files it never touched**, blaming whoever is next — roughly ten days a year on the current HUMANA calendar.

`refresh-pages.yml` regenerates and commits daily at 03:17 UTC, so `main` stays current and the guard only ever fires for the reason it was written: someone edited `stores.json` without regenerating.

## Verification

- Rendered the exact ordered menu an owner will see; 18 entries, no duplicates, no malformed names, all descriptions well inside Telegram's 256 limit
- `check-wiring` confirms all eighteen still resolve to a real handler
- Confirmed `refresh-pages.yml` stages exactly the paths `ci.yml` guards — `store`, `sitemap.xml`, `qr` — so the two cannot drift apart
- `validate-stores`, `check-inline-js`, `node --check` on both Workers, `wrangler 4 deploy --dry-run` all pass
- CI green on the head commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN