### PR TITLE
Confirm h2/c70 share a building at Любінська 100

### DIFF
--- a/store/c70/index.html
+++ b/store/c70/index.html
@@ -143,7 +143,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
   </table>
 
   <h2>Примітки</h2>
-  <p class="note">By weight. Part of the Світ секонд-хенду chain.</p>
+  <p class="note">By weight. Part of the Світ секонд-хенду chain. Confirmed: shares this building with h2 (HUMANA) — two separate stores, not a duplicate.</p>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/h2/index.html
+++ b/store/h2/index.html
@@ -144,7 +144,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
   </table>
 
   <h2>Примітки</h2>
-  <p class="note">2nd floor entrance. 2-week inventory cycle. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.</p>
+  <p class="note">2nd floor entrance. 2-week inventory cycle. Confirmed: shares this building with c70 (Світ секонд-хенду) — two separate stores, not a duplicate. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.</p>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/stores.json
+++ b/stores.json
@@ -85,7 +85,7 @@
     "cycle": 14,
     "lat": 49.822719,
     "lng": 23.973377,
-    "note": "2nd floor entrance. 2-week inventory cycle. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.",
+    "note": "2nd floor entrance. 2-week inventory cycle. Confirmed: shares this building with c70 (Світ секонд-хенду) — two separate stores, not a duplicate. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.",
     "flashDeal": {
       "text": "НД 16.08 зачинено · нова колекція в понеділок 17.08 · Closed Sun 16.08, new collection Mon 17.08",
       "alert": false,
@@ -1984,7 +1984,7 @@
     "cycle": 7,
     "lat": 49.8227191,
     "lng": 23.9733768,
-    "note": "By weight. Part of the Світ секонд-хенду chain.",
+    "note": "By weight. Part of the Світ секонд-хенду chain. Confirmed: shares this building with h2 (HUMANA) — two separate stores, not a duplicate.",
     "restock_date": "2026-08-05"
   },
   {


### PR DESCRIPTION
## Summary
Confirmed: `h2` (HUMANA — Lyubinska) and `c70` (Світ секонд-хенду — Любінська 100) really do share one building — two separate stores, not a duplicate. This was one of the "shared building, different chain" pairs a prior duplicate hunt flagged as likely-but-unverified. Noted directly on both records so it doesn't get second-guessed again, matching the same treatment already applied to the confirmed Сихівська 18 case (`h4`/`c28`).

Regenerated `store/h2/` and `store/c70/`.

## Test plan
- [x] `node scripts/validate-stores.mjs`
- [x] `node scripts/check-inline-js.mjs`
- [x] `node scripts/check-wiring.mjs`
- [x] `node scripts/build-store-pages.mjs && node scripts/build-qr-posters.mjs` — in sync
- [x] `(cd telegram-bot && node build-data.mjs)`
- [x] `node --check worker/worker.js && node --check telegram-bot/worker.js`


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_