### PR TITLE
Apply the standard HUMANA hours to h8 (Shevchenka)

### DIFF
--- a/store/h8/index.html
+++ b/store/h8/index.html
@@ -38,7 +38,43 @@
   "openingHoursSpecification": [
     {
       "@type": "OpeningHoursSpecification",
+      "dayOfWeek": "https://schema.org/Monday",
+      "opens": "10:00",
+      "closes": "20:00"
+    },
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": "https://schema.org/Tuesday",
+      "opens": "10:00",
+      "closes": "20:00"
+    },
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": "https://schema.org/Wednesday",
+      "opens": "10:00",
+      "closes": "20:00"
+    },
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": "https://schema.org/Thursday",
+      "opens": "10:00",
+      "closes": "20:00"
+    },
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": "https://schema.org/Friday",
+      "opens": "10:00",
+      "closes": "20:00"
+    },
+    {
+      "@type": "OpeningHoursSpecification",
       "dayOfWeek": "https://schema.org/Saturday",
+      "opens": "10:00",
+      "closes": "20:00"
+    },
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": "https://schema.org/Sunday",
       "opens": "10:00",
       "closes": "20:00"
     }
@@ -96,13 +132,13 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
   <h2>Години роботи</h2>
   <table>
     <tbody>
-      <tr><th scope="row">Понеділок</th><td class="dim">Невідомо</td></tr>
-      <tr><th scope="row">Вівторок</th><td class="dim">Невідомо</td></tr>
-      <tr><th scope="row">Середа</th><td class="dim">Невідомо</td></tr>
-      <tr><th scope="row">Четвер</th><td class="dim">Невідомо</td></tr>
-      <tr><th scope="row">П’ятниця</th><td class="dim">Невідомо</td></tr>
+      <tr><th scope="row">Понеділок</th><td>10:00–20:00</td></tr>
+      <tr><th scope="row">Вівторок</th><td>10:00–20:00</td></tr>
+      <tr><th scope="row">Середа</th><td>10:00–20:00</td></tr>
+      <tr><th scope="row">Четвер</th><td>10:00–20:00</td></tr>
+      <tr><th scope="row">П’ятниця</th><td>10:00–20:00</td></tr>
       <tr><th scope="row">Субота</th><td>10:00–20:00</td></tr>
-      <tr><th scope="row">Неділя</th><td class="dim">Невідомо</td></tr>
+      <tr><th scope="row">Неділя</th><td>10:00–20:00</td></tr>
     </tbody>
   </table>
 
@@ -124,7 +160,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
   </table>
 
   <h2>Примітки</h2>
-  <p class="note">Додано з оголошення HUMANA — пін і години потребують перевірки на місці. · Added from HUMANA’s own announcement; pin and hours need field verification. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.</p>
+  <p class="note">Додано з оголошення HUMANA — пін потребує перевірки на місці. Години встановлено за стандартним графіком мережі (10:00–20:00 щодня, як у решти 7 точок HUMANA), а не підтверджено особисто для цієї адреси. · Added from HUMANA’s own announcement; pin still needs field verification. Hours are set to the brand&#39;s standard 10:00–20:00 daily schedule (matching all 7 other HUMANA locations), not individually confirmed for this address. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.</p>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/stores.json
+++ b/stores.json
@@ -278,18 +278,18 @@
     "type": "humana",
     "pricing": "item",
     "hours": {
-      "mon": "?",
-      "tue": "?",
-      "wed": "?",
-      "thu": "?",
-      "fri": "?",
+      "mon": "10:00–20:00",
+      "tue": "10:00–20:00",
+      "wed": "10:00–20:00",
+      "thu": "10:00–20:00",
+      "fri": "10:00–20:00",
       "sat": "10:00–20:00",
-      "sun": "?"
+      "sun": "10:00–20:00"
     },
     "cycle": 35,
     "lat": 49.845559,
     "lng": 24.007059,
-    "note": "Додано з оголошення HUMANA — пін і години потребують перевірки на місці. · Added from HUMANA’s own announcement; pin and hours need field verification. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.",
+    "note": "Додано з оголошення HUMANA — пін потребує перевірки на місці. Години встановлено за стандартним графіком мережі (10:00–20:00 щодня, як у решти 7 точок HUMANA), а не підтверджено особисто для цієї адреси. · Added from HUMANA’s own announcement; pin still needs field verification. Hours are set to the brand's standard 10:00–20:00 daily schedule (matching all 7 other HUMANA locations), not individually confirmed for this address. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.",
     "restockDates": [
       "2026-01-12",
       "2026-02-16",


### PR DESCRIPTION
## Summary
`h8` ("HUMANA — Shevchenka", вул. Тараса Шевченка, 31) was added from HUMANA's own opening announcement without a field visit — its own note already said so ("pin and hours need field verification"). Its `hours` were mostly `"?"` (only Saturday had a value), while all 7 other HUMANA locations share identical `10:00–20:00` hours every day of the week.

- Set `h8`'s hours to `10:00–20:00` daily, matching the 7-for-7 pattern across every other HUMANA location.
- Updated the note to say hours are inferred from the brand-wide standard schedule, not individually confirmed for this address — the pin-needs-verification caveat is kept.

Regenerated `store/h8/`.

## Test plan
- [x] `node scripts/validate-stores.mjs`
- [x] `node scripts/check-inline-js.mjs`
- [x] `node scripts/check-wiring.mjs`
- [x] `node scripts/build-store-pages.mjs && node scripts/build-qr-posters.mjs` — in sync
- [x] `(cd telegram-bot && node build-data.mjs)`
- [x] `node --check worker/worker.js && node --check telegram-bot/worker.js`


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_