### PR TITLE
Apply #245's 5 new corrections, skip its stale Birka! Lux/c71 data

### DIFF
--- a/store/c2/index.html
+++ b/store/c2/index.html
@@ -5,12 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="theme-color" content="#17693a">
 <title>Second hand · Секонд-хенд Львів</title>
-<meta name="description" content="Second hand — секонд-хенд у Львові, поштучно (ціна за річ), останнє завезення: 2026-08-03. Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta name="description" content="Second hand — секонд-хенд у Львові, на вагу (ціна за кілограм), останнє завезення: 2026-08-03. Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <link rel="canonical" href="https://www.lvivsecondhand.com/store/c2/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Lviv Second Hand">
 <meta property="og:title" content="Second hand · Секонд-хенд Львів">
-<meta property="og:description" content="Second hand — секонд-хенд у Львові, поштучно (ціна за річ), останнє завезення: 2026-08-03. Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta property="og:description" content="Second hand — секонд-хенд у Львові, на вагу (ціна за кілограм), останнє завезення: 2026-08-03. Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <meta property="og:url" content="https://www.lvivsecondhand.com/store/c2/">
 <meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
 <meta property="og:locale" content="uk_UA">
@@ -114,7 +114,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
   <h2>Інформація</h2>
   <table>
     <tbody>
-      <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
+      <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-03</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>

--- a/store/c3/index.html
+++ b/store/c3/index.html
@@ -5,12 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="theme-color" content="#17693a">
 <title>Euro second hand — вул. Шота Руставелі, 42 · Секонд-хенд Львів</title>
-<meta name="description" content="Euro second hand — секонд-хенд у Львові, за адресою вул. Шота Руставелі, 42, поштучно (ціна за річ), завезення щотижня: середа. Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta name="description" content="Euro second hand — секонд-хенд у Львові, за адресою вул. Шота Руставелі, 42, на вагу (ціна за кілограм), завезення щотижня: середа. Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <link rel="canonical" href="https://www.lvivsecondhand.com/store/c3/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Lviv Second Hand">
 <meta property="og:title" content="Euro second hand — вул. Шота Руставелі, 42 · Секонд-хенд Львів">
-<meta property="og:description" content="Euro second hand — секонд-хенд у Львові, за адресою вул. Шота Руставелі, 42, поштучно (ціна за річ), завезення щотижня: середа. Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta property="og:description" content="Euro second hand — секонд-хенд у Львові, за адресою вул. Шота Руставелі, 42, на вагу (ціна за кілограм), завезення щотижня: середа. Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <meta property="og:url" content="https://www.lvivsecondhand.com/store/c3/">
 <meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
 <meta property="og:locale" content="uk_UA">
@@ -78,7 +78,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
   <table>
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Шота Руставелі, 42 <span class="dim">· 42 Shota Rustaveli St</span></td></tr>
-      <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
+      <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: середа</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>

--- a/store/c5/index.html
+++ b/store/c5/index.html
@@ -5,12 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="theme-color" content="#17693a">
 <title>Euro second hand — вулиця Юліуша Словацького, 14 · Секонд-хенд Львів</title>
-<meta name="description" content="Euro second hand — секонд-хенд у Львові, за адресою вулиця Юліуша Словацького, 14, поштучно (ціна за річ), останнє завезення: 2026-08-08. Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta name="description" content="Euro second hand — секонд-хенд у Львові, за адресою вулиця Юліуша Словацького, 14, на вагу (ціна за кілограм), останнє завезення: 2026-08-08. Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <link rel="canonical" href="https://www.lvivsecondhand.com/store/c5/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Lviv Second Hand">
 <meta property="og:title" content="Euro second hand — вулиця Юліуша Словацького, 14 · Секонд-хенд Львів">
-<meta property="og:description" content="Euro second hand — секонд-хенд у Львові, за адресою вулиця Юліуша Словацького, 14, поштучно (ціна за річ), останнє завезення: 2026-08-08. Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta property="og:description" content="Euro second hand — секонд-хенд у Львові, за адресою вулиця Юліуша Словацького, 14, на вагу (ціна за кілограм), останнє завезення: 2026-08-08. Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <meta property="og:url" content="https://www.lvivsecondhand.com/store/c5/">
 <meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
 <meta property="og:locale" content="uk_UA">
@@ -78,7 +78,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
   <table>
     <tbody>
       <tr><th scope="row">Адреса</th><td>вулиця Юліуша Словацького, 14 <span class="dim">· 14 Yuliusha Slovatskoho St</span></td></tr>
-      <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
+      <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-08</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>

--- a/store/s9/index.html
+++ b/store/s9/index.html
@@ -5,12 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="theme-color" content="#17693a">
 <title>Світ секонд-хенду — Горська 5а — вул. Горська, 5а · Секонд-хенд Львів</title>
-<meta name="description" content="Світ секонд-хенду — Горська 5а — секонд-хенд у Львові, за адресою вул. Горська, 5а, поштучно (ціна за річ). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta name="description" content="Світ секонд-хенду — Горська 5а — секонд-хенд у Львові, за адресою вул. Горська, 5а, на вагу (ціна за кілограм). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <link rel="canonical" href="https://www.lvivsecondhand.com/store/s9/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Lviv Second Hand">
 <meta property="og:title" content="Світ секонд-хенду — Горська 5а — вул. Горська, 5а · Секонд-хенд Львів">
