### PR TITLE
Note h8 as a recently-opened HUMANA location on the standard schedule

### DIFF
--- a/store/h8/index.html
+++ b/store/h8/index.html
@@ -160,7 +160,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
   </table>
 
   <h2>Примітки</h2>
-  <p class="note">Додано з оголошення HUMANA — пін потребує перевірки на місці. Години встановлено за стандартним графіком мережі (10:00–20:00 щодня, як у решти 7 точок HUMANA), а не підтверджено особисто для цієї адреси. · Added from HUMANA’s own announcement; pin still needs field verification. Hours are set to the brand&#39;s standard 10:00–20:00 daily schedule (matching all 7 other HUMANA locations), not individually confirmed for this address. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.</p>
+  <p class="note">Нещодавно відкрита точка HUMANA — оновлення товару за тим самим графіком мережі (5-тижневий цикл), що й інші точки. Пін потребує перевірки на місці; години встановлено за стандартним графіком мережі (10:00–20:00 щодня, як у решти 7 точок HUMANA). · Recently opened HUMANA location — restocks on the same brand-wide schedule (5-week cycle) as the other locations. Pin still needs field verification; hours are set to the brand&#39;s standard 10:00–20:00 daily schedule, matching all 7 other HUMANA locations. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.</p>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/stores.json
+++ b/stores.json
@@ -289,7 +289,7 @@
     "cycle": 35,
     "lat": 49.845559,
     "lng": 24.007059,
-    "note": "Додано з оголошення HUMANA — пін потребує перевірки на місці. Години встановлено за стандартним графіком мережі (10:00–20:00 щодня, як у решти 7 точок HUMANA), а не підтверджено особисто для цієї адреси. · Added from HUMANA’s own announcement; pin still needs field verification. Hours are set to the brand's standard 10:00–20:00 daily schedule (matching all 7 other HUMANA locations), not individually confirmed for this address. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.",
+    "note": "Нещодавно відкрита точка HUMANA — оновлення товару за тим самим графіком мережі (5-тижневий цикл), що й інші точки. Пін потребує перевірки на місці; години встановлено за стандартним графіком мережі (10:00–20:00 щодня, як у решти 7 точок HUMANA). · Recently opened HUMANA location — restocks on the same brand-wide schedule (5-week cycle) as the other locations. Pin still needs field verification; hours are set to the brand's standard 10:00–20:00 daily schedule, matching all 7 other HUMANA locations. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.",
     "restockDates": [
       "2026-01-12",
       "2026-02-16",


### PR DESCRIPTION
## Summary
Confirmed: `h8` is a recently opened HUMANA location, restocking on the same brand-wide 5-week cycle as every other HUMANA store — which already matches the `restockDates` calendar on the record (no data change needed there, it was already correct). Updated the note to say so directly instead of only framing the store as an unconfirmed announcement. The pin-verification caveat is unchanged — only the hours/schedule framing.

Regenerated `store/h8/`.

## Test plan
- [x] `node scripts/validate-stores.mjs`
- [x] `node scripts/check-inline-js.mjs`
- [x] `node scripts/check-wiring.mjs`
- [x] `node scripts/build-store-pages.mjs && node scripts/build-qr-posters.mjs` — in sync
- [x] `(cd telegram-bot && node build-data.mjs)`
- [x] `node --check worker/worker.js && node --check telegram-bot/worker.js`


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_