### PR TITLE
Apply c75's owner-submitted restock data (#196), missed in Phase A

### DIFF
--- a/store/c75/index.html
+++ b/store/c75/index.html
@@ -5,12 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="theme-color" content="#17693a">
 <title>Світ секонд-хенду — Симона Петлюри 2а — вул. Симона Петлюри, 2а · Секонд-хенд Львів</title>
-<meta name="description" content="Світ секонд-хенду — Симона Петлюри 2а — секонд-хенд у Львові, за адресою вул. Симона Петлюри, 2а, на вагу (ціна за кілограм). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta name="description" content="Світ секонд-хенду — Симона Петлюри 2а — секонд-хенд у Львові, за адресою вул. Симона Петлюри, 2а, на вагу (ціна за кілограм), останнє завезення: 2026-08-13. Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <link rel="canonical" href="https://www.lvivsecondhand.com/store/c75/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Lviv Second Hand">
 <meta property="og:title" content="Світ секонд-хенду — Симона Петлюри 2а — вул. Симона Петлюри, 2а · Секонд-хенд Львів">
-<meta property="og:description" content="Світ секонд-хенду — Симона Петлюри 2а — секонд-хенд у Львові, за адресою вул. Симона Петлюри, 2а, на вагу (ціна за кілограм). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta property="og:description" content="Світ секонд-хенду — Симона Петлюри 2а — секонд-хенд у Львові, за адресою вул. Симона Петлюри, 2а, на вагу (ціна за кілограм), останнє завезення: 2026-08-13. Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <meta property="og:url" content="https://www.lvivsecondhand.com/store/c75/">
 <meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
 <meta property="og:locale" content="uk_UA">
@@ -124,7 +124,8 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Адреса</th><td>вул. Симона Петлюри, 2а <span class="dim">· Symona Petliury St, 2a</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
       <tr><th scope="row">Мережа</th><td>Світ секонд-хенду</td></tr>
-      <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
+      <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-13</td></tr>
+      <tr><th scope="row">Цикл знижок</th><td>14 дн.</td></tr>
     </tbody>
   </table>
 

--- a/stores.json
+++ b/stores.json
@@ -2097,10 +2097,11 @@
       "sat": "09:00–19:00",
       "sun": "10:00–18:00"
     },
-    "cycle": 7,
+    "cycle": 14,
     "lat": 49.8228104,
     "lng": 23.9779404,
-    "note": "By weight. Part of the Світ секонд-хенду chain."
+    "note": "By weight. Part of the Світ секонд-хенду chain.",
+    "restock_date": "2026-08-13"
   },
   {
     "id": "c76",


### PR DESCRIPTION
Small follow-up, caught while closing out issues after Phase A/B merged.

`#196` ("Світ секонд-хенду - Петлюри") is an owner submission for the same address as the existing `c75` (вул. Симона Петлюри, 2а) — a correction, not a new store, per the backlog plan. It carries a 14-day cycle and a `2026-08-13` restock date; hours already matched what `c75` had.

**This fell through the cracks.** It wasn't part of `#198`'s edit batch (a separate map-contribution thread from the four owner-submission issues), so it was never in Phase A's edit list — I only caught the gap while writing the closing comment on `#196` and checking the record actually reflected it. It didn't.

## Fix

`c75.cycle`: 7 → 14, `c75.restock_date`: (none) → `2026-08-13`.

## Verification

- `node scripts/validate-stores.mjs` — 99 stores, no duplicate ids
- Both generators re-run; only `store/c75/index.html` changes, as expected for a two-field edit
- `check-wiring` passes

## Issue to close on merge

`#196`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_