-<meta property="og:description" content="Світ секонд-хенду — Горська 5а — секонд-хенд у Львові, за адресою вул. Горська, 5а, поштучно (ціна за річ). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta property="og:description" content="Світ секонд-хенду — Горська 5а — секонд-хенд у Львові, за адресою вул. Горська, 5а, на вагу (ціна за кілограм). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <meta property="og:url" content="https://www.lvivsecondhand.com/store/s9/">
 <meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
 <meta property="og:locale" content="uk_UA">
@@ -124,9 +124,9 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Горська, 5а <span class="dim">· 5a Horska St</span></td></tr>
       <tr><th scope="row">Телефон</th><td><a href="tel:0969461702">096 946 1702</a></td></tr>
-      <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
+      <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
       <tr><th scope="row">Мережа</th><td>Світ секонд-хенду</td></tr>
-      <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
+      <tr><th scope="row">Цикл знижок</th><td>14 дн.</td></tr>
     </tbody>
   </table>
 

--- a/stores.json
+++ b/stores.json
@@ -424,7 +424,8 @@
     "cycle": 7,
     "lat": 49.818,
     "lng": 24.005,
-    "note": "European brands. Furs, leather, bags, jewellery. Accepts items by appointment Mon/Wed/Fri."
+    "note": "European brands. Furs, leather, bags, jewellery. Accepts items by appointment Mon/Wed/Fri.",
+    "dailyDrop": true
   },
   {
     "id": "s9",
@@ -434,7 +435,7 @@
     "addressEn": "5a Horska St",
     "phone": "096 946 1702",
     "type": "other",
-    "pricing": "item",
+    "pricing": "kg",
     "hours": {
       "mon": "10:00–19:00",
       "tue": "10:00–19:00",
@@ -444,7 +445,7 @@
       "sat": "10:00–19:00",
       "sun": "10:00–19:00"
     },
-    "cycle": 7,
+    "cycle": 14,
     "lat": 49.8155,
     "lng": 24.0495,
     "note": "⭐ 4.1 (179 reviews). Open 7 days. Listed as \"Planet of Second-Hand\" (an English rendering of Світ секонд-хенду) prior to being confirmed as part of the chain."
@@ -481,7 +482,7 @@
     "addressEn": "",
     "phone": "",
     "type": "other",
-    "pricing": "item",
+    "pricing": "kg",
     "hours": {
       "sun": "09:00–17:00",
       "mon": "09:00–13:00",
@@ -505,7 +506,7 @@
     "addressEn": "42 Shota Rustaveli St",
     "phone": "",
     "type": "other",
-    "pricing": "item",
+    "pricing": "kg",
     "hours": {
       "mon": "?",
       "tue": "?",
@@ -554,7 +555,7 @@
     "addressEn": "14 Yuliusha Slovatskoho St",
     "phone": "",
     "type": "other",
-    "pricing": "item",
+    "pricing": "kg",
     "hours": {
       "mon": "?",
       "tue": "?",


### PR DESCRIPTION
## Summary

Reviewed all 30 corrections in #245 (another snapshot of the maintainer's local browser state, submitted after #242) with a scripted field-by-field diff against current `stores.json` rather than by eye, given the scale.

**Applied — 5 real corrections not yet on record:**
- `c2`, `c3`, `c5` (three separate "Euro/Second hand" listings): pricing `item` → `kg`
- `s8` (Umka): `dailyDrop: true` — matches its "European brands" resale model; the maintainer's own edit, on a store the earlier "супер"/"бомба"/"super"/"Bomba" keyword search had no reason to catch
- `s9` (Світ секонд-хенду — Горська 5а): pricing `item` → `kg`, cycle `7` → `14`

**Skipped deliberately:**
- `s6` and `c59`'s proposed data is a **stale pre-fix snapshot** — this submission was built from a browser state captured before #244 corrected their coordinates/names/hours. Applying it would have reverted that fix immediately after merging it.
- `c71`'s `restock_date` (2026-08-05) is the same already-rejected anonymous-edit date flagged when reviewing #242 — still stale.

Everything else in the 30 either already matches (the #198 restock-date batch, the `dailyDrop` flags from #243) or is a GitHub 300-char note-truncation artifact in the issue's own rendering (`c123`/`c124`), not a real data difference.

Closes #245.

## Test plan
- [x] `node scripts/validate-stores.mjs` — OK, 132 stores
- [x] `node scripts/check-inline-js.mjs` — OK
- [x] `node scripts/check-wiring.mjs` — OK
- [x] `node scripts/build-store-pages.mjs && node scripts/build-qr-posters.mjs` / bot `build-data.mjs` — regenerated, in sync
- [x] `node --check worker/worker.js && node --check telegram-bot/worker.js` — OK
- [x] Scripted field-by-field diff of all 30 proposed corrections against current data (not manual inspection), to catch everything at this scale reliably

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_