### PR TITLE
Surface the real error when "Add to the official map" fails

### DIFF
--- a/index.html
+++ b/index.html
@@ -2889,12 +2889,19 @@ async function contributeGitHub(btn){
       method:'POST', headers:{'Content-Type':'application/json'},
       body: JSON.stringify({ kind:'contribution', payload: b }),
     });
-    if(!res.ok) throw new Error('submit failed');
+    if(!res.ok) {
+      // Distinguish "reached the server but it said no" from a network-level
+      // failure (CORS, ad-blocker, offline) — both used to collapse into the
+      // same silent alert, which made this un-diagnosable without dev tools.
+      const detail = await res.text().catch(() => '');
+      throw new Error(`HTTP ${res.status}${detail ? ': ' + detail.slice(0, 100) : ''}`);
+    }
     track('action','contribute');
     document.getElementById('share-overlay').classList.add('hidden');
     alert(t('submitThanks'));
   } catch(e){
-    alert(t('submitFailed'));
+    console.error('contributeGitHub failed:', e);
+    alert(t('submitFailed') + '\n\n(' + (e && e.message ? e.message : 'unknown error') + ')');
   } finally {
     if(btn) btn.disabled = false;
   }


### PR DESCRIPTION
## Summary

Investigated the reported "Add to the official map" failure (generic "couldn't submit — try again" alert). Could not reproduce it — everything I could test from outside the browser came back healthy:

- `/api/submit` on the live worker accepts a real contribution payload correctly (tested directly, bypassing the browser).
- CORS preflight + the actual POST both succeed for `https://www.lvivsecondhand.com` and `https://lvivsecondhand.com`.
- The deployed site is running the current code (checked for markers from the last two merged PRs).
- Payload size isn't the issue — confirmed the 24000-char cap does reject oversized bundles with a clean 413, but the user's bundle is small.
- Not an in-app-browser/WebView restriction — reported as a normal browser.

Every failure mode in `contributeGitHub()` was collapsing into one generic, undifferentiated `alert(t('submitFailed'))`, with nothing logged — impossible to diagnose further without dev tools already open at the moment of failure.

**Change:** the alert now includes the actual cause — `HTTP <status>: <response body>` when the server answered but rejected the submission, or the browser's own fetch-rejection message (e.g. `Failed to fetch`, which usually means a network-level block — CORS, ad-blocker, offline — rather than anything server-side) when the request never got a response. Also logs the full error to the console. This isn't a confirmed fix for the underlying bug — it's what's needed to actually identify it, since every external check came back clean.

## Test plan
- [x] `node scripts/validate-stores.mjs` — OK
- [x] `node scripts/check-inline-js.mjs` — OK
- [x] `node scripts/check-wiring.mjs` — OK
- [x] `node scripts/build-store-pages.mjs && node scripts/build-qr-posters.mjs` / bot `build-data.mjs` — regenerated, no diff
- [x] Verified the live `/api/submit` endpoint directly (curl): correct CORS headers for both domain variants, 200 on a normal payload, 413 on an oversized one

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_