### PR TITLE
Phase D: HUMANA Широка 81а closing note (h5, permanently closing 2026-08-23)

### DIFF
--- a/store/h5/index.html
+++ b/store/h5/index.html
@@ -144,7 +144,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
   </table>
 
   <h2>Примітки</h2>
-  <p class="note">2-week inventory cycle. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.</p>
+  <p class="note">⚠️ Магазин закривається назавжди 23.08.2026. Розпродаж: одяг/взуття/текстиль — 56 грн, дрібнички — 30 грн, ексклюзивні знахідки — знижка -50%. · 2-week inventory cycle. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · ⚠️ Permanently closing 2026-08-23. Clearance sale: clothing/shoes/textiles 56 UAH, small items 30 UAH, exclusive finds -50% off. · Hours can change the day before a new collection; some stores close or open short.</p>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/stores.json
+++ b/stores.json
@@ -184,13 +184,7 @@
     "cycle": 14,
     "lat": 49.841221,
     "lng": 23.96754,
-    "note": "2-week inventory cycle. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.",
-    "flashDeal": {
-      "text": "НД 16.08 зачинено · нова колекція в понеділок 17.08 · Closed Sun 16.08, new collection Mon 17.08",
-      "alert": false,
-      "startsAt": "2026-08-15T16:20:00.000Z",
-      "expiresAt": "2026-08-16T21:00:00.000Z"
-    }
+    "note": "⚠️ Магазин закривається назавжди 23.08.2026. Розпродаж: одяг/взуття/текстиль — 56 грн, дрібнички — 30 грн, ексклюзивні знахідки — знижка -50%. · 2-week inventory cycle. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · ⚠️ Permanently closing 2026-08-23. Clearance sale: clothing/shoes/textiles 56 UAH, small items 30 UAH, exclusive finds -50% off. · Hours can change the day before a new collection; some stores close or open short."
   },
   {
     "id": "h6",


### PR DESCRIPTION
Per #211: `h5` (HUMANA — Shyroka, вул. Широка, 81а) is permanently closing **2026-08-23** and is currently running a clearance sale.

*(Rebuilt on top of #213/#214 after the first push — no functional change, just a fresh base to avoid the dirty-merge issue hit on Phase B.)*

## What's added

Note, both languages: clothing/shoes/textiles flat 56 ₴, small items 30 ₴, exclusive finds -50% off, plus the closing date. Real value for shoppers during the four days it's still open — no reason to wait on this.

Also cleared `h5`'s `flashDeal` field while already touching the record — it expired `2026-08-16T21:00`, stale as of today, and the new note replaces it as the reason to visit.

## What's deliberately not done yet

**Not removing the store.** It's still open through the 23rd. I'll come back after that date and remove `h5` once it's actually closed — scheduled a self check-in for then rather than guessing a removal date into this PR or leaving it as a TODO that depends on someone remembering.

## Verification

- `node scripts/validate-stores.mjs` — 99 stores, no duplicate ids
- Both generators re-run; only `store/h5/index.html` changes (note-only edit, as expected)
- `check-wiring`, `check-inline-js` pass

## Issue to close on merge

`#211`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)