### PR TITLE
Add s10's Saturday restock day from the #208 community list

### DIFF
--- a/store/s10/index.html
+++ b/store/s10/index.html
@@ -5,12 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="theme-color" content="#17693a">
 <title>Planeta Second Hand — вул. Драгана, 4 · Секонд-хенд Львів</title>
-<meta name="description" content="Planeta Second Hand — секонд-хенд у Львові, за адресою вул. Драгана, 4, поштучно (ціна за річ). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta name="description" content="Planeta Second Hand — секонд-хенд у Львові, за адресою вул. Драгана, 4, поштучно (ціна за річ), завезення щотижня: субота. Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <link rel="canonical" href="https://www.lvivsecondhand.com/store/s10/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Lviv Second Hand">
 <meta property="og:title" content="Planeta Second Hand — вул. Драгана, 4 · Секонд-хенд Львів">
-<meta property="og:description" content="Planeta Second Hand — секонд-хенд у Львові, за адресою вул. Драгана, 4, поштучно (ціна за річ). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta property="og:description" content="Planeta Second Hand — секонд-хенд у Львові, за адресою вул. Драгана, 4, поштучно (ціна за річ), завезення щотижня: субота. Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <meta property="og:url" content="https://www.lvivsecondhand.com/store/s10/">
 <meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
 <meta property="og:locale" content="uk_UA">
@@ -119,6 +119,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Адреса</th><td>вул. Драгана, 4 <span class="dim">· Drahana St, 4</span></td></tr>
       <tr><th scope="row">Телефон</th><td><a href="tel:0971467226">097 146 7226</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
+      <tr><th scope="row">Завезення</th><td>Завезення щотижня: субота</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
   </table>

--- a/stores.json
+++ b/stores.json
@@ -466,6 +466,7 @@
       "sun": "closed"
     },
     "cycle": 7,
+    "restockDay": "sat",
     "lat": 49.813,
     "lng": 24.031,
     "note": "⭐ 3.8 (187 reviews)."


### PR DESCRIPTION
## Summary
- Cross-checked the community-maintained restock list posted in #208 against `stores.json` (full analysis posted as a comment on #208).
- Of everything in that list, this is the one clean, additive, non-conflicting fix: `s10` (Planeta Second Hand, вул. Драгана, 4) had no `restockDay` set, and the list's "Субота" (Saturday) is consistent with `s10`'s existing `cycle: 7` — so it actually takes effect in `getDayInfo()`, unlike several other "new info" matches that turned out to be no-ops (see #208 comment for why).
- Regenerated `store/` pages via `scripts/build-store-pages.mjs`; `qr/`, `sitemap.xml`, and the bot's data snapshot were also rebuilt and are unchanged in content.

## Test plan
- [x] `node scripts/validate-stores.mjs`
- [x] `node scripts/check-inline-js.mjs`
- [x] `node scripts/check-wiring.mjs`
- [x] `node scripts/build-store-pages.mjs && node scripts/build-qr-posters.mjs` — in sync
- [x] `(cd telegram-bot && node build-data.mjs)`
- [x] `node --check worker/worker.js && node --check telegram-bot/worker.js`


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_