### PR TITLE
Apply the 9 new dailyDrop flags from #242

### DIFF
--- a/stores.json
+++ b/stores.json
@@ -353,7 +353,8 @@
     "cycle": 7,
     "lat": 49.85,
     "lng": 24.0195,
-    "note": "Stock and used. Branded items. Updated daily. Frequent sales."
+    "note": "Stock and used. Branded items. Updated daily. Frequent sales.",
+    "dailyDrop": true
   },
   {
     "id": "s6",
@@ -637,7 +638,8 @@
     "cycle": 7,
     "lat": 49.836733,
     "lng": 24.003885,
-    "note": ""
+    "note": "",
+    "dailyDrop": true
   },
   {
     "id": "c10",
@@ -660,7 +662,8 @@
     "cycle": 7,
     "lat": 49.835161,
     "lng": 24.005551,
-    "note": "50% off"
+    "note": "50% off",
+    "dailyDrop": true
   },
   {
     "id": "c11",
@@ -1684,7 +1687,8 @@
     "cycle": 7,
     "lat": 49.834682,
     "lng": 24.008058,
-    "note": "From locator.lviv.ua listing."
+    "note": "From locator.lviv.ua listing.",
+    "dailyDrop": true
   },
   {
     "id": "c58",
@@ -2351,7 +2355,8 @@
       "thu": "09:00–20:00",
       "fri": "09:00–20:00",
       "sat": "09:00–20:00"
-    }
+    },
+    "dailyDrop": true
   },
   {
     "id": "c88",
@@ -2374,7 +2379,8 @@
       "thu": "09:00–20:00",
       "fri": "09:00–20:00",
       "sat": "09:00–20:00"
-    }
+    },
+    "dailyDrop": true
   },
   {
     "id": "c89",
@@ -3111,7 +3117,8 @@
       "fri": "?",
       "sat": "?",
       "sun": "?"
-    }
+    },
+    "dailyDrop": true
   },
   {
     "id": "c121",
@@ -3180,7 +3187,8 @@
       "fri": "?",
       "sat": "?",
       "sun": "?"
-    }
+    },
+    "dailyDrop": true
   },
   {
     "id": "c124",
@@ -3203,6 +3211,7 @@
       "fri": "?",
       "sat": "?",
       "sun": "?"
-    }
+    },
+    "dailyDrop": true
   }
 ]


### PR DESCRIPTION
## Summary

Reviewed all 22 corrections in #242 (the real map-contribution bundle submitted after the 413 fix) against current `stores.json`.

- **13 of 22 already matched current data exactly** — no-op: `c84`'s hours/note/restock_date (applied in #235), and the 10 restock dates on `c60`/`c77`/`c76`/`c72`/`c68`/`c53`/`c70`/`c78`/`c74`/`c69` (applied weeks earlier via the #198 batch).
- **`c71`'s proposed `restock_date` (2026-08-05) was skipped deliberately.** It's the *stale* anonymous map-edit date for that store — this session already resolved a conflict between that and an owner-submission's date, choosing 2026-08-11 as the trustworthy one. Applying the resubmitted device-local value would have silently reverted that call.
- **9 genuinely new corrections, applied:** `dailyDrop: true` on `c123`, `c88`, `c87`, `c124`, `c120`, `s4`, `c9`, `c10`, `c57` — flagged individually by the maintainer through the app's Edit/delivery-date modal, on stores the earlier "супер"/"бомба"/"super"/"Bomba" keyword search never caught (МЮНХЕН, ЄвроБренд, ObnovaNova, and a few unbranded "Sekond Hand"/"Оутлет Сток" listings).

Closes #242.

**Not part of this PR:** #238 and #239, the other two open `map-contribution` issues, are test submissions from debugging the "Add to the official map" 413 bug earlier today (one fake `dailyDrop` edit on `c2`, one empty bundle) — not real corrections. Closing those separately without merging.

## Test plan
- [x] `node scripts/validate-stores.mjs` — OK, 131 stores
- [x] `node scripts/check-inline-js.mjs` — OK
- [x] `node scripts/check-wiring.mjs` — OK
- [x] `node scripts/build-store-pages.mjs && node scripts/build-qr-posters.mjs` / bot `build-data.mjs` — regenerated, no diff (dailyDrop isn't reflected in static SEO pages, matching precedent)
- [x] `node --check worker/worker.js && node --check telegram-bot/worker.js` — OK

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_