### PR TITLE
Add chain landing pages and cross-link the store pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,9 @@ jobs:
       - name: Check store pages are in sync with stores.json
         run: |
           node scripts/build-store-pages.mjs
-          if [ -n "$(git status --porcelain -- store sitemap.xml)" ]; then
-            echo "::error::store/ or sitemap.xml is stale. Run: node scripts/build-store-pages.mjs"
-            git status --porcelain -- store sitemap.xml
+          if [ -n "$(git status --porcelain -- store chain sitemap.xml)" ]; then
+            echo "::error::store/, chain/ or sitemap.xml is stale. Run: node scripts/build-store-pages.mjs"
+            git status --porcelain -- store chain sitemap.xml
             exit 1
           fi
           echo "Store pages are in sync."

--- a/.github/workflows/refresh-pages.yml
+++ b/.github/workflows/refresh-pages.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           git config user.name "lviv-secondhand-bot"
           git config user.email "actions@users.noreply.github.com"
-          git add store sitemap.xml qr
+          git add store chain sitemap.xml qr
           if git diff --cached --quiet; then
             echo "Nothing changed — no calendar date passed since the last run."
             exit 0

--- a/.github/workflows/update-map.yml
+++ b/.github/workflows/update-map.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           git config user.name "lviv-secondhand-bot"
           git config user.email "actions@users.noreply.github.com"
-          git add stores.json store sitemap.xml qr
+          git add stores.json store chain sitemap.xml qr
           if git diff --cached --quiet; then
             echo "No changes after patch — nothing to commit."
             exit 0

--- a/chain/birka-lux/index.html
+++ b/chain/birka-lux/index.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="theme-color" content="#17693a">
+<title>Birka! Lux у Львові — 3 магазини: адреси та години</title>
+<meta name="description" content="Усі 3 магазини мережі Birka! Lux у Львові на одній карті: адреси, години роботи, ціни та дні завезення товару.">
+<link rel="canonical" href="https://www.lvivsecondhand.com/chain/birka-lux/">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Lviv Second Hand">
+<meta property="og:title" content="Birka! Lux у Львові — 3 магазини: адреси та години">
+<meta property="og:description" content="Усі 3 магазини мережі Birka! Lux у Львові на одній карті: адреси, години роботи, ціни та дні завезення товару.">
+<meta property="og:url" content="https://www.lvivsecondhand.com/chain/birka-lux/">
+<meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
+<meta property="og:locale" content="uk_UA">
+<link rel="icon" href="https://www.lvivsecondhand.com/favicon.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="https://www.lvivsecondhand.com/apple-touch-icon.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": "https://www.lvivsecondhand.com/chain/birka-lux/#chain",
+  "name": "Birka! Lux",
+  "url": "https://www.lvivsecondhand.com/chain/birka-lux/",
+  "areaServed": {
+    "@type": "City",
+    "name": "Львів"
+  },
+  "location": [
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/s6/#store",
+      "name": "Birka! Lux — Зелена 69а",
+      "url": "https://www.lvivsecondhand.com/store/s6/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Зелена, 69а",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8304495,
+        "longitude": 24.0440999
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c59/#store",
+      "name": "Birka! Lux — Котика 2",
+      "url": "https://www.lvivsecondhand.com/store/c59/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Богдана Котика, 2",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.836844,
+        "longitude": 24.0601287
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c125/#store",
+      "name": "Birka! Lux — Шпитальна 7",
+      "url": "https://www.lvivsecondhand.com/store/c125/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Шпитальна, 7",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8443936,
+        "longitude": 24.0235193
+      }
+    }
+  ],
+  "isPartOf": {
+    "@type": "WebSite",
+    "@id": "https://www.lvivsecondhand.com/#website"
+  }
+}
+</script>
+<style>
+:root{--paper:#f7f4ef;--ink:#14211a;--muted:#5d6b63;--green:#17693a;--line:#e2ddd4;--card:#fff}
+@media(prefers-color-scheme:dark){:root{--paper:#0f1613;--ink:#e8efe9;--muted:#9aa9a0;--green:#4bbd7a;--line:#26332c;--card:#151f1a}}
+*{box-sizing:border-box}
+body{margin:0;background:var(--paper);color:var(--ink);font:16px/1.6 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+.wrap{max-width:680px;margin:0 auto;padding:24px 20px 56px}
+a{color:var(--green)}
+.crumb{font-size:13px;color:var(--muted);margin-bottom:18px}
+.crumb a{color:var(--muted)}
+h1{font-size:26px;line-height:1.25;margin:0 0 6px}
+.sub{color:var(--muted);margin:0 0 22px;font-size:15px}
+table{width:100%;border-collapse:collapse;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden;margin:0 0 22px}
+th,td{text-align:left;padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px;vertical-align:top}
+tr:last-child th,tr:last-child td{border-bottom:0}
+th{font-weight:600;color:var(--muted)}
+table.facts th{width:56%}
+.dim{color:var(--muted);font-size:14px}
+h2{font-size:17px;margin:26px 0 10px}
+.cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 22px 0}
+footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <nav class="crumb"><a href="https://www.lvivsecondhand.com/">Секонд-хенди Львова</a> › <a href="https://www.lvivsecondhand.com/store/">Усі магазини</a> › Birka! Lux</nav>
+
+  <h1>Birka! Lux у Львові</h1>
+  <p class="sub">3 магазини мережі на карті секонд-хендів Львова — адреси, години роботи та дні завезення.</p>
+
+  <a class="cta" href="https://www.lvivsecondhand.com/">Відкрити на карті</a>
+
+  <h2>Про мережу</h2>
+  <table class="facts">
+    <tbody>
+      <tr><th scope="row">Магазинів у Львові</th><td>3</td></tr>
+      <tr><th scope="row">Відомі години роботи</th><td>3 з 3</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Магазини мережі</h2>
+  <table>
+    <thead><tr><th scope="col">Магазин</th><th scope="col">Ціни та завезення</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/s6/">Birka! Lux — Зелена 69а</a><br><span class="dim">вул. Зелена, 69а</span></td>
+        <td>Поштучно (ціна за річ)</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c59/">Birka! Lux — Котика 2</a><br><span class="dim">вул. Богдана Котика, 2</span></td>
+        <td>Поштучно (ціна за річ)</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c125/">Birka! Lux — Шпитальна 7</a><br><span class="dim">вул. Шпитальна, 7</span></td>
+        <td>Поштучно (ціна за річ)</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <footer>
+    Дані оновлюються спільнотою. Помітили помилку — виправте у
+    <a href="https://www.lvivsecondhand.com/">застосунку</a>.<br>
+    <a href="https://www.lvivsecondhand.com/store/">← Усі секонд-хенди Львова списком</a>
+  </footer>
+</div>
+</body>
+</html>

--- a/chain/economclass/index.html
+++ b/chain/economclass/index.html
@@ -1,0 +1,576 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="theme-color" content="#17693a">
+<title>EconomClass у Львові — 22 магазини: адреси та години</title>
+<meta name="description" content="Усі 22 магазини мережі EconomClass у Львові на одній карті: адреси, години роботи, ціни на вагу та дні завезення товару.">
+<link rel="canonical" href="https://www.lvivsecondhand.com/chain/economclass/">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Lviv Second Hand">
+<meta property="og:title" content="EconomClass у Львові — 22 магазини: адреси та години">
+<meta property="og:description" content="Усі 22 магазини мережі EconomClass у Львові на одній карті: адреси, години роботи, ціни на вагу та дні завезення товару.">
+<meta property="og:url" content="https://www.lvivsecondhand.com/chain/economclass/">
+<meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
+<meta property="og:locale" content="uk_UA">
+<link rel="icon" href="https://www.lvivsecondhand.com/favicon.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="https://www.lvivsecondhand.com/apple-touch-icon.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": "https://www.lvivsecondhand.com/chain/economclass/#chain",
+  "name": "EconomClass",
+  "url": "https://www.lvivsecondhand.com/chain/economclass/",
+  "areaServed": {
+    "@type": "City",
+    "name": "Львів"
+  },
+  "location": [
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c32/#store",
+      "name": "EconomClass — B. Khmelnytskoho 275",
+      "url": "https://www.lvivsecondhand.com/store/c32/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Б. Хмельницького, 275",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.874502,
+        "longitude": 24.059873
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c51/#store",
+      "name": "EconomClass — Chervonohrad, S. Bandery 14",
+      "url": "https://www.lvivsecondhand.com/store/c51/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "м. Червоноград, вул. С. Бандери, 14",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 50.400879,
+        "longitude": 24.248485
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c48/#store",
+      "name": "EconomClass — Chervonohrad, Sheptytskoho 1",
+      "url": "https://www.lvivsecondhand.com/store/c48/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "м. Червоноград, вул. Шептицького, 1",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 50.400227,
+        "longitude": 24.24146
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c46/#store",
+      "name": "EconomClass — Chervonohrad, Sheptytskoho 2",
+      "url": "https://www.lvivsecondhand.com/store/c46/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "м. Червоноград, вул. Шептицького, 2",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 50.397938,
+        "longitude": 24.241436
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c47/#store",
+      "name": "EconomClass — Chervonohrad, Sokalska 2",
+      "url": "https://www.lvivsecondhand.com/store/c47/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "м. Червоноград, вул. Сокальська, 2",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 50.396307,
+        "longitude": 24.23171
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c37/#store",
+      "name": "EconomClass — Chornovola 67",
+      "url": "https://www.lvivsecondhand.com/store/c37/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Чорновола, 67",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.861428,
+        "longitude": 24.017172
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c38/#store",
+      "name": "EconomClass — Drahana 2",
+      "url": "https://www.lvivsecondhand.com/store/c38/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Драгана, 2",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.785192,
+        "longitude": 24.05725
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c41/#store",
+      "name": "EconomClass — Drohobych, Kovalska 2",
+      "url": "https://www.lvivsecondhand.com/store/c41/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "м. Дрогобич, вул. Ковальська, 2",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.352335,
+        "longitude": 23.507713
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c40/#store",
+      "name": "EconomClass — Drohobych, Shevchenka 1",
+      "url": "https://www.lvivsecondhand.com/store/c40/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "м. Дрогобич, вул. Шевченка, 1",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.353021,
+        "longitude": 23.507125
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c83/#store",
+      "name": "EconomClass — Drohobych, Shevchenka 1 (2nd floor)",
+      "url": "https://www.lvivsecondhand.com/store/c83/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "м. Дрогобич, вул. Шевченка, 1 (2 поверх)",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.353021,
+        "longitude": 23.507125
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c31/#store",
+      "name": "EconomClass — Heroiv UPA 73",
+      "url": "https://www.lvivsecondhand.com/store/c31/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Героїв УПА, 73",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.827142,
+        "longitude": 23.992055
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c39/#store",
+      "name": "EconomClass — Horodok, Peremyshlska 20",
+      "url": "https://www.lvivsecondhand.com/store/c39/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "м. Городок, вул. Перемишльська, 20",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.783715,
+        "longitude": 23.642052
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c33/#store",
+      "name": "EconomClass — Horska 5A",
+      "url": "https://www.lvivsecondhand.com/store/c33/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Горська, 5А",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8155,
+        "longitude": 24.0495
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c35/#store",
+      "name": "EconomClass — Lychakivska 201",
+      "url": "https://www.lvivsecondhand.com/store/c35/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Личаківська, 201",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.836163,
+        "longitude": 24.071829
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c34/#store",
+      "name": "EconomClass — Mazepy 11V",
+      "url": "https://www.lvivsecondhand.com/store/c34/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Мазепи, 11В",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.871284,
+        "longitude": 24.03208
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c42/#store",
+      "name": "EconomClass — Novoyavorivsk, Bandery 21A",
+      "url": "https://www.lvivsecondhand.com/store/c42/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "м. Новояворівськ, вул. Бандери, 21а",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.93135,
+        "longitude": 23.573224
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c50/#store",
+      "name": "EconomClass — Novyi Rozdil, Shevchenka 16",
+      "url": "https://www.lvivsecondhand.com/store/c50/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "м. Новий Розділ, просп. Шевченка, 16",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.472014,
+        "longitude": 24.135333
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c44/#store",
+      "name": "EconomClass — Sambir, Torhova 62",
+      "url": "https://www.lvivsecondhand.com/store/c44/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "м. Самбір, вул. Торгова, 62",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.515604,
+        "longitude": 23.198259
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c49/#store",
+      "name": "EconomClass — Sokal, Sheptytskoho 93",
+      "url": "https://www.lvivsecondhand.com/store/c49/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "м. Сокаль, вул. Шептицького, 93",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 50.478494,
+        "longitude": 24.277853
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c45/#store",
+      "name": "EconomClass — Stryi, Uspenska 36A",
+      "url": "https://www.lvivsecondhand.com/store/c45/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "м. Стрий, вул. Успенська, 36а",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.25597,
+        "longitude": 23.856467
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c36/#store",
+      "name": "EconomClass — Vyhovskoho 49",
+      "url": "https://www.lvivsecondhand.com/store/c36/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Виговського, 49",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.816043,
+        "longitude": 23.973503
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c43/#store",
+      "name": "EconomClass — Yavoriv, Makoveia 62",
+      "url": "https://www.lvivsecondhand.com/store/c43/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "м. Яворів, вул. Маковея, 62",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.939703,
+        "longitude": 23.380577
+      }
+    }
+  ],
+  "isPartOf": {
+    "@type": "WebSite",
+    "@id": "https://www.lvivsecondhand.com/#website"
+  }
+}
+</script>
+<style>
+:root{--paper:#f7f4ef;--ink:#14211a;--muted:#5d6b63;--green:#17693a;--line:#e2ddd4;--card:#fff}
+@media(prefers-color-scheme:dark){:root{--paper:#0f1613;--ink:#e8efe9;--muted:#9aa9a0;--green:#4bbd7a;--line:#26332c;--card:#151f1a}}
+*{box-sizing:border-box}
+body{margin:0;background:var(--paper);color:var(--ink);font:16px/1.6 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+.wrap{max-width:680px;margin:0 auto;padding:24px 20px 56px}
+a{color:var(--green)}
+.crumb{font-size:13px;color:var(--muted);margin-bottom:18px}
+.crumb a{color:var(--muted)}
+h1{font-size:26px;line-height:1.25;margin:0 0 6px}
+.sub{color:var(--muted);margin:0 0 22px;font-size:15px}
+table{width:100%;border-collapse:collapse;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden;margin:0 0 22px}
+th,td{text-align:left;padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px;vertical-align:top}
+tr:last-child th,tr:last-child td{border-bottom:0}
+th{font-weight:600;color:var(--muted)}
+table.facts th{width:56%}
+.dim{color:var(--muted);font-size:14px}
+h2{font-size:17px;margin:26px 0 10px}
+.cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 22px 0}
+footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <nav class="crumb"><a href="https://www.lvivsecondhand.com/">Секонд-хенди Львова</a> › <a href="https://www.lvivsecondhand.com/store/">Усі магазини</a> › EconomClass</nav>
+
+  <h1>EconomClass у Львові</h1>
+  <p class="sub">22 магазини мережі на карті секонд-хендів Львова — адреси, години роботи та дні завезення.</p>
+
+  <a class="cta" href="https://www.lvivsecondhand.com/">Відкрити на карті</a>
+
+  <h2>Про мережу</h2>
+  <table class="facts">
+    <tbody>
+      <tr><th scope="row">Магазинів у Львові</th><td>22</td></tr>
+      <tr><th scope="row">На вагу</th><td>22 з 22</td></tr>
+      <tr><th scope="row">Відомі години роботи</th><td>22 з 22</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Магазини мережі</h2>
+  <table>
+    <thead><tr><th scope="col">Магазин</th><th scope="col">Ціни та завезення</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><br><span class="dim">вул. Б. Хмельницького, 275</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: вівторок</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><br><span class="dim">м. Червоноград, вул. С. Бандери, 14</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: вівторок</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><br><span class="dim">м. Червоноград, вул. Шептицького, 1</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: п’ятниця</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><br><span class="dim">м. Червоноград, вул. Шептицького, 2</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: середа</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><br><span class="dim">м. Червоноград, вул. Сокальська, 2</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: четвер</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><br><span class="dim">вул. Чорновола, 67</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: п’ятниця</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><br><span class="dim">вул. Драгана, 2</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: субота</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><br><span class="dim">м. Дрогобич, вул. Ковальська, 2</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: п’ятниця</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c40/">EconomClass — Drohobych, Shevchenka 1</a><br><span class="dim">м. Дрогобич, вул. Шевченка, 1</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: середа</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c83/">EconomClass — Drohobych, Shevchenka 1 (2nd floor)</a><br><span class="dim">м. Дрогобич, вул. Шевченка, 1 (2 поверх)</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: понеділок</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c31/">EconomClass — Heroiv UPA 73</a><br><span class="dim">вул. Героїв УПА, 73</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: понеділок</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c39/">EconomClass — Horodok, Peremyshlska 20</a><br><span class="dim">м. Городок, вул. Перемишльська, 20</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: п’ятниця</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c33/">EconomClass — Horska 5A</a><br><span class="dim">вул. Горська, 5А</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: вівторок</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c35/">EconomClass — Lychakivska 201</a><br><span class="dim">вул. Личаківська, 201</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: п’ятниця</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c34/">EconomClass — Mazepy 11V</a><br><span class="dim">вул. Мазепи, 11В</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: четвер</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c42/">EconomClass — Novoyavorivsk, Bandery 21A</a><br><span class="dim">м. Новояворівськ, вул. Бандери, 21а</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: п’ятниця</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c50/">EconomClass — Novyi Rozdil, Shevchenka 16</a><br><span class="dim">м. Новий Розділ, просп. Шевченка, 16</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: п’ятниця</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c44/">EconomClass — Sambir, Torhova 62</a><br><span class="dim">м. Самбір, вул. Торгова, 62</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: вівторок</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c49/">EconomClass — Sokal, Sheptytskoho 93</a><br><span class="dim">м. Сокаль, вул. Шептицького, 93</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: четвер</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c45/">EconomClass — Stryi, Uspenska 36A</a><br><span class="dim">м. Стрий, вул. Успенська, 36а</span></td>
+        <td>На вагу (ціна за кілограм)</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c36/">EconomClass — Vyhovskoho 49</a><br><span class="dim">вул. Виговського, 49</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: п’ятниця</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c43/">EconomClass — Yavoriv, Makoveia 62</a><br><span class="dim">м. Яворів, вул. Маковея, 62</span></td>
+        <td>На вагу (ціна за кілограм)</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <footer>
+    Дані оновлюються спільнотою. Помітили помилку — виправте у
+    <a href="https://www.lvivsecondhand.com/">застосунку</a>.<br>
+    <a href="https://www.lvivsecondhand.com/store/">← Усі секонд-хенди Львова списком</a>
+  </footer>
+</div>
+</body>
+</html>

--- a/chain/humana/index.html
+++ b/chain/humana/index.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="theme-color" content="#17693a">
+<title>HUMANA у Львові — 8 магазинів: адреси та години</title>
+<meta name="description" content="Усі 8 магазинів мережі HUMANA у Львові на одній карті: адреси, години роботи, ціни та дні завезення товару.">
+<link rel="canonical" href="https://www.lvivsecondhand.com/chain/humana/">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Lviv Second Hand">
+<meta property="og:title" content="HUMANA у Львові — 8 магазинів: адреси та години">
+<meta property="og:description" content="Усі 8 магазинів мережі HUMANA у Львові на одній карті: адреси, години роботи, ціни та дні завезення товару.">
+<meta property="og:url" content="https://www.lvivsecondhand.com/chain/humana/">
+<meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
+<meta property="og:locale" content="uk_UA">
+<link rel="icon" href="https://www.lvivsecondhand.com/favicon.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="https://www.lvivsecondhand.com/apple-touch-icon.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": "https://www.lvivsecondhand.com/chain/humana/#chain",
+  "name": "HUMANA",
+  "url": "https://www.lvivsecondhand.com/chain/humana/",
+  "areaServed": {
+    "@type": "City",
+    "name": "Львів"
+  },
+  "location": [
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/h3/#store",
+      "name": "HUMANA — Chornovola",
+      "url": "https://www.lvivsecondhand.com/store/h3/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "просп. В. Чорновола, 95",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.86345,
+        "longitude": 24.016631
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/h6/#store",
+      "name": "HUMANA — Doroshenka",
+      "url": "https://www.lvivsecondhand.com/store/h6/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. П. Дорошенка, 1",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.840313,
+        "longitude": 24.02733
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/h1/#store",
+      "name": "HUMANA — Knyahyni Olhy",
+      "url": "https://www.lvivsecondhand.com/store/h1/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Княгині Ольги, 5а",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.822992,
+        "longitude": 24.008012
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/h2/#store",
+      "name": "HUMANA — Lyubinska",
+      "url": "https://www.lvivsecondhand.com/store/h2/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Любинська, 100 (2 поверх)",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.822719,
+        "longitude": 23.973377
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/h8/#store",
+      "name": "HUMANA — Shevchenka",
+      "url": "https://www.lvivsecondhand.com/store/h8/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Тараса Шевченка, 31",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.845559,
+        "longitude": 24.007059
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/h5/#store",
+      "name": "HUMANA — Shyroka",
+      "url": "https://www.lvivsecondhand.com/store/h5/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Широка, 81а",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.841221,
+        "longitude": 23.96754
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/h4/#store",
+      "name": "HUMANA — Sykhivska",
+      "url": "https://www.lvivsecondhand.com/store/h4/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Сиховська, 18",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.794862,
+        "longitude": 24.063585
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/h7/#store",
+      "name": "HUMANA Vintage",
+      "url": "https://www.lvivsecondhand.com/store/h7/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Валова, 13",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.840059,
+        "longitude": 24.032867
+      }
+    }
+  ],
+  "isPartOf": {
+    "@type": "WebSite",
+    "@id": "https://www.lvivsecondhand.com/#website"
+  }
+}
+</script>
+<style>
+:root{--paper:#f7f4ef;--ink:#14211a;--muted:#5d6b63;--green:#17693a;--line:#e2ddd4;--card:#fff}
+@media(prefers-color-scheme:dark){:root{--paper:#0f1613;--ink:#e8efe9;--muted:#9aa9a0;--green:#4bbd7a;--line:#26332c;--card:#151f1a}}
+*{box-sizing:border-box}
+body{margin:0;background:var(--paper);color:var(--ink);font:16px/1.6 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+.wrap{max-width:680px;margin:0 auto;padding:24px 20px 56px}
+a{color:var(--green)}
+.crumb{font-size:13px;color:var(--muted);margin-bottom:18px}
+.crumb a{color:var(--muted)}
+h1{font-size:26px;line-height:1.25;margin:0 0 6px}
+.sub{color:var(--muted);margin:0 0 22px;font-size:15px}
+table{width:100%;border-collapse:collapse;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden;margin:0 0 22px}
+th,td{text-align:left;padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px;vertical-align:top}
+tr:last-child th,tr:last-child td{border-bottom:0}
+th{font-weight:600;color:var(--muted)}
+table.facts th{width:56%}
+.dim{color:var(--muted);font-size:14px}
+h2{font-size:17px;margin:26px 0 10px}
+.cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 22px 0}
+footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <nav class="crumb"><a href="https://www.lvivsecondhand.com/">Секонд-хенди Львова</a> › <a href="https://www.lvivsecondhand.com/store/">Усі магазини</a> › HUMANA</nav>
+
+  <h1>HUMANA у Львові</h1>
+  <p class="sub">8 магазинів мережі на карті секонд-хендів Львова — адреси, години роботи та дні завезення.</p>
+
+  <a class="cta" href="https://www.lvivsecondhand.com/">Відкрити на карті</a>
+
+  <h2>Про мережу</h2>
+  <table class="facts">
+    <tbody>
+      <tr><th scope="row">Магазинів у Львові</th><td>8</td></tr>
+      <tr><th scope="row">Відомі години роботи</th><td>8 з 8</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Магазини мережі</h2>
+  <table>
+    <thead><tr><th scope="col">Магазин</th><th scope="col">Ціни та завезення</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/h3/">HUMANA — Chornovola</a><br><span class="dim">просп. В. Чорновола, 95</span></td>
+        <td>Поштучно (ціна за річ)<br><span class="dim">Останнє завезення: 2026-08-17 (за офіційним календарем)</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/h6/">HUMANA — Doroshenka</a><br><span class="dim">вул. П. Дорошенка, 1</span></td>
+        <td>Поштучно (ціна за річ)<br><span class="dim">Останнє завезення: 2026-08-17 (за офіційним календарем)</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/h1/">HUMANA — Knyahyni Olhy</a><br><span class="dim">вул. Княгині Ольги, 5а</span></td>
+        <td>Поштучно (ціна за річ)<br><span class="dim">Останнє завезення: 2026-08-17 (за офіційним календарем)</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/h2/">HUMANA — Lyubinska</a><br><span class="dim">вул. Любинська, 100 (2 поверх)</span></td>
+        <td>Поштучно (ціна за річ)</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/h8/">HUMANA — Shevchenka</a><br><span class="dim">вул. Тараса Шевченка, 31</span></td>
+        <td>Поштучно (ціна за річ)<br><span class="dim">Останнє завезення: 2026-08-17 (за офіційним календарем)</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/h5/">HUMANA — Shyroka</a><br><span class="dim">вул. Широка, 81а</span></td>
+        <td>Поштучно (ціна за річ)</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/h4/">HUMANA — Sykhivska</a><br><span class="dim">вул. Сиховська, 18</span></td>
+        <td>Поштучно (ціна за річ)</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/h7/">HUMANA Vintage</a><br><span class="dim">вул. Валова, 13</span></td>
+        <td>Поштучно (ціна за річ)<br><span class="dim">Останнє завезення: 2026-08-17 (за офіційним календарем)</span></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <footer>
+    Дані оновлюються спільнотою. Помітили помилку — виправте у
+    <a href="https://www.lvivsecondhand.com/">застосунку</a>.<br>
+    <a href="https://www.lvivsecondhand.com/store/">← Усі секонд-хенди Львова списком</a>
+  </footer>
+</div>
+</body>
+</html>

--- a/chain/myunkhen/index.html
+++ b/chain/myunkhen/index.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="theme-color" content="#17693a">
+<title>МЮНХЕН у Львові — 2 магазини: адреси та години</title>
+<meta name="description" content="Усі 2 магазини мережі МЮНХЕН у Львові на одній карті: адреси, години роботи, ціни та дні завезення товару.">
+<link rel="canonical" href="https://www.lvivsecondhand.com/chain/myunkhen/">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Lviv Second Hand">
+<meta property="og:title" content="МЮНХЕН у Львові — 2 магазини: адреси та години">
+<meta property="og:description" content="Усі 2 магазини мережі МЮНХЕН у Львові на одній карті: адреси, години роботи, ціни та дні завезення товару.">
+<meta property="og:url" content="https://www.lvivsecondhand.com/chain/myunkhen/">
+<meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
+<meta property="og:locale" content="uk_UA">
+<link rel="icon" href="https://www.lvivsecondhand.com/favicon.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="https://www.lvivsecondhand.com/apple-touch-icon.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": "https://www.lvivsecondhand.com/chain/myunkhen/#chain",
+  "name": "МЮНХЕН",
+  "url": "https://www.lvivsecondhand.com/chain/myunkhen/",
+  "areaServed": {
+    "@type": "City",
+    "name": "Львів"
+  },
+  "location": [
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c123/#store",
+      "name": "МЮНХЕН — Вороного 2",
+      "url": "https://www.lvivsecondhand.com/store/c123/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вулиця Миколи Вороного, 2",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8386832,
+        "longitude": 24.0299467
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c124/#store",
+      "name": "МЮНХЕН — Городоцька 10",
+      "url": "https://www.lvivsecondhand.com/store/c124/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "Городоцька вулиця, 10",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8439178,
+        "longitude": 24.023748
+      }
+    }
+  ],
+  "isPartOf": {
+    "@type": "WebSite",
+    "@id": "https://www.lvivsecondhand.com/#website"
+  }
+}
+</script>
+<style>
+:root{--paper:#f7f4ef;--ink:#14211a;--muted:#5d6b63;--green:#17693a;--line:#e2ddd4;--card:#fff}
+@media(prefers-color-scheme:dark){:root{--paper:#0f1613;--ink:#e8efe9;--muted:#9aa9a0;--green:#4bbd7a;--line:#26332c;--card:#151f1a}}
+*{box-sizing:border-box}
+body{margin:0;background:var(--paper);color:var(--ink);font:16px/1.6 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+.wrap{max-width:680px;margin:0 auto;padding:24px 20px 56px}
+a{color:var(--green)}
+.crumb{font-size:13px;color:var(--muted);margin-bottom:18px}
+.crumb a{color:var(--muted)}
+h1{font-size:26px;line-height:1.25;margin:0 0 6px}
+.sub{color:var(--muted);margin:0 0 22px;font-size:15px}
+table{width:100%;border-collapse:collapse;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden;margin:0 0 22px}
+th,td{text-align:left;padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px;vertical-align:top}
+tr:last-child th,tr:last-child td{border-bottom:0}
+th{font-weight:600;color:var(--muted)}
+table.facts th{width:56%}
+.dim{color:var(--muted);font-size:14px}
+h2{font-size:17px;margin:26px 0 10px}
+.cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 22px 0}
+footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <nav class="crumb"><a href="https://www.lvivsecondhand.com/">Секонд-хенди Львова</a> › <a href="https://www.lvivsecondhand.com/store/">Усі магазини</a> › МЮНХЕН</nav>
+
+  <h1>МЮНХЕН у Львові</h1>
+  <p class="sub">2 магазини мережі на карті секонд-хендів Львова — адреси, години роботи та дні завезення.</p>
+
+  <a class="cta" href="https://www.lvivsecondhand.com/">Відкрити на карті</a>
+
+  <h2>Про мережу</h2>
+  <table class="facts">
+    <tbody>
+      <tr><th scope="row">Магазинів у Львові</th><td>2</td></tr>
+      <tr><th scope="row">Відомі години роботи</th><td>0 з 2</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Магазини мережі</h2>
+  <table>
+    <thead><tr><th scope="col">Магазин</th><th scope="col">Ціни та завезення</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c123/">МЮНХЕН — Вороного 2</a><br><span class="dim">вулиця Миколи Вороного, 2</span></td>
+        <td>Поштучно (ціна за річ)</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c124/">МЮНХЕН — Городоцька 10</a><br><span class="dim">Городоцька вулиця, 10</span></td>
+        <td>Поштучно (ціна за річ)</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <footer>
+    Дані оновлюються спільнотою. Помітили помилку — виправте у
+    <a href="https://www.lvivsecondhand.com/">застосунку</a>.<br>
+    <a href="https://www.lvivsecondhand.com/store/">← Усі секонд-хенди Львова списком</a>
+  </footer>
+</div>
+</body>
+</html>

--- a/chain/stok-ta-sekond-khend/index.html
+++ b/chain/stok-ta-sekond-khend/index.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="theme-color" content="#17693a">
+<title>Сток та секонд хенд у Львові — 3 магазини: адреси та години</title>
+<meta name="description" content="Усі 3 магазини мережі Сток та секонд хенд у Львові на одній карті: адреси, години роботи, ціни та дні завезення товару.">
+<link rel="canonical" href="https://www.lvivsecondhand.com/chain/stok-ta-sekond-khend/">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Lviv Second Hand">
+<meta property="og:title" content="Сток та секонд хенд у Львові — 3 магазини: адреси та години">
+<meta property="og:description" content="Усі 3 магазини мережі Сток та секонд хенд у Львові на одній карті: адреси, години роботи, ціни та дні завезення товару.">
+<meta property="og:url" content="https://www.lvivsecondhand.com/chain/stok-ta-sekond-khend/">
+<meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
+<meta property="og:locale" content="uk_UA">
+<link rel="icon" href="https://www.lvivsecondhand.com/favicon.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="https://www.lvivsecondhand.com/apple-touch-icon.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": "https://www.lvivsecondhand.com/chain/stok-ta-sekond-khend/#chain",
+  "name": "Сток та секонд хенд",
+  "url": "https://www.lvivsecondhand.com/chain/stok-ta-sekond-khend/",
+  "areaServed": {
+    "@type": "City",
+    "name": "Львів"
+  },
+  "location": [
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c90/#store",
+      "name": "Сток та секонд хенд — Величковського 30а",
+      "url": "https://www.lvivsecondhand.com/store/c90/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Величковського, 30а",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8756978,
+        "longitude": 23.934949
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c89/#store",
+      "name": "Сток та секонд хенд — Пасічна 96А",
+      "url": "https://www.lvivsecondhand.com/store/c89/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Пасічна, 96А",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8219211,
+        "longitude": 24.0753189
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c91/#store",
+      "name": "Сток та секонд хенд — Стрийська 61",
+      "url": "https://www.lvivsecondhand.com/store/c91/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Стрийська, 61",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.795196,
+        "longitude": 24.017837
+      }
+    }
+  ],
+  "isPartOf": {
+    "@type": "WebSite",
+    "@id": "https://www.lvivsecondhand.com/#website"
+  }
+}
+</script>
+<style>
+:root{--paper:#f7f4ef;--ink:#14211a;--muted:#5d6b63;--green:#17693a;--line:#e2ddd4;--card:#fff}
+@media(prefers-color-scheme:dark){:root{--paper:#0f1613;--ink:#e8efe9;--muted:#9aa9a0;--green:#4bbd7a;--line:#26332c;--card:#151f1a}}
+*{box-sizing:border-box}
+body{margin:0;background:var(--paper);color:var(--ink);font:16px/1.6 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+.wrap{max-width:680px;margin:0 auto;padding:24px 20px 56px}
+a{color:var(--green)}
+.crumb{font-size:13px;color:var(--muted);margin-bottom:18px}
+.crumb a{color:var(--muted)}
+h1{font-size:26px;line-height:1.25;margin:0 0 6px}
+.sub{color:var(--muted);margin:0 0 22px;font-size:15px}
+table{width:100%;border-collapse:collapse;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden;margin:0 0 22px}
+th,td{text-align:left;padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px;vertical-align:top}
+tr:last-child th,tr:last-child td{border-bottom:0}
+th{font-weight:600;color:var(--muted)}
+table.facts th{width:56%}
+.dim{color:var(--muted);font-size:14px}
+h2{font-size:17px;margin:26px 0 10px}
+.cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 22px 0}
+footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <nav class="crumb"><a href="https://www.lvivsecondhand.com/">Секонд-хенди Львова</a> › <a href="https://www.lvivsecondhand.com/store/">Усі магазини</a> › Сток та секонд хенд</nav>
+
+  <h1>Сток та секонд хенд у Львові</h1>
+  <p class="sub">3 магазини мережі на карті секонд-хендів Львова — адреси, години роботи та дні завезення.</p>
+
+  <a class="cta" href="https://www.lvivsecondhand.com/">Відкрити на карті</a>
+
+  <h2>Про мережу</h2>
+  <table class="facts">
+    <tbody>
+      <tr><th scope="row">Магазинів у Львові</th><td>3</td></tr>
+      <tr><th scope="row">Відомі години роботи</th><td>3 з 3</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Магазини мережі</h2>
+  <table>
+    <thead><tr><th scope="col">Магазин</th><th scope="col">Ціни та завезення</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c90/">Сток та секонд хенд — Величковського 30а</a><br><span class="dim">вул. Величковського, 30а</span></td>
+        <td>Поштучно (ціна за річ)</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c89/">Сток та секонд хенд — Пасічна 96А</a><br><span class="dim">вул. Пасічна, 96А</span></td>
+        <td>Поштучно (ціна за річ)</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c91/">Сток та секонд хенд — Стрийська 61</a><br><span class="dim">вул. Стрийська, 61</span></td>
+        <td>Поштучно (ціна за річ)</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <footer>
+    Дані оновлюються спільнотою. Помітили помилку — виправте у
+    <a href="https://www.lvivsecondhand.com/">застосунку</a>.<br>
+    <a href="https://www.lvivsecondhand.com/store/">← Усі секонд-хенди Львова списком</a>
+  </footer>
+</div>
+</body>
+</html>

--- a/chain/svit-sekond-khendu/index.html
+++ b/chain/svit-sekond-khendu/index.html
@@ -1,0 +1,488 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="theme-color" content="#17693a">
+<title>Світ секонд-хенду у Львові — 18 магазинів: адреси та години</title>
+<meta name="description" content="Усі 18 магазинів мережі Світ секонд-хенду у Львові на одній карті: адреси, години роботи, ціни на вагу та дні завезення товару.">
+<link rel="canonical" href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Lviv Second Hand">
+<meta property="og:title" content="Світ секонд-хенду у Львові — 18 магазинів: адреси та години">
+<meta property="og:description" content="Усі 18 магазинів мережі Світ секонд-хенду у Львові на одній карті: адреси, години роботи, ціни на вагу та дні завезення товару.">
+<meta property="og:url" content="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">
+<meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
+<meta property="og:locale" content="uk_UA">
+<link rel="icon" href="https://www.lvivsecondhand.com/favicon.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="https://www.lvivsecondhand.com/apple-touch-icon.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": "https://www.lvivsecondhand.com/chain/svit-sekond-khendu/#chain",
+  "name": "Світ секонд-хенду",
+  "url": "https://www.lvivsecondhand.com/chain/svit-sekond-khendu/",
+  "areaServed": {
+    "@type": "City",
+    "name": "Львів"
+  },
+  "location": [
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c73/#store",
+      "name": "Світ секонд-хенду — Антоненка-Давидовича 10",
+      "url": "https://www.lvivsecondhand.com/store/c73/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Бориса Антоненка-Давидовича, 10",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.7923088,
+        "longitude": 24.064716
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c69/#store",
+      "name": "Світ секонд-хенду — Володимира Великого 34",
+      "url": "https://www.lvivsecondhand.com/store/c69/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Володимира Великого, 34",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8113762,
+        "longitude": 23.993522
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c71/#store",
+      "name": "Світ секонд-хенду — Гетьмана Мазепи 24",
+      "url": "https://www.lvivsecondhand.com/store/c71/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Гетьмана Мазепи, 24",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8713384,
+        "longitude": 24.0401275
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/s9/#store",
+      "name": "Світ секонд-хенду — Горська 5а",
+      "url": "https://www.lvivsecondhand.com/store/s9/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Горська, 5а",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8155,
+        "longitude": 24.0495
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c72/#store",
+      "name": "Світ секонд-хенду — Грінченка 6а",
+      "url": "https://www.lvivsecondhand.com/store/c72/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Грінченка, 6а",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8727939,
+        "longitude": 24.0520688
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c85/#store",
+      "name": "Світ секонд-хенду — Джорджа Вашингтона 5А",
+      "url": "https://www.lvivsecondhand.com/store/c85/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Джорджа Вашингтона, 5А",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8164139,
+        "longitude": 24.0694339
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/s10/#store",
+      "name": "Світ секонд-хенду — Драгана 4",
+      "url": "https://www.lvivsecondhand.com/store/s10/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Драгана, 4",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.813,
+        "longitude": 24.031
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c70/#store",
+      "name": "Світ секонд-хенду — Любінська 100",
+      "url": "https://www.lvivsecondhand.com/store/c70/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Любінська, 100",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8227191,
+        "longitude": 23.9733768
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c68/#store",
+      "name": "Світ секонд-хенду — Наукова 53",
+      "url": "https://www.lvivsecondhand.com/store/c68/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Наукова, 53",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8044185,
+        "longitude": 23.986757
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c60/#store",
+      "name": "Світ секонд-хенду — Наукова 64",
+      "url": "https://www.lvivsecondhand.com/store/c60/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Наукова, 64",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.804906,
+        "longitude": 23.992896
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c74/#store",
+      "name": "Світ секонд-хенду — Пасічна 51",
+      "url": "https://www.lvivsecondhand.com/store/c74/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Пасічна, 51",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8279266,
+        "longitude": 24.0715241
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c53/#store",
+      "name": "Світ секонд-хенду — Патона 2",
+      "url": "https://www.lvivsecondhand.com/store/c53/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Патона, 2",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.823034,
+        "longitude": 23.964913
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c75/#store",
+      "name": "Світ секонд-хенду — Симона Петлюри 2а",
+      "url": "https://www.lvivsecondhand.com/store/c75/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Симона Петлюри, 2а",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8228104,
+        "longitude": 23.9779404
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c86/#store",
+      "name": "Світ секонд-хенду — Степана Бандери 22",
+      "url": "https://www.lvivsecondhand.com/store/c86/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Степана Бандери, 22",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8348764,
+        "longitude": 24.0109518
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c84/#store",
+      "name": "Світ секонд-хенду — Цехова 1",
+      "url": "https://www.lvivsecondhand.com/store/c84/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Цехова, 1",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.84924,
+        "longitude": 24.024066
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c76/#store",
+      "name": "Світ секонд-хенду — Чорновола 45",
+      "url": "https://www.lvivsecondhand.com/store/c76/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "просп. В'ячеслава Чорновола, 45",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8549529,
+        "longitude": 24.0219794
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c78/#store",
+      "name": "Світ секонд-хенду — Шевченка 358",
+      "url": "https://www.lvivsecondhand.com/store/c78/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Тараса Шевченка, 358",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.868508,
+        "longitude": 23.9523548
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c77/#store",
+      "name": "Світ секонд-хенду — Широка 70б",
+      "url": "https://www.lvivsecondhand.com/store/c77/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Широка, 70б",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8424662,
+        "longitude": 23.9656562
+      }
+    }
+  ],
+  "isPartOf": {
+    "@type": "WebSite",
+    "@id": "https://www.lvivsecondhand.com/#website"
+  }
+}
+</script>
+<style>
+:root{--paper:#f7f4ef;--ink:#14211a;--muted:#5d6b63;--green:#17693a;--line:#e2ddd4;--card:#fff}
+@media(prefers-color-scheme:dark){:root{--paper:#0f1613;--ink:#e8efe9;--muted:#9aa9a0;--green:#4bbd7a;--line:#26332c;--card:#151f1a}}
+*{box-sizing:border-box}
+body{margin:0;background:var(--paper);color:var(--ink);font:16px/1.6 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+.wrap{max-width:680px;margin:0 auto;padding:24px 20px 56px}
+a{color:var(--green)}
+.crumb{font-size:13px;color:var(--muted);margin-bottom:18px}
+.crumb a{color:var(--muted)}
+h1{font-size:26px;line-height:1.25;margin:0 0 6px}
+.sub{color:var(--muted);margin:0 0 22px;font-size:15px}
+table{width:100%;border-collapse:collapse;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden;margin:0 0 22px}
+th,td{text-align:left;padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px;vertical-align:top}
+tr:last-child th,tr:last-child td{border-bottom:0}
+th{font-weight:600;color:var(--muted)}
+table.facts th{width:56%}
+.dim{color:var(--muted);font-size:14px}
+h2{font-size:17px;margin:26px 0 10px}
+.cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 22px 0}
+footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <nav class="crumb"><a href="https://www.lvivsecondhand.com/">Секонд-хенди Львова</a> › <a href="https://www.lvivsecondhand.com/store/">Усі магазини</a> › Світ секонд-хенду</nav>
+
+  <h1>Світ секонд-хенду у Львові</h1>
+  <p class="sub">18 магазинів мережі на карті секонд-хендів Львова — адреси, години роботи та дні завезення.</p>
+
+  <a class="cta" href="https://www.lvivsecondhand.com/">Відкрити на карті</a>
+
+  <h2>Про мережу</h2>
+  <table class="facts">
+    <tbody>
+      <tr><th scope="row">Магазинів у Львові</th><td>18</td></tr>
+      <tr><th scope="row">На вагу</th><td>17 з 18</td></tr>
+      <tr><th scope="row">Відомі години роботи</th><td>18 з 18</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Магазини мережі</h2>
+  <table>
+    <thead><tr><th scope="col">Магазин</th><th scope="col">Ціни та завезення</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><br><span class="dim">вул. Бориса Антоненка-Давидовича, 10</span></td>
+        <td>На вагу (ціна за кілограм)</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><br><span class="dim">вул. Володимира Великого, 34</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Останнє завезення: 2026-07-29</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><br><span class="dim">вул. Гетьмана Мазепи, 24</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Останнє завезення: 2026-08-11</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><br><span class="dim">вул. Горська, 5а</span></td>
+        <td>На вагу (ціна за кілограм)</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><br><span class="dim">вул. Грінченка, 6а</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Останнє завезення: 2026-08-07</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><br><span class="dim">вул. Джорджа Вашингтона, 5А</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Останнє завезення: 2026-08-15</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><br><span class="dim">вул. Драгана, 4</span></td>
+        <td>Поштучно (ціна за річ)<br><span class="dim">Завезення щотижня: субота</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><br><span class="dim">вул. Любінська, 100</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Останнє завезення: 2026-08-05</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c68/">Світ секонд-хенду — Наукова 53</a><br><span class="dim">вул. Наукова, 53</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Останнє завезення: 2026-08-06</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c60/">Світ секонд-хенду — Наукова 64</a><br><span class="dim">вул. Наукова, 64</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Останнє завезення: 2026-08-14</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c74/">Світ секонд-хенду — Пасічна 51</a><br><span class="dim">вул. Пасічна, 51</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Останнє завезення: 2026-07-29</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c53/">Світ секонд-хенду — Патона 2</a><br><span class="dim">вул. Патона, 2</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Останнє завезення: 2026-08-11</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c75/">Світ секонд-хенду — Симона Петлюри 2а</a><br><span class="dim">вул. Симона Петлюри, 2а</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Останнє завезення: 2026-08-13</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c86/">Світ секонд-хенду — Степана Бандери 22</a><br><span class="dim">вул. Степана Бандери, 22</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Останнє завезення: 2026-08-15</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c84/">Світ секонд-хенду — Цехова 1</a><br><span class="dim">вул. Цехова, 1</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Останнє завезення: 2026-08-07</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c76/">Світ секонд-хенду — Чорновола 45</a><br><span class="dim">просп. В&#39;ячеслава Чорновола, 45</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Останнє завезення: 2026-08-13</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c78/">Світ секонд-хенду — Шевченка 358</a><br><span class="dim">вул. Тараса Шевченка, 358</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Останнє завезення: 2026-08-15</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c77/">Світ секонд-хенду — Широка 70б</a><br><span class="dim">вул. Широка, 70б</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Останнє завезення: 2026-08-14</span></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <footer>
+    Дані оновлюються спільнотою. Помітили помилку — виправте у
+    <a href="https://www.lvivsecondhand.com/">застосунку</a>.<br>
+    <a href="https://www.lvivsecondhand.com/store/">← Усі секонд-хенди Львова списком</a>
+  </footer>
+</div>
+</body>
+</html>

--- a/chain/yevro-trend-sekond-khend/index.html
+++ b/chain/yevro-trend-sekond-khend/index.html
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="theme-color" content="#17693a">
+<title>Євро Тренд Секонд хенд у Львові — 10 магазинів: адреси та години</title>
+<meta name="description" content="Усі 10 магазинів мережі Євро Тренд Секонд хенд у Львові на одній карті: адреси, години роботи, ціни на вагу та дні завезення товару.">
+<link rel="canonical" href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Lviv Second Hand">
+<meta property="og:title" content="Євро Тренд Секонд хенд у Львові — 10 магазинів: адреси та години">
+<meta property="og:description" content="Усі 10 магазинів мережі Євро Тренд Секонд хенд у Львові на одній карті: адреси, години роботи, ціни на вагу та дні завезення товару.">
+<meta property="og:url" content="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">
+<meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
+<meta property="og:locale" content="uk_UA">
+<link rel="icon" href="https://www.lvivsecondhand.com/favicon.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="https://www.lvivsecondhand.com/apple-touch-icon.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": "https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/#chain",
+  "name": "Євро Тренд Секонд хенд",
+  "url": "https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/",
+  "areaServed": {
+    "@type": "City",
+    "name": "Львів"
+  },
+  "location": [
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c30/#store",
+      "name": "Євро Тренд Секонд хенд — Богдана Хмельницького 176",
+      "url": "https://www.lvivsecondhand.com/store/c30/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вулиця Богдана Хмельницького, 176",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.861805,
+        "longitude": 24.051611
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c29/#store",
+      "name": "Євро Тренд Секонд хенд — Володимира Великого 59Б",
+      "url": "https://www.lvivsecondhand.com/store/c29/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вулиця Володимира Великого, 59б",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.809116,
+        "longitude": 24.00112
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c23/#store",
+      "name": "Євро Тренд Секонд хенд — Городоцька 67",
+      "url": "https://www.lvivsecondhand.com/store/c23/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вулиця Городоцька, 67",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.841631,
+        "longitude": 24.016137
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c24/#store",
+      "name": "Євро Тренд Секонд хенд — Горська 2А",
+      "url": "https://www.lvivsecondhand.com/store/c24/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вулиця Горська, 2",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8156,
+        "longitude": 24.0497
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c27/#store",
+      "name": "Євро Тренд Секонд хенд — Котлярська 6",
+      "url": "https://www.lvivsecondhand.com/store/c27/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вулиця Котлярська, 6",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.845323,
+        "longitude": 24.023052
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c26/#store",
+      "name": "Євро Тренд Секонд хенд — Наукова 47",
+      "url": "https://www.lvivsecondhand.com/store/c26/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вулиця Наукова, 47",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.804155,
+        "longitude": 23.990601
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c28/#store",
+      "name": "Євро Тренд Секонд хенд — Сихівська 18",
+      "url": "https://www.lvivsecondhand.com/store/c28/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вулиця Сихівська, 18",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.794862,
+        "longitude": 24.063585
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c25/#store",
+      "name": "Євро Тренд Секонд хенд — Червоної Калини 59",
+      "url": "https://www.lvivsecondhand.com/store/c25/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "проспект Червоної Калини, 59",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.796834,
+        "longitude": 24.054224
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c21/#store",
+      "name": "Євро Тренд Секонд хенд — Чорновола 101",
+      "url": "https://www.lvivsecondhand.com/store/c21/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "проспект В'ячеслава Чорновола, 101",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.865577,
+        "longitude": 24.015615
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c22/#store",
+      "name": "Євро Тренд Секонд хенд — Широка 31",
+      "url": "https://www.lvivsecondhand.com/store/c22/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вулиця Широка, 31",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.842187,
+        "longitude": 23.975855
+      }
+    }
+  ],
+  "isPartOf": {
+    "@type": "WebSite",
+    "@id": "https://www.lvivsecondhand.com/#website"
+  }
+}
+</script>
+<style>
+:root{--paper:#f7f4ef;--ink:#14211a;--muted:#5d6b63;--green:#17693a;--line:#e2ddd4;--card:#fff}
+@media(prefers-color-scheme:dark){:root{--paper:#0f1613;--ink:#e8efe9;--muted:#9aa9a0;--green:#4bbd7a;--line:#26332c;--card:#151f1a}}
+*{box-sizing:border-box}
+body{margin:0;background:var(--paper);color:var(--ink);font:16px/1.6 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+.wrap{max-width:680px;margin:0 auto;padding:24px 20px 56px}
+a{color:var(--green)}
+.crumb{font-size:13px;color:var(--muted);margin-bottom:18px}
+.crumb a{color:var(--muted)}
+h1{font-size:26px;line-height:1.25;margin:0 0 6px}
+.sub{color:var(--muted);margin:0 0 22px;font-size:15px}
+table{width:100%;border-collapse:collapse;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden;margin:0 0 22px}
+th,td{text-align:left;padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px;vertical-align:top}
+tr:last-child th,tr:last-child td{border-bottom:0}
+th{font-weight:600;color:var(--muted)}
+table.facts th{width:56%}
+.dim{color:var(--muted);font-size:14px}
+h2{font-size:17px;margin:26px 0 10px}
+.cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 22px 0}
+footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <nav class="crumb"><a href="https://www.lvivsecondhand.com/">Секонд-хенди Львова</a> › <a href="https://www.lvivsecondhand.com/store/">Усі магазини</a> › Євро Тренд Секонд хенд</nav>
+
+  <h1>Євро Тренд Секонд хенд у Львові</h1>
+  <p class="sub">10 магазинів мережі на карті секонд-хендів Львова — адреси, години роботи та дні завезення.</p>
+
+  <a class="cta" href="https://www.lvivsecondhand.com/">Відкрити на карті</a>
+
+  <h2>Про мережу</h2>
+  <table class="facts">
+    <tbody>
+      <tr><th scope="row">Магазинів у Львові</th><td>10</td></tr>
+      <tr><th scope="row">На вагу</th><td>10 з 10</td></tr>
+      <tr><th scope="row">Відомі години роботи</th><td>10 з 10</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Магазини мережі</h2>
+  <table>
+    <thead><tr><th scope="col">Магазин</th><th scope="col">Ціни та завезення</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c30/">Євро Тренд Секонд хенд — Богдана Хмельницького 176</a><br><span class="dim">вулиця Богдана Хмельницького, 176</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: п’ятниця</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><br><span class="dim">вулиця Володимира Великого, 59б</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: п’ятниця</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c23/">Євро Тренд Секонд хенд — Городоцька 67</a><br><span class="dim">вулиця Городоцька, 67</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: четвер</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c24/">Євро Тренд Секонд хенд — Горська 2А</a><br><span class="dim">вулиця Горська, 2</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: середа</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><br><span class="dim">вулиця Котлярська, 6</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: четвер</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c26/">Євро Тренд Секонд хенд — Наукова 47</a><br><span class="dim">вулиця Наукова, 47</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: четвер</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c28/">Євро Тренд Секонд хенд — Сихівська 18</a><br><span class="dim">вулиця Сихівська, 18</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: понеділок</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c25/">Євро Тренд Секонд хенд — Червоної Калини 59</a><br><span class="dim">проспект Червоної Калини, 59</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: вівторок</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c21/">Євро Тренд Секонд хенд — Чорновола 101</a><br><span class="dim">проспект В&#39;ячеслава Чорновола, 101</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: понеділок</span></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c22/">Євро Тренд Секонд хенд — Широка 31</a><br><span class="dim">вулиця Широка, 31</span></td>
+        <td>На вагу (ціна за кілограм)<br><span class="dim">Завезення щотижня: вівторок</span></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <footer>
+    Дані оновлюються спільнотою. Помітили помилку — виправте у
+    <a href="https://www.lvivsecondhand.com/">застосунку</a>.<br>
+    <a href="https://www.lvivsecondhand.com/store/">← Усі секонд-хенди Львова списком</a>
+  </footer>
+</div>
+</body>
+</html>

--- a/chain/yevrobrend/index.html
+++ b/chain/yevrobrend/index.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="theme-color" content="#17693a">
+<title>ЄвроБренд у Львові — 2 магазини: адреси та години</title>
+<meta name="description" content="Усі 2 магазини мережі ЄвроБренд у Львові на одній карті: адреси, години роботи, ціни та дні завезення товару.">
+<link rel="canonical" href="https://www.lvivsecondhand.com/chain/yevrobrend/">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Lviv Second Hand">
+<meta property="og:title" content="ЄвроБренд у Львові — 2 магазини: адреси та години">
+<meta property="og:description" content="Усі 2 магазини мережі ЄвроБренд у Львові на одній карті: адреси, години роботи, ціни та дні завезення товару.">
+<meta property="og:url" content="https://www.lvivsecondhand.com/chain/yevrobrend/">
+<meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
+<meta property="og:locale" content="uk_UA">
+<link rel="icon" href="https://www.lvivsecondhand.com/favicon.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="https://www.lvivsecondhand.com/apple-touch-icon.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": "https://www.lvivsecondhand.com/chain/yevrobrend/#chain",
+  "name": "ЄвроБренд",
+  "url": "https://www.lvivsecondhand.com/chain/yevrobrend/",
+  "areaServed": {
+    "@type": "City",
+    "name": "Львів"
+  },
+  "location": [
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c88/#store",
+      "name": "ЄвроБренд — Городоцька 33",
+      "url": "https://www.lvivsecondhand.com/store/c88/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Городоцька, 33",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8429182,
+        "longitude": 24.0214116
+      }
+    },
+    {
+      "@type": "Store",
+      "@id": "https://www.lvivsecondhand.com/store/c87/#store",
+      "name": "ЄвроБренд — Городоцька 94",
+      "url": "https://www.lvivsecondhand.com/store/c87/",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "вул. Городоцька, 94",
+        "addressLocality": "Львів",
+        "addressRegion": "Львівська область",
+        "addressCountry": "UA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 49.8378348,
+        "longitude": 24.0054075
+      }
+    }
+  ],
+  "isPartOf": {
+    "@type": "WebSite",
+    "@id": "https://www.lvivsecondhand.com/#website"
+  }
+}
+</script>
+<style>
+:root{--paper:#f7f4ef;--ink:#14211a;--muted:#5d6b63;--green:#17693a;--line:#e2ddd4;--card:#fff}
+@media(prefers-color-scheme:dark){:root{--paper:#0f1613;--ink:#e8efe9;--muted:#9aa9a0;--green:#4bbd7a;--line:#26332c;--card:#151f1a}}
+*{box-sizing:border-box}
+body{margin:0;background:var(--paper);color:var(--ink);font:16px/1.6 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+.wrap{max-width:680px;margin:0 auto;padding:24px 20px 56px}
+a{color:var(--green)}
+.crumb{font-size:13px;color:var(--muted);margin-bottom:18px}
+.crumb a{color:var(--muted)}
+h1{font-size:26px;line-height:1.25;margin:0 0 6px}
+.sub{color:var(--muted);margin:0 0 22px;font-size:15px}
+table{width:100%;border-collapse:collapse;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden;margin:0 0 22px}
+th,td{text-align:left;padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px;vertical-align:top}
+tr:last-child th,tr:last-child td{border-bottom:0}
+th{font-weight:600;color:var(--muted)}
+table.facts th{width:56%}
+.dim{color:var(--muted);font-size:14px}
+h2{font-size:17px;margin:26px 0 10px}
+.cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 22px 0}
+footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <nav class="crumb"><a href="https://www.lvivsecondhand.com/">Секонд-хенди Львова</a> › <a href="https://www.lvivsecondhand.com/store/">Усі магазини</a> › ЄвроБренд</nav>
+
+  <h1>ЄвроБренд у Львові</h1>
+  <p class="sub">2 магазини мережі на карті секонд-хендів Львова — адреси, години роботи та дні завезення.</p>
+
+  <a class="cta" href="https://www.lvivsecondhand.com/">Відкрити на карті</a>
+
+  <h2>Про мережу</h2>
+  <table class="facts">
+    <tbody>
+      <tr><th scope="row">Магазинів у Львові</th><td>2</td></tr>
+      <tr><th scope="row">Відомі години роботи</th><td>2 з 2</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Магазини мережі</h2>
+  <table>
+    <thead><tr><th scope="col">Магазин</th><th scope="col">Ціни та завезення</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c88/">ЄвроБренд — Городоцька 33</a><br><span class="dim">вул. Городоцька, 33</span></td>
+        <td>Поштучно (ціна за річ)</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.lvivsecondhand.com/store/c87/">ЄвроБренд — Городоцька 94</a><br><span class="dim">вул. Городоцька, 94</span></td>
+        <td>Поштучно (ціна за річ)</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <footer>
+    Дані оновлюються спільнотою. Помітили помилку — виправте у
+    <a href="https://www.lvivsecondhand.com/">застосунку</a>.<br>
+    <a href="https://www.lvivsecondhand.com/store/">← Усі секонд-хенди Львова списком</a>
+  </footer>
+</div>
+</body>
+</html>

--- a/scripts/build-store-pages.mjs
+++ b/scripts/build-store-pages.mjs
@@ -1,12 +1,18 @@
 #!/usr/bin/env node
-// Generate a static, crawlable page per store from stores.json, plus the
-// /store/ index and the site sitemap.
+// Generate a static, crawlable page per store from stores.json, plus a landing
+// page per multi-branch chain, the /store/ index and the site sitemap.
 //
 // Why this exists: the app renders every store client-side on one URL, so
-// search engines had a single page to rank for a site that is really about ~92
+// search engines had a single page to rank for a site that is really about ~130
 // distinct places. Someone googling a shop by name or street had nothing to
 // match. These pages give each store its own URL, its own title/description,
 // and LocalBusiness structured data.
+//
+// The /chain/ pages answer the other half of that: a chain existed here only as
+// N unconnected store pages, so a brand-plus-city search ("HUMANA Львів") — the
+// highest-intent query this dataset can serve — matched nothing. They double as
+// the hub that links the branches together, alongside the per-store "поруч"
+// block, so the store pages are no longer a flat set of leaves.
 //
 // The output is committed to the repo — GitHub Pages serves this repo's root
 // directly, so generated files ARE the deploy. That means they can drift from
@@ -21,6 +27,7 @@ import { fileURLToPath } from 'node:url';
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const ORIGIN = 'https://www.lvivsecondhand.com';
 const OUT_DIR = join(ROOT, 'store');
+const CHAIN_DIR = join(ROOT, 'chain');
 
 const DAYS = [
   ['mon', 'Понеділок', 'Monday'],
@@ -45,6 +52,82 @@ const esc = (s) => String(s ?? '')
 // "</script>". Escaping the slash keeps the JSON valid while making that
 // impossible, whatever ends up in a store name or note.
 const jsonLd = (obj) => JSON.stringify(obj, null, 2).replace(/<\//g, '<\\/');
+
+// Ukrainian → latin slug, following the KMU-2010 national transliteration for
+// the letters that actually occur in these names. Chain slugs go in URLs that
+// must stay stable, so this is a fixed table rather than anything locale- or
+// runtime-dependent.
+const TRANSLIT = {
+  а: 'a', б: 'b', в: 'v', г: 'h', ґ: 'g', д: 'd', е: 'e', є: 'ye', ж: 'zh',
+  з: 'z', и: 'y', і: 'i', ї: 'yi', й: 'i', к: 'k', л: 'l', м: 'm', н: 'n',
+  о: 'o', п: 'p', р: 'r', с: 's', т: 't', у: 'u', ф: 'f', х: 'kh', ц: 'ts',
+  ч: 'ch', ш: 'sh', щ: 'shch', ь: '', ю: 'yu', я: 'ya', ʼ: '', "'": '',
+};
+function slugify(name) {
+  return String(name).toLowerCase().split('')
+    .map((ch) => (ch in TRANSLIT ? TRANSLIT[ch] : ch))
+    .join('')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+// Ukrainian numerals take three forms, and "22 магазинів" reads as broken
+// Ukrainian to a native speaker — the teens are the exception that a naive
+// n===1 check gets wrong (11 takes the same form as 5, not 1).
+function plural(n, one, few, many) {
+  const m10 = n % 10;
+  const m100 = n % 100;
+  if (m100 >= 11 && m100 <= 14) return many;
+  if (m10 === 1) return one;
+  if (m10 >= 2 && m10 <= 4) return few;
+  return many;
+}
+
+// Metres between two pins. Plain haversine — the distances here are a few km at
+// most, so nothing fancier earns its complexity.
+function distMeters(a, b) {
+  const R = 6371000;
+  const toRad = (d) => (d * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const x = Math.sin(dLat / 2) ** 2
+    + Math.cos(toRad(a.lat)) * Math.cos(toRad(b.lat)) * Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.asin(Math.sqrt(x));
+}
+const fmtDist = (m) => (m < 950 ? `${Math.round(m / 10) * 10} м` : `${(m / 1000).toFixed(1)} км`);
+
+// Nearest other stores, for the "поруч" block. Capped by radius as well as
+// count: for an isolated store on the edge of the city, the 6th-nearest shop
+// is not meaningfully "nearby", and padding the list with 4km links would be
+// noise for a reader and a weak signal for a crawler.
+const NEARBY_MAX = 6;
+const NEARBY_RADIUS_M = 2500;
+function nearbyStores(s, all) {
+  return all
+    .filter((o) => o.id !== s.id)
+    .map((o) => ({ store: o, m: distMeters(s, o) }))
+    .filter((o) => o.m <= NEARBY_RADIUS_M)
+    .sort((a, b) => a.m - b.m)
+    .slice(0, NEARBY_MAX);
+}
+
+// Chains worth their own landing page: a brand with more than one branch.
+// "Independent" is a bucket, not a chain, and a single-location brand already
+// has exactly one page — its store page — so a second URL for the same shop
+// would just compete with it.
+function chainGroups(stores) {
+  const by = new Map();
+  for (const s of stores) {
+    const b = s.brand;
+    if (!b || b === 'Independent') continue;
+    if (!by.has(b)) by.set(b, []);
+    by.get(b).push(s);
+  }
+  return [...by.entries()]
+    .filter(([, list]) => list.length > 1)
+    .map(([brand, list]) => ({ brand, slug: slugify(brand), stores: list }))
+    .sort((a, b) => b.stores.length - a.stores.length || a.brand.localeCompare(b.brand, 'uk'));
+}
 
 const pricingLabel = (p) => p === 'kg'
   ? { ua: 'На вагу (ціна за кілограм)', en: 'By weight' }
@@ -102,8 +185,12 @@ function restockLine(s, todayIso) {
   return { has: false };
 }
 
-function storePage(s, todayIso) {
+function storePage(s, todayIso, allStores, chainBySlug) {
   const { rows } = parseHours(s.hours);
+  const nearby = nearbyStores(s, allStores);
+  const chain = s.brand && s.brand !== 'Independent'
+    ? chainBySlug.get(slugify(s.brand))
+    : null;
   const price = pricingLabel(s.pricing);
   const addr = s.address || '';
   const restock = restockLine(s, todayIso);
@@ -153,7 +240,11 @@ function storePage(s, todayIso) {
     addr ? `<tr><th scope="row">Адреса</th><td>${esc(addr)}${s.addressEn ? ` <span class="dim">· ${esc(s.addressEn)}</span>` : ''}</td></tr>` : '',
     s.phone ? `<tr><th scope="row">Телефон</th><td><a href="tel:${esc(s.phone.replace(/[^\d+]/g, ''))}">${esc(s.phone)}</a></td></tr>` : '',
     `<tr><th scope="row">Тип цін</th><td>${esc(price.ua)}</td></tr>`,
-    s.brand && s.brand !== 'Independent' ? `<tr><th scope="row">Мережа</th><td>${esc(s.brand)}</td></tr>` : '',
+    s.brand && s.brand !== 'Independent'
+      ? `<tr><th scope="row">Мережа</th><td>${chain
+          ? `<a href="${ORIGIN}/chain/${esc(chain.slug)}/">${esc(s.brand)}</a> <span class="dim">· ${chain.stores.length} ${plural(chain.stores.length, 'магазин', 'магазини', 'магазинів')} у Львові</span>`
+          : esc(s.brand)}</td></tr>`
+      : '',
     restock.has ? `<tr><th scope="row">Завезення</th><td>${esc(restock.ua)}</td></tr>` : '',
     cycleTxt ? `<tr><th scope="row">Цикл знижок</th><td>${esc(cycleTxt)}</td></tr>` : '',
   ].filter(Boolean).join('\n      ');
@@ -199,6 +290,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -236,6 +330,21 @@ ${s.restockDates.map((d) => `      <tr><th scope="row">${esc(d)}</th><td${d <= t
 ` : ''}${s.note ? `
   <h2>Примітки</h2>
   <p class="note">${esc(s.note)}</p>
+` : ''}${chain && chain.stores.length > 1 ? `
+  <h2>Інші магазини мережі ${esc(chain.brand)}</h2>
+  <ul class="links">
+${chain.stores.filter((o) => o.id !== s.id).slice(0, 8).map((o) =>
+    `      <li><a href="${ORIGIN}/store/${esc(o.id)}/">${esc(o.name)}</a>${o.address ? `<span class="dim"> — ${esc(o.address)}</span>` : ''}</li>`
+  ).join('\n')}
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="${ORIGIN}/chain/${esc(chain.slug)}/">Усі ${chain.stores.length} ${plural(chain.stores.length, 'магазин', 'магазини', 'магазинів')} мережі ${esc(chain.brand)} →</a></p>
+` : ''}${nearby.length ? `
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+${nearby.map(({ store: o, m }) =>
+    `      <li><a href="${ORIGIN}/store/${esc(o.id)}/">${esc(o.name)}</a><span class="dim"> — ${esc(fmtDist(m))}${o.address ? `, ${esc(o.address)}` : ''}</span></li>`
+  ).join('\n')}
+  </ul>
 ` : ''}
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у
@@ -248,7 +357,143 @@ ${s.restockDates.map((d) => `      <tr><th scope="row">${esc(d)}</th><td${d <= t
 `;
 }
 
-function indexPage(stores) {
+// One landing page per multi-branch chain. These target the highest-intent
+// query the site had no answer for — a brand name plus the city ("HUMANA
+// Львів") — which previously matched nothing here, because a chain existed
+// only as N unconnected store pages with no page describing the chain itself.
+function chainPage(chain, todayIso) {
+  const { brand, slug, stores: branches } = chain;
+  const n = branches.length;
+  const nWord = plural(n, 'магазин', 'магазини', 'магазинів');
+  const url = `${ORIGIN}/chain/${slug}/`;
+  const kg = branches.filter((s) => s.pricing === 'kg').length;
+  const withHours = branches.filter((s) => Object.values(s.hours || {}).some((v) => v && v !== '?')).length;
+
+  const title = `${brand} у Львові — ${n} ${nWord}: адреси та години`;
+  const description = `Усі ${n} ${nWord} мережі ${brand} у Львові на одній карті: адреси, години роботи, ціни${kg ? ' на вагу' : ''} та дні завезення товару.`;
+
+  // Organization + its locations, each @id-linked to that branch's own store
+  // page entity, so the chain and its shops resolve as one connected graph
+  // rather than N unrelated Stores that happen to share a name.
+  const ld = {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    '@id': `${url}#chain`,
+    name: brand,
+    url,
+    areaServed: { '@type': 'City', name: 'Львів' },
+    location: branches.map((s) => ({
+      '@type': 'Store',
+      '@id': `${ORIGIN}/store/${s.id}/#store`,
+      name: s.name,
+      url: `${ORIGIN}/store/${s.id}/`,
+      ...(s.address ? {
+        address: {
+          '@type': 'PostalAddress',
+          streetAddress: s.address,
+          addressLocality: 'Львів',
+          addressRegion: 'Львівська область',
+          addressCountry: 'UA',
+        },
+      } : {}),
+      geo: { '@type': 'GeoCoordinates', latitude: s.lat, longitude: s.lng },
+    })),
+    isPartOf: { '@type': 'WebSite', '@id': `${ORIGIN}/#website` },
+  };
+
+  const rows = branches.map((s) => {
+    const restock = restockLine(s, todayIso);
+    return `      <tr>
+        <td><a href="${ORIGIN}/store/${esc(s.id)}/">${esc(s.name)}</a>${s.address ? `<br><span class="dim">${esc(s.address)}</span>` : ''}</td>
+        <td>${esc(pricingLabel(s.pricing).ua)}${restock.has ? `<br><span class="dim">${esc(restock.ua)}</span>` : ''}</td>
+      </tr>`;
+  }).join('\n');
+
+  const facts = [
+    `<tr><th scope="row">Магазинів у Львові</th><td>${n}</td></tr>`,
+    kg ? `<tr><th scope="row">На вагу</th><td>${kg} з ${n}</td></tr>` : '',
+    `<tr><th scope="row">Відомі години роботи</th><td>${withHours} з ${n}</td></tr>`,
+  ].filter(Boolean).join('\n      ');
+
+  return `<!DOCTYPE html>
+<html lang="uk">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="theme-color" content="#17693a">
+<title>${esc(title)}</title>
+<meta name="description" content="${esc(description)}">
+<link rel="canonical" href="${esc(url)}">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Lviv Second Hand">
+<meta property="og:title" content="${esc(title)}">
+<meta property="og:description" content="${esc(description)}">
+<meta property="og:url" content="${esc(url)}">
+<meta property="og:image" content="${ORIGIN}/og-image.png">
+<meta property="og:locale" content="uk_UA">
+<link rel="icon" href="${ORIGIN}/favicon.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="${ORIGIN}/apple-touch-icon.png">
+<script type="application/ld+json">
+${jsonLd(ld)}
+</script>
+<style>
+:root{--paper:#f7f4ef;--ink:#14211a;--muted:#5d6b63;--green:#17693a;--line:#e2ddd4;--card:#fff}
+@media(prefers-color-scheme:dark){:root{--paper:#0f1613;--ink:#e8efe9;--muted:#9aa9a0;--green:#4bbd7a;--line:#26332c;--card:#151f1a}}
+*{box-sizing:border-box}
+body{margin:0;background:var(--paper);color:var(--ink);font:16px/1.6 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+.wrap{max-width:680px;margin:0 auto;padding:24px 20px 56px}
+a{color:var(--green)}
+.crumb{font-size:13px;color:var(--muted);margin-bottom:18px}
+.crumb a{color:var(--muted)}
+h1{font-size:26px;line-height:1.25;margin:0 0 6px}
+.sub{color:var(--muted);margin:0 0 22px;font-size:15px}
+table{width:100%;border-collapse:collapse;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden;margin:0 0 22px}
+th,td{text-align:left;padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px;vertical-align:top}
+tr:last-child th,tr:last-child td{border-bottom:0}
+th{font-weight:600;color:var(--muted)}
+table.facts th{width:56%}
+.dim{color:var(--muted);font-size:14px}
+h2{font-size:17px;margin:26px 0 10px}
+.cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 22px 0}
+footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <nav class="crumb"><a href="${ORIGIN}/">Секонд-хенди Львова</a> › <a href="${ORIGIN}/store/">Усі магазини</a> › ${esc(brand)}</nav>
+
+  <h1>${esc(brand)} у Львові</h1>
+  <p class="sub">${n} ${nWord} мережі на карті секонд-хендів Львова — адреси, години роботи та дні завезення.</p>
+
+  <a class="cta" href="${ORIGIN}/">Відкрити на карті</a>
+
+  <h2>Про мережу</h2>
+  <table class="facts">
+    <tbody>
+      ${facts}
+    </tbody>
+  </table>
+
+  <h2>Магазини мережі</h2>
+  <table>
+    <thead><tr><th scope="col">Магазин</th><th scope="col">Ціни та завезення</th></tr></thead>
+    <tbody>
+${rows}
+    </tbody>
+  </table>
+
+  <footer>
+    Дані оновлюються спільнотою. Помітили помилку — виправте у
+    <a href="${ORIGIN}/">застосунку</a>.<br>
+    <a href="${ORIGIN}/store/">← Усі секонд-хенди Львова списком</a>
+  </footer>
+</div>
+</body>
+</html>
+`;
+}
+
+function indexPage(stores, chains) {
   const url = `${ORIGIN}/store/`;
   const title = 'Усі секонд-хенди Львова — список магазинів';
   const description = `Повний список секонд-хендів Львова (${stores.length} магазинів): адреси, години роботи, ціни на вагу та поштучно, дні завезення.`;
@@ -305,6 +550,7 @@ h1{font-size:26px;line-height:1.25;margin:0 0 6px}
 ul{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
 li{padding:11px 14px;border-bottom:1px solid var(--line);font-size:15px}
 li:last-child{border-bottom:0}
+h2{font-size:17px;margin:26px 0 10px}
 .dim{color:var(--muted);font-size:14px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 0 22px}
 footer{margin-top:30px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
@@ -316,7 +562,14 @@ footer{margin-top:30px;padding-top:16px;border-top:1px solid var(--line);font-si
   <h1>${esc(title)}</h1>
   <p class="sub">${stores.length} магазинів на карті Львова — адреси, години, ціни та дні завезення.</p>
   <a class="cta" href="${ORIGIN}/">Відкрити карту</a>
+${chains.length ? `
+  <h2>Мережі секонд-хендів</h2>
   <ul>
+${chains.map((c) => `      <li><a href="${ORIGIN}/chain/${esc(c.slug)}/">${esc(c.brand)}</a><span class="dim"> — ${c.stores.length} ${plural(c.stores.length, 'магазин', 'магазини', 'магазинів')}</span></li>`).join('\n')}
+  </ul>
+
+  <h2>Усі магазини</h2>
+` : ''}  <ul>
 ${items}
   </ul>
   <footer><a href="${ORIGIN}/">← На карту секонд-хендів Львова</a></footer>
@@ -326,7 +579,7 @@ ${items}
 `;
 }
 
-function sitemap(stores) {
+function sitemap(stores, chains) {
   const staticUrls = [
     { loc: `${ORIGIN}/`, freq: 'daily', pri: '1.0' },
     { loc: `${ORIGIN}/store/`, freq: 'weekly', pri: '0.8' },
@@ -335,6 +588,7 @@ function sitemap(stores) {
   ];
   const entries = [
     ...staticUrls,
+    ...chains.map((c) => ({ loc: `${ORIGIN}/chain/${c.slug}/`, freq: 'weekly', pri: '0.7' })),
     ...stores.map((s) => ({ loc: `${ORIGIN}/store/${s.id}/`, freq: 'weekly', pri: '0.6' })),
   ];
   const body = entries.map((e) =>
@@ -360,17 +614,35 @@ const stores = all
   .filter((s) => !s.watermark)
   .sort((a, b) => a.name.localeCompare(b.name, 'uk'));
 
+const chains = chainGroups(stores);
+const chainBySlug = new Map(chains.map((c) => [c.slug, c]));
+// A collision would silently make two chains share one URL, with the second
+// overwriting the first. Cheap to assert, and the failure is otherwise
+// invisible until someone notices a chain page describing the wrong brand.
+if (chainBySlug.size !== chains.length) {
+  throw new Error('chain slug collision — two brands transliterate to the same URL');
+}
+
 // Rebuild from scratch so a store deleted from stores.json can't leave an
-// orphan page serving a shop that no longer exists.
+// orphan page serving a shop that no longer exists. Same for a chain that
+// drops to a single branch, or is renamed: its old URL must stop existing
+// rather than linger with stale contents.
 if (existsSync(OUT_DIR)) rmSync(OUT_DIR, { recursive: true });
 mkdirSync(OUT_DIR, { recursive: true });
+if (existsSync(CHAIN_DIR)) rmSync(CHAIN_DIR, { recursive: true });
+mkdirSync(CHAIN_DIR, { recursive: true });
 
 for (const s of stores) {
   const dir = join(OUT_DIR, s.id);
   mkdirSync(dir, { recursive: true });
-  writeFileSync(join(dir, 'index.html'), storePage(s, TODAY));
+  writeFileSync(join(dir, 'index.html'), storePage(s, TODAY, stores, chainBySlug));
 }
-writeFileSync(join(OUT_DIR, 'index.html'), indexPage(stores));
-writeFileSync(join(ROOT, 'sitemap.xml'), sitemap(stores));
+for (const c of chains) {
+  const dir = join(CHAIN_DIR, c.slug);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'index.html'), chainPage(c, TODAY));
+}
+writeFileSync(join(OUT_DIR, 'index.html'), indexPage(stores, chains));
+writeFileSync(join(ROOT, 'sitemap.xml'), sitemap(stores, chains));
 
-console.log(`Generated ${stores.length} store pages + /store/ index + sitemap.xml (${stores.length + 4} URLs).`);
+console.log(`Generated ${stores.length} store pages + ${chains.length} chain pages + /store/ index + sitemap.xml (${stores.length + chains.length + 4} URLs).`);

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -25,6 +25,46 @@
     <priority>0.1</priority>
   </url>
   <url>
+    <loc>https://www.lvivsecondhand.com/chain/economclass/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.lvivsecondhand.com/chain/svit-sekond-khendu/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.lvivsecondhand.com/chain/humana/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.lvivsecondhand.com/chain/stok-ta-sekond-khend/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.lvivsecondhand.com/chain/birka-lux/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.lvivsecondhand.com/chain/yevrobrend/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.lvivsecondhand.com/chain/myunkhen/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://www.lvivsecondhand.com/store/c62/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>

--- a/store/c10/index.html
+++ b/store/c10/index.html
@@ -54,6 +54,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -90,6 +93,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">50% off</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c57/">Оутлет Сток</a><span class="dim"> — 190 м, вул. Степана Бандери</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c9/">Sekond Hand</a><span class="dim"> — 210 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c65/">Магазин Планета Секонд-хенд</a><span class="dim"> — 250 м, пл. Липнева, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c7/">Second Hand</a><span class="dim"> — 260 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c98/">Second hand — Горської 5а</a><span class="dim"> — 290 м, вул. Алли Горської, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c87/">ЄвроБренд — Городоцька 94</a><span class="dim"> — 300 м, вул. Городоцька, 94</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c100/index.html
+++ b/store/c100/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown). At the Provesin market.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c60/">Світ секонд-хенду — Наукова 64</a><span class="dim"> — 370 м, вул. Наукова, 64</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><span class="dim"> — 400 м, вулиця Володимира Великого, 59б</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c94/">Second hand — Володимира Великого 51</a><span class="dim"> — 520 м, вул. Володимира Великого, 51</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c95/">Second hand — Володимира Великого 59А</a><span class="dim"> — 520 м, вул. Володимира Великого, 59А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c93/">Second hand — Володимира Великого 26А</a><span class="dim"> — 540 м, вул. Володимира Великого, 26A</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c26/">Євро Тренд Секонд хенд — Наукова 47</a><span class="dim"> — 560 м, вулиця Наукова, 47</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c101/index.html
+++ b/store/c101/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown).</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — 120 м, вул. Любінська, 100</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h2/">HUMANA — Lyubinska</a><span class="dim"> — 120 м, вул. Любинська, 100 (2 поверх)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c75/">Світ секонд-хенду — Симона Петлюри 2а</a><span class="dim"> — 440 м, вул. Симона Петлюри, 2а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c110/">Second hand — Симона Петлюри 3</a><span class="dim"> — 450 м, вул. Симона Петлюри, 3</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c102/">Second hand — Любінська 120</a><span class="dim"> — 500 м, вул. Любінська, 120</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c53/">Світ секонд-хенду — Патона 2</a><span class="dim"> — 510 м, вул. Патона, 2</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c102/index.html
+++ b/store/c102/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown). Nominatim could not pin down this house number on Lyubinska St (a long, multi-segment street in OSM); placed at the nearest resolvable segment as a best-effort estimate — field check would help.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c53/">Світ секонд-хенду — Патона 2</a><span class="dim"> — 380 м, вул. Патона, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c101/">Second hand — Любінська 102</a><span class="dim"> — 500 м, вул. Любінська, 102</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c58/">Секонд Мікс</a><span class="dim"> — 550 м, вул. Патона</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — 620 м, вул. Любінська, 100</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h2/">HUMANA — Lyubinska</a><span class="dim"> — 620 м, вул. Любинська, 100 (2 поверх)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c36/">EconomClass — Vyhovskoho 49</a><span class="dim"> — 670 м, вул. Виговського, 49</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c103/index.html
+++ b/store/c103/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown). Only ~90m from c71 (вул. Гетьмана Мазепи, 24 — Світ секонд-хенду, on a 14-day dated cycle, not a weekday one). Possibly the same store misreported, possibly a genuine neighbor — kept separate pending a field check rather than merged on proximity alone.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — 60 м, вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c34/">EconomClass — Mazepy 11V</a><span class="dim"> — 630 м, вул. Мазепи, 11В</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — 810 м, вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c92/">Second hand — Хмельницького 214</a><span class="dim"> — 1.3 км, вул. Богдана Хмельницького, 214</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c30/">Євро Тренд Секонд хенд — Богдана Хмельницького 176</a><span class="dim"> — 1.3 км, вулиця Богдана Хмельницького, 176</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — 1.4 км, вул. Б. Хмельницького, 275</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c104/index.html
+++ b/store/c104/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown).</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c108/">Second hand — Пасічна 53</a><span class="dim"> — 130 м, вул. Пасічна, 53</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c74/">Світ секонд-хенду — Пасічна 51</a><span class="dim"> — 210 м, вул. Пасічна, 51</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c89/">Сток та секонд хенд — Пасічна 96А</a><span class="dim"> — 540 м, вул. Пасічна, 96А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c35/">EconomClass — Lychakivska 201</a><span class="dim"> — 1.1 км, вул. Личаківська, 201</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — 1.2 км, вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c59/">Birka! Lux — Котика 2</a><span class="dim"> — 1.5 км, вул. Богдана Котика, 2</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c105/index.html
+++ b/store/c105/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown). Nominatim never resolved house 45 on Naukova St to a specific point (the street is split into disconnected OSM segments); placed at c26&#39;s exact coordinates (Наукова, 47 — next door) as a best-effort estimate, same treatment as c91/c55. Field check would help.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c26/">Євро Тренд Секонд хенд — Наукова 47</a><span class="dim"> — 0 м, вулиця Наукова, 47</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c106/">Євро Секонд Хенд — Наукова 49а</a><span class="dim"> — 130 м, вул. Наукова, 49а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c60/">Світ секонд-хенду — Наукова 64</a><span class="dim"> — 180 м, вул. Наукова, 64</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c68/">Світ секонд-хенду — Наукова 53</a><span class="dim"> — 280 м, вул. Наукова, 53</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c100/">Second hand — Княгині Ольги 114</a><span class="dim"> — 560 м, вул. Княгині Ольги, 114 (ринок &quot;Провесінь&quot;)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — 830 м, вул. Володимира Великого, 34</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c106/index.html
+++ b/store/c106/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown). Business name from OpenStreetMap/Nominatim, which lists a &quot;Євро Секонд Хенд&quot; POI at this exact address — not the same brand as c26 (Євро Тренд Секонд хенд), ~83m away.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c26/">Євро Тренд Секонд хенд — Наукова 47</a><span class="dim"> — 130 м, вулиця Наукова, 47</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c105/">Second hand — Наукова 45</a><span class="dim"> — 130 м, вул. Наукова, 45</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c68/">Світ секонд-хенду — Наукова 53</a><span class="dim"> — 150 м, вул. Наукова, 53</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c60/">Світ секонд-хенду — Наукова 64</a><span class="dim"> — 300 м, вул. Наукова, 64</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c100/">Second hand — Княгині Ольги 114</a><span class="dim"> — 660 м, вул. Княгині Ольги, 114 (ринок &quot;Провесінь&quot;)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — 850 м, вул. Володимира Великого, 34</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c107/index.html
+++ b/store/c107/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -98,6 +101,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown). Community list (#208) says &quot;restocks rarely&quot; with no specific day or interval given.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c25/">Євро Тренд Секонд хенд — Червоної Калини 59</a><span class="dim"> — 40 м, проспект Червоної Калини, 59</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c11/">Євро секонд хенд</a><span class="dim"> — 60 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c111/">Second hand — Сихівська 13</a><span class="dim"> — 680 м, вул. Сихівська, 13</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c28/">Євро Тренд Секонд хенд — Сихівська 18</a><span class="dim"> — 730 м, вулиця Сихівська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h4/">HUMANA — Sykhivska</a><span class="dim"> — 730 м, вул. Сиховська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c15/">Euro marke</a><span class="dim"> — 790 м, пр. Червоної Калини, 66А</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c108/index.html
+++ b/store/c108/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown).</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c74/">Світ секонд-хенду — Пасічна 51</a><span class="dim"> — 90 м, вул. Пасічна, 51</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c104/">Second hand — Медової Печери 1</a><span class="dim"> — 130 м, вул. Медової Печери, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c89/">Сток та секонд хенд — Пасічна 96А</a><span class="dim"> — 640 м, вул. Пасічна, 96А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c35/">EconomClass — Lychakivska 201</a><span class="dim"> — 1.0 км, вул. Личаківська, 201</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — 1.2 км, вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c59/">Birka! Lux — Котика 2</a><span class="dim"> — 1.4 км, вул. Богдана Котика, 2</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c109/index.html
+++ b/store/c109/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,12 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown). 2nd floor. In Vynnyky (a second, distinct &quot;Петра Дорошенка&quot; street also exists near Малехів further north — this placement assumes the Vynnyky one, consistent with the other Vynnyky entry in this same list).</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c96/">Second hand — Галицька 18 (Винники)</a><span class="dim"> — 1.1 км, вул. Галицька, 18 (Винники)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c119/">MOSTOK</a><span class="dim"> — 1.2 км, вул. Шептицького, 19а</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c11/index.html
+++ b/store/c11/index.html
@@ -54,6 +54,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -87,6 +90,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Неділя</th><td class="dim">Невідомо</td></tr>
     </tbody>
   </table>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c107/">Second hand — Довженка 4</a><span class="dim"> — 60 м, вул. Олександра Довженка, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c25/">Євро Тренд Секонд хенд — Червоної Калини 59</a><span class="dim"> — 70 м, проспект Червоної Калини, 59</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c111/">Second hand — Сихівська 13</a><span class="dim"> — 720 м, вул. Сихівська, 13</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c28/">Євро Тренд Секонд хенд — Сихівська 18</a><span class="dim"> — 770 м, вулиця Сихівська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h4/">HUMANA — Sykhivska</a><span class="dim"> — 770 м, вул. Сиховська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c15/">Euro marke</a><span class="dim"> — 790 м, пр. Червоної Калини, 66А</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c110/index.html
+++ b/store/c110/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown). Nominatim never resolved this house number to a specific point; placed near c75 (Симона Петлюри, 2а) as a best-effort estimate.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c75/">Світ секонд-хенду — Симона Петлюри 2а</a><span class="dim"> — 80 м, вул. Симона Петлюри, 2а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h2/">HUMANA — Lyubinska</a><span class="dim"> — 330 м, вул. Любинська, 100 (2 поверх)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — 330 м, вул. Любінська, 100</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c101/">Second hand — Любінська 102</a><span class="dim"> — 450 м, вул. Любінська, 102</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s3/">Yevromiks</a><span class="dim"> — 710 м, вул. Городоцька, 123</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c36/">EconomClass — Vyhovskoho 49</a><span class="dim"> — 890 м, вул. Виговського, 49</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c111/index.html
+++ b/store/c111/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown).</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c28/">Євро Тренд Секонд хенд — Сихівська 18</a><span class="dim"> — 180 м, вулиця Сихівська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h4/">HUMANA — Sykhivska</a><span class="dim"> — 180 м, вул. Сиховська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — 250 м, вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c99/">Second hand — Кавалерідзе 6</a><span class="dim"> — 270 м, вул. Івана Кавалерідзе, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c15/">Euro marke</a><span class="dim"> — 430 м, пр. Червоної Калини, 66А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c25/">Євро Тренд Секонд хенд — Червоної Калини 59</a><span class="dim"> — 650 м, проспект Червоної Калини, 59</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c112/index.html
+++ b/store/c112/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown).</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c98/">Second hand — Горської 5а</a><span class="dim"> — 500 м, вул. Алли Горської, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c65/">Магазин Планета Секонд-хенд</a><span class="dim"> — 530 м, пл. Липнева, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c7/">Second Hand</a><span class="dim"> — 660 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c9/">Sekond Hand</a><span class="dim"> — 680 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c10/">Sekond Hand</a><span class="dim"> — 750 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c87/">ЄвроБренд — Городоцька 94</a><span class="dim"> — 830 м, вул. Городоцька, 94</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c113/index.html
+++ b/store/c113/index.html
@@ -62,6 +62,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -101,6 +104,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding. Name and phone from the dlab.com.ua business directory, listed there as &quot;Одяг з Європи, Сток та секонд хенд&quot; — a distinct name from c55 (Точка Секонд Хенд), which strengthens (but doesn&#39;t fully confirm) that these are two separate stores rather than one misplaced record.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — 1.0 км, вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c114/">Second hand — Стрийська 57</a><span class="dim"> — 1.1 км, вул. Стрийська, 57</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c121/">Комісійний — Гашека 15а</a><span class="dim"> — 1.2 км, вулиця Ярослава Гашека, 15а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c94/">Second hand — Володимира Великого 51</a><span class="dim"> — 1.3 км, вул. Володимира Великого, 51</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c95/">Second hand — Володимира Великого 59А</a><span class="dim"> — 1.4 км, вул. Володимира Великого, 59А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><span class="dim"> — 1.4 км, вулиця Володимира Великого, 59б</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c114/index.html
+++ b/store/c114/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown). Possibly the same store as c55 (Точка Секонд Хенд, address on record as just вул. Стрийська with no house number) — kept separate pending a field check, same treatment as c91.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c121/">Комісійний — Гашека 15а</a><span class="dim"> — 160 м, вулиця Ярослава Гашека, 15а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c91/">Сток та секонд хенд — Стрийська 61</a><span class="dim"> — 360 м, вул. Стрийська, 61</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c55/">Точка Секонд Хенд</a><span class="dim"> — 360 м, вул. Стрийська</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c113/">Одяг з Європи — Стрийська 45</a><span class="dim"> — 1.1 км, вул. Стрийська, 45</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c94/">Second hand — Володимира Великого 51</a><span class="dim"> — 1.7 км, вул. Володимира Великого, 51</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><span class="dim"> — 1.7 км, вулиця Володимира Великого, 59б</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c115/index.html
+++ b/store/c115/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown).</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c22/">Євро Тренд Секонд хенд — Широка 31</a><span class="dim"> — 40 м, вулиця Широка, 31</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h5/">HUMANA — Shyroka</a><span class="dim"> — 610 м, вул. Широка, 81а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c77/">Світ секонд-хенду — Широка 70б</a><span class="dim"> — 750 м, вул. Широка, 70б</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c64/">Ваш секонд-хенд</a><span class="dim"> — 790 м, вул. Широка</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c63/">Конфі Склад</a><span class="dim"> — 800 м, вул. Широка</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c112/">Second hand — Смаль-Стоцького 1</a><span class="dim"> — 1.6 км, вул. Смаль-Стоцького, 1</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c116/index.html
+++ b/store/c116/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown).</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c56/">Luxovski</a><span class="dim"> — 50 м, вул. Шпитальна, 11</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c61/">Євро секонд хенд</a><span class="dim"> — 80 м, вул. Базарна, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c79/">Супер секонд-хенд</a><span class="dim"> — 110 м, вул. Базарна, 8</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — 200 м, вулиця Котлярська, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c125/">Birka! Lux — Шпитальна 7</a><span class="dim"> — 240 м, вул. Шпитальна, 7</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c88/">ЄвроБренд — Городоцька 33</a><span class="dim"> — 240 м, вул. Городоцька, 33</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c118/index.html
+++ b/store/c118/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown).</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c76/">Світ секонд-хенду — Чорновола 45</a><span class="dim"> — 110 м, просп. В&#39;ячеслава Чорновола, 45</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c122/">Second hand — Окуневського 3</a><span class="dim"> — 420 м, вулиця Теофіла Окуневського, 3</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s4/">ObnovaNova</a><span class="dim"> — 670 м, просп. В. Чорновола, 16і</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — 690 м, вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c84/">Світ секонд-хенду — Цехова 1</a><span class="dim"> — 760 м, вул. Цехова, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c62/">Бомба</a><span class="dim"> — 890 м, вул. Пантелеймона Куліша</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c119/index.html
+++ b/store/c119/index.html
@@ -62,6 +62,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -100,6 +103,12 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Men&#39;s and women&#39;s clothing (sweaters, jeans, jackets, dresses). In Vynnyky, an eastern suburb of Lviv. From the dlab.com.ua Lviv business directory (Сток одягу. Секонд хенд category) — not yet confirmed against the map’s other sources; hours unknown.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c109/">Second hand — Петра Дорошенка 1</a><span class="dim"> — 1.2 км, вул. Петра Дорошенка, 1 (2 поверх)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c96/">Second hand — Галицька 18 (Винники)</a><span class="dim"> — 1.3 км, вул. Галицька, 18 (Винники)</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c120/index.html
+++ b/store/c120/index.html
@@ -62,6 +62,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -100,6 +103,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Consignment shop: used and new clothing, footwear, fur, accessories. From the dlab.com.ua Lviv business directory (Сток одягу. Секонд хенд category) — not yet confirmed against the map’s other sources; hours unknown.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c124/">МЮНХЕН — Городоцька 10</a><span class="dim"> — 320 м, Городоцька вулиця, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c125/">Birka! Lux — Шпитальна 7</a><span class="dim"> — 330 м, вул. Шпитальна, 7</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — 380 м, вулиця Котлярська, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h6/">HUMANA — Doroshenka</a><span class="dim"> — 450 м, вул. П. Дорошенка, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c8/">Second Hand Bomba</a><span class="dim"> — 490 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c88/">ЄвроБренд — Городоцька 33</a><span class="dim"> — 500 м, вул. Городоцька, 33</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c121/index.html
+++ b/store/c121/index.html
@@ -62,6 +62,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -100,6 +103,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Consignment shop: women&#39;s, men&#39;s, and children&#39;s used clothing and footwear. Name (&quot;Комісійний&quot;) from an OpenStreetMap/Nominatim POI at this exact address. From the dlab.com.ua Lviv business directory (Сток одягу. Секонд хенд category) — not yet confirmed against the map’s other sources; hours unknown.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c114/">Second hand — Стрийська 57</a><span class="dim"> — 160 м, вул. Стрийська, 57</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c91/">Сток та секонд хенд — Стрийська 61</a><span class="dim"> — 210 м, вул. Стрийська, 61</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c55/">Точка Секонд Хенд</a><span class="dim"> — 210 м, вул. Стрийська</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c113/">Одяг з Європи — Стрийська 45</a><span class="dim"> — 1.2 км, вул. Стрийська, 45</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c100/">Second hand — Княгині Ольги 114</a><span class="dim"> — 1.9 км, вул. Княгині Ольги, 114 (ринок &quot;Провесінь&quot;)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><span class="dim"> — 1.9 км, вулиця Володимира Великого, 59б</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c122/index.html
+++ b/store/c122/index.html
@@ -62,6 +62,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -100,6 +103,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Large assortment of stock clothing, footwear, underwear; household textiles from Germany. From the dlab.com.ua Lviv business directory (Сток одягу. Секонд хенд category) — not yet confirmed against the map’s other sources; hours unknown.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — 280 м, вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c118/">Second hand — Чорновола 57</a><span class="dim"> — 420 м, пр. В&#39;ячеслава Чорновола, 57</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h3/">HUMANA — Chornovola</a><span class="dim"> — 510 м, просп. В. Чорновола, 95</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c76/">Світ секонд-хенду — Чорновола 45</a><span class="dim"> — 530 м, просп. В&#39;ячеслава Чорновола, 45</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c21/">Євро Тренд Секонд хенд — Чорновола 101</a><span class="dim"> — 750 м, проспект В&#39;ячеслава Чорновола, 101</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s4/">ObnovaNova</a><span class="dim"> — 1.0 км, просп. В. Чорновола, 16і</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c123/index.html
+++ b/store/c123/index.html
@@ -62,6 +62,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -81,7 +84,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Адреса</th><td>вулиця Миколи Вороного, 2 <span class="dim">· 2 Mykoly Voronoho St</span></td></tr>
       <tr><th scope="row">Телефон</th><td><a href="tel:+380971345578">+38 (097) 134-55-78</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
-      <tr><th scope="row">Мережа</th><td>МЮНХЕН</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/myunkhen/">МЮНХЕН</a> <span class="dim">· 2 магазини у Львові</span></td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
   </table>
@@ -101,6 +104,22 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Stock clothing &amp; footwear chain, 2 Lviv locations (see also c124, Городоцька 10): men&#39;s, women&#39;s, children&#39;s clothing, footwear, hats, belts, underwear, bags. From the dlab.com.ua Lviv business directory (Сток одягу. Секонд хенд category) — not yet confirmed against the map’s other sources; hours unknown.</p>
+
+  <h2>Інші магазини мережі МЮНХЕН</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c124/">МЮНХЕН — Городоцька 10</a><span class="dim"> — Городоцька вулиця, 10</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/myunkhen/">Усі 2 магазини мережі МЮНХЕН →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c8/">Second Hand Bomba</a><span class="dim"> — 250 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h7/">HUMANA Vintage</a><span class="dim"> — 260 м, вул. Валова, 13</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h6/">HUMANA — Doroshenka</a><span class="dim"> — 260 м, вул. П. Дорошенка, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c4/">Second Hand - Bomba womens</a><span class="dim"> — 290 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c2/">Second hand</a><span class="dim"> — 400 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c20/">Second hand Bomba</a><span class="dim"> — 430 м</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c124/index.html
+++ b/store/c124/index.html
@@ -62,6 +62,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -81,7 +84,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Адреса</th><td>Городоцька вулиця, 10 <span class="dim">· 10 Horodotska St</span></td></tr>
       <tr><th scope="row">Телефон</th><td><a href="tel:+380676790598">+38 (067) 679-05-98</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
-      <tr><th scope="row">Мережа</th><td>МЮНХЕН</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/myunkhen/">МЮНХЕН</a> <span class="dim">· 2 магазини у Львові</span></td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
   </table>
@@ -101,6 +104,22 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Stock clothing &amp; footwear chain, 2 Lviv locations (see also c123, Вороного 2): men&#39;s, women&#39;s, children&#39;s clothing, footwear, hats, belts, underwear, bags. From the dlab.com.ua Lviv business directory (Сток одягу. Секонд хенд category) — not yet confirmed against the map’s other sources; hours unknown.</p>
+
+  <h2>Інші магазини мережі МЮНХЕН</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c123/">МЮНХЕН — Вороного 2</a><span class="dim"> — вулиця Миколи Вороного, 2</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/myunkhen/">Усі 2 магазини мережі МЮНХЕН →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c125/">Birka! Lux — Шпитальна 7</a><span class="dim"> — 60 м, вул. Шпитальна, 7</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — 160 м, вулиця Котлярська, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c88/">ЄвроБренд — Городоцька 33</a><span class="dim"> — 200 м, вул. Городоцька, 33</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c116/">Second hand — Шолом-Алейхема 20</a><span class="dim"> — 270 м, вулиця Шолом-Алейхема, 20</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c56/">Luxovski</a><span class="dim"> — 290 м, вул. Шпитальна, 11</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c120/">ЕЛІТ</a><span class="dim"> — 320 м, вул. Театральна, 23</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c125/index.html
+++ b/store/c125/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Шпитальна, 7 <span class="dim">· 7 Shpytalna St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Birka! Lux</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/birka-lux/">Birka! Lux</a> <span class="dim">· 3 магазини у Львові</span></td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
   </table>
@@ -143,6 +146,23 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Confirmed as a 3-location chain (Зелена 69а, Котика 2, Шпитальна 7) via a list.in.ua directory listing with published hours.</p>
+
+  <h2>Інші магазини мережі Birka! Lux</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/s6/">Birka! Lux — Зелена 69а</a><span class="dim"> — вул. Зелена, 69а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c59/">Birka! Lux — Котика 2</a><span class="dim"> — вул. Богдана Котика, 2</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/birka-lux/">Усі 3 магазини мережі Birka! Lux →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c124/">МЮНХЕН — Городоцька 10</a><span class="dim"> — 60 м, Городоцька вулиця, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — 110 м, вулиця Котлярська, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c88/">ЄвроБренд — Городоцька 33</a><span class="dim"> — 220 м, вул. Городоцька, 33</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c116/">Second hand — Шолом-Алейхема 20</a><span class="dim"> — 240 м, вулиця Шолом-Алейхема, 20</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c56/">Luxovski</a><span class="dim"> — 250 м, вул. Шпитальна, 11</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c61/">Євро секонд хенд</a><span class="dim"> — 310 м, вул. Базарна, 1</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c15/index.html
+++ b/store/c15/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -98,6 +101,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Address from OpenStreetMap/Nominatim (an &quot;Euro marke[t]&quot; POI 12m from this pin). The #208 community list reports both Saturday and Monday restocks at this address — possibly two stores sharing a building — so no restockDay was set.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c111/">Second hand — Сихівська 13</a><span class="dim"> — 430 м, вул. Сихівська, 13</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — 510 м, вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c99/">Second hand — Кавалерідзе 6</a><span class="dim"> — 550 м, вул. Івана Кавалерідзе, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c17/">Євро секонд-хенд</a><span class="dim"> — 580 м, пр. Червоної Калини, 105</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — 610 м, вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c28/">Євро Тренд Секонд хенд — Сихівська 18</a><span class="dim"> — 620 м, вулиця Сихівська, 18</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c16/index.html
+++ b/store/c16/index.html
@@ -54,6 +54,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -87,6 +90,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Неділя</th><td class="dim">Невідомо</td></tr>
     </tbody>
   </table>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c17/">Євро секонд-хенд</a><span class="dim"> — 80 м, пр. Червоної Калини, 105</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — 250 м, вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c15/">Euro marke</a><span class="dim"> — 650 м, пр. Червоної Калини, 66А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — 860 м, вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c99/">Second hand — Кавалерідзе 6</a><span class="dim"> — 900 м, вул. Івана Кавалерідзе, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c111/">Second hand — Сихівська 13</a><span class="dim"> — 1.0 км, вул. Сихівська, 13</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c17/index.html
+++ b/store/c17/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Address from OpenStreetMap/Nominatim (a &quot;Євро секонд-хенд&quot; POI 24m from this pin) and the #208 community list.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c16/">Euro Second Hand</a><span class="dim"> — 80 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — 240 м, вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c15/">Euro marke</a><span class="dim"> — 580 м, пр. Червоної Калини, 66А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — 800 м, вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c99/">Second hand — Кавалерідзе 6</a><span class="dim"> — 830 м, вул. Івана Кавалерідзе, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c111/">Second hand — Сихівська 13</a><span class="dim"> — 890 м, вул. Сихівська, 13</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c19/index.html
+++ b/store/c19/index.html
@@ -54,6 +54,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -90,6 +93,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">New stock arrives every day; the shop only does a full seasonal wardrobe change rather than following a fixed restock cycle.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c59/">Birka! Lux — Котика 2</a><span class="dim"> — 880 м, вул. Богдана Котика, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c20/">Second hand Bomba</a><span class="dim"> — 1.0 км</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c2/">Second hand</a><span class="dim"> — 1.0 км</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s6/">Birka! Lux — Зелена 69а</a><span class="dim"> — 1.1 км, вул. Зелена, 69а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h7/">HUMANA Vintage</a><span class="dim"> — 1.2 км, вул. Валова, 13</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c66/">Секонд-хенд Супер Бомба</a><span class="dim"> — 1.2 км, вул. Шота Руставелі, 4</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c2/index.html
+++ b/store/c2/index.html
@@ -98,6 +98,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -132,6 +135,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Неділя</th><td>09:00–17:00</td></tr>
     </tbody>
   </table>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c20/">Second hand Bomba</a><span class="dim"> — 60 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h7/">HUMANA Vintage</a><span class="dim"> — 240 м, вул. Валова, 13</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c123/">МЮНХЕН — Вороного 2</a><span class="dim"> — 400 м, вулиця Миколи Вороного, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c66/">Секонд-хенд Супер Бомба</a><span class="dim"> — 560 м, вул. Шота Руставелі, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h6/">HUMANA — Doroshenka</a><span class="dim"> — 610 м, вул. П. Дорошенка, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c8/">Second Hand Bomba</a><span class="dim"> — 620 м</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c20/index.html
+++ b/store/c20/index.html
@@ -98,6 +98,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -134,6 +137,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">New stock arrives every day; the shop only does a full seasonal wardrobe change rather than following a fixed restock cycle.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c2/">Second hand</a><span class="dim"> — 60 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h7/">HUMANA Vintage</a><span class="dim"> — 230 м, вул. Валова, 13</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c123/">МЮНХЕН — Вороного 2</a><span class="dim"> — 430 м, вулиця Миколи Вороного, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h6/">HUMANA — Doroshenka</a><span class="dim"> — 620 м, вул. П. Дорошенка, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c66/">Секонд-хенд Супер Бомба</a><span class="dim"> — 620 м, вул. Шота Руставелі, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c8/">Second Hand Bomba</a><span class="dim"> — 630 м</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c21/index.html
+++ b/store/c21/index.html
@@ -99,6 +99,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -117,7 +120,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>проспект В&#39;ячеслава Чорновола, 101 <span class="dim">· 101 Chornovola Ave</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Євро Тренд Секонд хенд</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Євро Тренд Секонд хенд</a> <span class="dim">· 10 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: понеділок</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -138,6 +141,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Restocked Mondays. A Lviv business directory (dlab.com.ua) lists &quot;EconomClass, секонд-хенд&quot; at this exact address instead — could be a directory error, a chain change, or two shops sharing the building (a pattern confirmed elsewhere on this map); not changed pending a field check.</p>
+
+  <h2>Інші магазини мережі Євро Тренд Секонд хенд</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c30/">Євро Тренд Секонд хенд — Богдана Хмельницького 176</a><span class="dim"> — вулиця Богдана Хмельницького, 176</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><span class="dim"> — вулиця Володимира Великого, 59б</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c23/">Євро Тренд Секонд хенд — Городоцька 67</a><span class="dim"> — вулиця Городоцька, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c24/">Євро Тренд Секонд хенд — Горська 2А</a><span class="dim"> — вулиця Горська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — вулиця Котлярська, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c26/">Євро Тренд Секонд хенд — Наукова 47</a><span class="dim"> — вулиця Наукова, 47</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c28/">Євро Тренд Секонд хенд — Сихівська 18</a><span class="dim"> — вулиця Сихівська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c25/">Євро Тренд Секонд хенд — Червоної Калини 59</a><span class="dim"> — проспект Червоної Калини, 59</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Усі 10 магазинів мережі Євро Тренд Секонд хенд →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/h3/">HUMANA — Chornovola</a><span class="dim"> — 250 м, просп. В. Чорновола, 95</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — 470 м, вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c122/">Second hand — Окуневського 3</a><span class="dim"> — 750 м, вулиця Теофіла Окуневського, 3</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c118/">Second hand — Чорновола 57</a><span class="dim"> — 1.2 км, пр. В&#39;ячеслава Чорновола, 57</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c76/">Світ секонд-хенду — Чорновола 45</a><span class="dim"> — 1.3 км, просп. В&#39;ячеслава Чорновола, 45</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c34/">EconomClass — Mazepy 11V</a><span class="dim"> — 1.3 км, вул. Мазепи, 11В</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c22/index.html
+++ b/store/c22/index.html
@@ -99,6 +99,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -117,7 +120,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вулиця Широка, 31 <span class="dim">· 31 Shyroka St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Євро Тренд Секонд хенд</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Євро Тренд Секонд хенд</a> <span class="dim">· 10 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: вівторок</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -138,6 +141,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Restocked Tuesdays.</p>
+
+  <h2>Інші магазини мережі Євро Тренд Секонд хенд</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c30/">Євро Тренд Секонд хенд — Богдана Хмельницького 176</a><span class="dim"> — вулиця Богдана Хмельницького, 176</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><span class="dim"> — вулиця Володимира Великого, 59б</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c23/">Євро Тренд Секонд хенд — Городоцька 67</a><span class="dim"> — вулиця Городоцька, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c24/">Євро Тренд Секонд хенд — Горська 2А</a><span class="dim"> — вулиця Горська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — вулиця Котлярська, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c26/">Євро Тренд Секонд хенд — Наукова 47</a><span class="dim"> — вулиця Наукова, 47</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c28/">Євро Тренд Секонд хенд — Сихівська 18</a><span class="dim"> — вулиця Сихівська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c25/">Євро Тренд Секонд хенд — Червоної Калини 59</a><span class="dim"> — проспект Червоної Калини, 59</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Усі 10 магазинів мережі Євро Тренд Секонд хенд →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c115/">Second hand — Широка 29</a><span class="dim"> — 40 м, вул. Широка, 29</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h5/">HUMANA — Shyroka</a><span class="dim"> — 610 м, вул. Широка, 81а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c77/">Світ секонд-хенду — Широка 70б</a><span class="dim"> — 730 м, вул. Широка, 70б</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c64/">Ваш секонд-хенд</a><span class="dim"> — 780 м, вул. Широка</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c63/">Конфі Склад</a><span class="dim"> — 780 м, вул. Широка</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c112/">Second hand — Смаль-Стоцького 1</a><span class="dim"> — 1.6 км, вул. Смаль-Стоцького, 1</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c23/index.html
+++ b/store/c23/index.html
@@ -99,6 +99,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -117,7 +120,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вулиця Городоцька, 67 <span class="dim">· 67 Horodotska St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Євро Тренд Секонд хенд</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Євро Тренд Секонд хенд</a> <span class="dim">· 10 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: четвер</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -138,6 +141,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Restocked Thursdays (updated per the #208 community list, which disagreed with the Wednesday previously on record — no other corroborating source, so treated as the newer/better information).</p>
+
+  <h2>Інші магазини мережі Євро Тренд Секонд хенд</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c30/">Євро Тренд Секонд хенд — Богдана Хмельницького 176</a><span class="dim"> — вулиця Богдана Хмельницького, 176</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><span class="dim"> — вулиця Володимира Великого, 59б</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c24/">Євро Тренд Секонд хенд — Горська 2А</a><span class="dim"> — вулиця Горська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — вулиця Котлярська, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c26/">Євро Тренд Секонд хенд — Наукова 47</a><span class="dim"> — вулиця Наукова, 47</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c28/">Євро Тренд Секонд хенд — Сихівська 18</a><span class="dim"> — вулиця Сихівська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c25/">Євро Тренд Секонд хенд — Червоної Калини 59</a><span class="dim"> — проспект Червоної Калини, 59</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c21/">Євро Тренд Секонд хенд — Чорновола 101</a><span class="dim"> — проспект В&#39;ячеслава Чорновола, 101</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Усі 10 магазинів мережі Євро Тренд Секонд хенд →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c97/">Second hand — Городоцька 45</a><span class="dim"> — 250 м, вул. Городоцька, 45</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c88/">ЄвроБренд — Городоцька 33</a><span class="dim"> — 400 м, вул. Городоцька, 33</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c116/">Second hand — Шолом-Алейхема 20</a><span class="dim"> — 480 м, вулиця Шолом-Алейхема, 20</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c61/">Євро секонд хенд</a><span class="dim"> — 480 м, вул. Базарна, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c56/">Luxovski</a><span class="dim"> — 510 м, вул. Шпитальна, 11</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c79/">Супер секонд-хенд</a><span class="dim"> — 520 м, вул. Базарна, 8</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c24/index.html
+++ b/store/c24/index.html
@@ -99,6 +99,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -117,7 +120,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вулиця Горська, 2 <span class="dim">· 2A Horska St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Євро Тренд Секонд хенд</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Євро Тренд Секонд хенд</a> <span class="dim">· 10 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: середа</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -138,6 +141,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Restocked Wednesdays. (Approx. location.)</p>
+
+  <h2>Інші магазини мережі Євро Тренд Секонд хенд</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c30/">Євро Тренд Секонд хенд — Богдана Хмельницького 176</a><span class="dim"> — вулиця Богдана Хмельницького, 176</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><span class="dim"> — вулиця Володимира Великого, 59б</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c23/">Євро Тренд Секонд хенд — Городоцька 67</a><span class="dim"> — вулиця Городоцька, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — вулиця Котлярська, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c26/">Євро Тренд Секонд хенд — Наукова 47</a><span class="dim"> — вулиця Наукова, 47</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c28/">Євро Тренд Секонд хенд — Сихівська 18</a><span class="dim"> — вулиця Сихівська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c25/">Євро Тренд Секонд хенд — Червоної Калини 59</a><span class="dim"> — проспект Червоної Калини, 59</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c21/">Євро Тренд Секонд хенд — Чорновола 101</a><span class="dim"> — проспект В&#39;ячеслава Чорновола, 101</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Усі 10 магазинів мережі Євро Тренд Секонд хенд →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — 20 м, вул. Горська, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c33/">EconomClass — Horska 5A</a><span class="dim"> — 20 м, вул. Горська, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — 1.4 км, вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — 1.4 км, вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s6/">Birka! Lux — Зелена 69а</a><span class="dim"> — 1.7 км, вул. Зелена, 69а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c89/">Сток та секонд хенд — Пасічна 96А</a><span class="dim"> — 2.0 км, вул. Пасічна, 96А</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c25/index.html
+++ b/store/c25/index.html
@@ -100,6 +100,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -119,7 +122,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Адреса</th><td>проспект Червоної Калини, 59 <span class="dim">· 59 Chervonoi Kalyny Ave</span></td></tr>
       <tr><th scope="row">Телефон</th><td><a href="tel:0509173559">050 917 3559</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Євро Тренд Секонд хенд</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Євро Тренд Секонд хенд</a> <span class="dim">· 10 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: вівторок</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -140,6 +143,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. ⭐ 3.4 (138 reviews). Closed Sundays. Restock day updated to Tuesday per the #208 community list, which disagreed with the Wednesday previously on record — no other corroborating source, so treated as the newer/better information.</p>
+
+  <h2>Інші магазини мережі Євро Тренд Секонд хенд</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c30/">Євро Тренд Секонд хенд — Богдана Хмельницького 176</a><span class="dim"> — вулиця Богдана Хмельницького, 176</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><span class="dim"> — вулиця Володимира Великого, 59б</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c23/">Євро Тренд Секонд хенд — Городоцька 67</a><span class="dim"> — вулиця Городоцька, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c24/">Євро Тренд Секонд хенд — Горська 2А</a><span class="dim"> — вулиця Горська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — вулиця Котлярська, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c26/">Євро Тренд Секонд хенд — Наукова 47</a><span class="dim"> — вулиця Наукова, 47</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c28/">Євро Тренд Секонд хенд — Сихівська 18</a><span class="dim"> — вулиця Сихівська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c21/">Євро Тренд Секонд хенд — Чорновола 101</a><span class="dim"> — проспект В&#39;ячеслава Чорновола, 101</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Усі 10 магазинів мережі Євро Тренд Секонд хенд →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c107/">Second hand — Довженка 4</a><span class="dim"> — 40 м, вул. Олександра Довженка, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c11/">Євро секонд хенд</a><span class="dim"> — 70 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c111/">Second hand — Сихівська 13</a><span class="dim"> — 650 м, вул. Сихівська, 13</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c28/">Євро Тренд Секонд хенд — Сихівська 18</a><span class="dim"> — 710 м, вулиця Сихівська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h4/">HUMANA — Sykhivska</a><span class="dim"> — 710 м, вул. Сиховська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c15/">Euro marke</a><span class="dim"> — 750 м, пр. Червоної Калини, 66А</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c26/index.html
+++ b/store/c26/index.html
@@ -99,6 +99,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -117,7 +120,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вулиця Наукова, 47 <span class="dim">· 47 Naukova St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Євро Тренд Секонд хенд</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Євро Тренд Секонд хенд</a> <span class="dim">· 10 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: четвер</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -138,6 +141,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Restocked Thursdays.</p>
+
+  <h2>Інші магазини мережі Євро Тренд Секонд хенд</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c30/">Євро Тренд Секонд хенд — Богдана Хмельницького 176</a><span class="dim"> — вулиця Богдана Хмельницького, 176</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><span class="dim"> — вулиця Володимира Великого, 59б</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c23/">Євро Тренд Секонд хенд — Городоцька 67</a><span class="dim"> — вулиця Городоцька, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c24/">Євро Тренд Секонд хенд — Горська 2А</a><span class="dim"> — вулиця Горська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — вулиця Котлярська, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c28/">Євро Тренд Секонд хенд — Сихівська 18</a><span class="dim"> — вулиця Сихівська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c25/">Євро Тренд Секонд хенд — Червоної Калини 59</a><span class="dim"> — проспект Червоної Калини, 59</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c21/">Євро Тренд Секонд хенд — Чорновола 101</a><span class="dim"> — проспект В&#39;ячеслава Чорновола, 101</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Усі 10 магазинів мережі Євро Тренд Секонд хенд →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c105/">Second hand — Наукова 45</a><span class="dim"> — 0 м, вул. Наукова, 45</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c106/">Євро Секонд Хенд — Наукова 49а</a><span class="dim"> — 130 м, вул. Наукова, 49а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c60/">Світ секонд-хенду — Наукова 64</a><span class="dim"> — 180 м, вул. Наукова, 64</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c68/">Світ секонд-хенду — Наукова 53</a><span class="dim"> — 280 м, вул. Наукова, 53</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c100/">Second hand — Княгині Ольги 114</a><span class="dim"> — 560 м, вул. Княгині Ольги, 114 (ринок &quot;Провесінь&quot;)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — 830 м, вул. Володимира Великого, 34</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c27/index.html
+++ b/store/c27/index.html
@@ -99,6 +99,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -117,7 +120,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вулиця Котлярська, 6 <span class="dim">· 6 Kotliarska St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Євро Тренд Секонд хенд</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Євро Тренд Секонд хенд</a> <span class="dim">· 10 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: четвер</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -138,6 +141,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Restocked Thursdays.</p>
+
+  <h2>Інші магазини мережі Євро Тренд Секонд хенд</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c30/">Євро Тренд Секонд хенд — Богдана Хмельницького 176</a><span class="dim"> — вулиця Богдана Хмельницького, 176</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><span class="dim"> — вулиця Володимира Великого, 59б</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c23/">Євро Тренд Секонд хенд — Городоцька 67</a><span class="dim"> — вулиця Городоцька, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c24/">Євро Тренд Секонд хенд — Горська 2А</a><span class="dim"> — вулиця Горська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c26/">Євро Тренд Секонд хенд — Наукова 47</a><span class="dim"> — вулиця Наукова, 47</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c28/">Євро Тренд Секонд хенд — Сихівська 18</a><span class="dim"> — вулиця Сихівська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c25/">Євро Тренд Секонд хенд — Червоної Калини 59</a><span class="dim"> — проспект Червоної Калини, 59</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c21/">Євро Тренд Секонд хенд — Чорновола 101</a><span class="dim"> — проспект В&#39;ячеслава Чорновола, 101</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Усі 10 магазинів мережі Євро Тренд Секонд хенд →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c125/">Birka! Lux — Шпитальна 7</a><span class="dim"> — 110 м, вул. Шпитальна, 7</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c124/">МЮНХЕН — Городоцька 10</a><span class="dim"> — 160 м, Городоцька вулиця, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c56/">Luxovski</a><span class="dim"> — 190 м, вул. Шпитальна, 11</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c116/">Second hand — Шолом-Алейхема 20</a><span class="dim"> — 200 м, вулиця Шолом-Алейхема, 20</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c61/">Євро секонд хенд</a><span class="dim"> — 260 м, вул. Базарна, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c79/">Супер секонд-хенд</a><span class="dim"> — 260 м, вул. Базарна, 8</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c28/index.html
+++ b/store/c28/index.html
@@ -99,6 +99,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -117,7 +120,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вулиця Сихівська, 18 <span class="dim">· 18 Sykhivska St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Євро Тренд Секонд хенд</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Євро Тренд Секонд хенд</a> <span class="dim">· 10 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: понеділок</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -138,6 +141,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Restocked Mondays (updated per the #208 community list, which disagreed with the Friday previously on record — no other corroborating source, so treated as the newer/better information).</p>
+
+  <h2>Інші магазини мережі Євро Тренд Секонд хенд</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c30/">Євро Тренд Секонд хенд — Богдана Хмельницького 176</a><span class="dim"> — вулиця Богдана Хмельницького, 176</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><span class="dim"> — вулиця Володимира Великого, 59б</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c23/">Євро Тренд Секонд хенд — Городоцька 67</a><span class="dim"> — вулиця Городоцька, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c24/">Євро Тренд Секонд хенд — Горська 2А</a><span class="dim"> — вулиця Горська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — вулиця Котлярська, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c26/">Євро Тренд Секонд хенд — Наукова 47</a><span class="dim"> — вулиця Наукова, 47</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c25/">Євро Тренд Секонд хенд — Червоної Калини 59</a><span class="dim"> — проспект Червоної Калини, 59</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c21/">Євро Тренд Секонд хенд — Чорновола 101</a><span class="dim"> — проспект В&#39;ячеслава Чорновола, 101</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Усі 10 магазинів мережі Євро Тренд Секонд хенд →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/h4/">HUMANA — Sykhivska</a><span class="dim"> — 0 м, вул. Сиховська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c111/">Second hand — Сихівська 13</a><span class="dim"> — 180 м, вул. Сихівська, 13</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c99/">Second hand — Кавалерідзе 6</a><span class="dim"> — 280 м, вул. Івана Кавалерідзе, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — 300 м, вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c15/">Euro marke</a><span class="dim"> — 620 м, пр. Червоної Калини, 66А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c25/">Євро Тренд Секонд хенд — Червоної Калини 59</a><span class="dim"> — 710 м, проспект Червоної Калини, 59</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c29/index.html
+++ b/store/c29/index.html
@@ -99,6 +99,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -117,7 +120,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вулиця Володимира Великого, 59б <span class="dim">· 59B V. Velykoho St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Євро Тренд Секонд хенд</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Євро Тренд Секонд хенд</a> <span class="dim">· 10 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: п’ятниця</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -138,6 +141,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Restocked Fridays.</p>
+
+  <h2>Інші магазини мережі Євро Тренд Секонд хенд</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c30/">Євро Тренд Секонд хенд — Богдана Хмельницького 176</a><span class="dim"> — вулиця Богдана Хмельницького, 176</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c23/">Євро Тренд Секонд хенд — Городоцька 67</a><span class="dim"> — вулиця Городоцька, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c24/">Євро Тренд Секонд хенд — Горська 2А</a><span class="dim"> — вулиця Горська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — вулиця Котлярська, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c26/">Євро Тренд Секонд хенд — Наукова 47</a><span class="dim"> — вулиця Наукова, 47</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c28/">Євро Тренд Секонд хенд — Сихівська 18</a><span class="dim"> — вулиця Сихівська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c25/">Євро Тренд Секонд хенд — Червоної Калини 59</a><span class="dim"> — проспект Червоної Калини, 59</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c21/">Євро Тренд Секонд хенд — Чорновола 101</a><span class="dim"> — проспект В&#39;ячеслава Чорновола, 101</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Усі 10 магазинів мережі Євро Тренд Секонд хенд →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c94/">Second hand — Володимира Великого 51</a><span class="dim"> — 120 м, вул. Володимира Великого, 51</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c95/">Second hand — Володимира Великого 59А</a><span class="dim"> — 130 м, вул. Володимира Великого, 59А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c100/">Second hand — Княгині Ольги 114</a><span class="dim"> — 400 м, вул. Княгині Ольги, 114 (ринок &quot;Провесінь&quot;)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c93/">Second hand — Володимира Великого 26А</a><span class="dim"> — 420 м, вул. Володимира Великого, 26A</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — 600 м, вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c60/">Світ секонд-хенду — Наукова 64</a><span class="dim"> — 750 м, вул. Наукова, 64</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c3/index.html
+++ b/store/c3/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Address from OpenStreetMap/Nominatim (a &quot;Euro second hand&quot; POI 7m from this pin) and the #208 community list. Not c66 (Шота Руставелі, 4) — that store is ~450m away, a different building.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c66/">Секонд-хенд Супер Бомба</a><span class="dim"> — 470 м, вул. Шота Руставелі, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s6/">Birka! Lux — Зелена 69а</a><span class="dim"> — 840 м, вул. Зелена, 69а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c123/">МЮНХЕН — Вороного 2</a><span class="dim"> — 1.0 км, вулиця Миколи Вороного, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c2/">Second hand</a><span class="dim"> — 1.0 км</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c20/">Second hand Bomba</a><span class="dim"> — 1.1 км</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h7/">HUMANA Vintage</a><span class="dim"> — 1.1 км, вул. Валова, 13</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c30/index.html
+++ b/store/c30/index.html
@@ -99,6 +99,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -117,7 +120,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вулиця Богдана Хмельницького, 176 <span class="dim">· 176 B. Khmelnytskoho St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Євро Тренд Секонд хенд</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Євро Тренд Секонд хенд</a> <span class="dim">· 10 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: п’ятниця</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -138,6 +141,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Restocked Fridays.</p>
+
+  <h2>Інші магазини мережі Євро Тренд Секонд хенд</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><span class="dim"> — вулиця Володимира Великого, 59б</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c23/">Євро Тренд Секонд хенд — Городоцька 67</a><span class="dim"> — вулиця Городоцька, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c24/">Євро Тренд Секонд хенд — Горська 2А</a><span class="dim"> — вулиця Горська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — вулиця Котлярська, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c26/">Євро Тренд Секонд хенд — Наукова 47</a><span class="dim"> — вулиця Наукова, 47</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c28/">Євро Тренд Секонд хенд — Сихівська 18</a><span class="dim"> — вулиця Сихівська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c25/">Євро Тренд Секонд хенд — Червоної Калини 59</a><span class="dim"> — проспект Червоної Калини, 59</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c21/">Євро Тренд Секонд хенд — Чорновола 101</a><span class="dim"> — проспект В&#39;ячеслава Чорновола, 101</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Усі 10 магазинів мережі Євро Тренд Секонд хенд →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c92/">Second hand — Хмельницького 214</a><span class="dim"> — 1.0 км, вул. Богдана Хмельницького, 214</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — 1.2 км, вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c103/">Second hand — Мазепи 26</a><span class="dim"> — 1.3 км, вул. Мазепи, 26</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — 1.3 км, вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — 1.5 км, вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c34/">EconomClass — Mazepy 11V</a><span class="dim"> — 1.8 км, вул. Мазепи, 11В</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c31/index.html
+++ b/store/c31/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Героїв УПА, 73 <span class="dim">· 73 Heroiv UPA St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: понеділок</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Оновлення товару «ЛЮКС» — вівторок. · Clothing from Europe by weight, daily markdowns. &quot;Lux&quot; restock on Tuesday.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c112/">Second hand — Смаль-Стоцького 1</a><span class="dim"> — 830 м, вул. Смаль-Стоцького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s3/">Yevromiks</a><span class="dim"> — 1.0 км, вул. Городоцька, 123</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c65/">Магазин Планета Секонд-хенд</a><span class="dim"> — 1.1 км, пл. Липнева, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c110/">Second hand — Симона Петлюри 3</a><span class="dim"> — 1.1 км, вул. Симона Петлюри, 3</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c75/">Світ секонд-хенду — Симона Петлюри 2а</a><span class="dim"> — 1.1 км, вул. Симона Петлюри, 2а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c98/">Second hand — Горської 5а</a><span class="dim"> — 1.2 км, вул. Алли Горської, 5а</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c32/index.html
+++ b/store/c32/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Б. Хмельницького, 275 <span class="dim">· 275 B. Khmelnytskoho St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: вівторок</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Оновлення товару «ЛЮКС» — середа. · Clothing from Europe by weight, daily markdowns. &quot;Lux&quot; restock on Wednesday.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c40/">EconomClass — Drohobych, Shevchenka 1</a><span class="dim"> — м. Дрогобич, вул. Шевченка, 1</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — 590 м, вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c92/">Second hand — Хмельницького 214</a><span class="dim"> — 600 м, вул. Богдана Хмельницького, 214</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c103/">Second hand — Мазепи 26</a><span class="dim"> — 1.4 км, вул. Мазепи, 26</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — 1.5 км, вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c30/">Євро Тренд Секонд хенд — Богдана Хмельницького 176</a><span class="dim"> — 1.5 км, вулиця Богдана Хмельницького, 176</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c34/">EconomClass — Mazepy 11V</a><span class="dim"> — 2.0 км, вул. Мазепи, 11В</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c33/index.html
+++ b/store/c33/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Горська, 5А <span class="dim">· 5A Horska St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: вівторок</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Оновлення товару «ЛЮКС» — середа. · Clothing from Europe by weight, daily markdowns. &quot;Lux&quot; restock on Wednesday.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — 0 м, вул. Горська, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c24/">Євро Тренд Секонд хенд — Горська 2А</a><span class="dim"> — 20 м, вулиця Горська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — 1.4 км, вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — 1.4 км, вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s6/">Birka! Lux — Зелена 69а</a><span class="dim"> — 1.7 км, вул. Зелена, 69а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c89/">Сток та секонд хенд — Пасічна 96А</a><span class="dim"> — 2.0 км, вул. Пасічна, 96А</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c34/index.html
+++ b/store/c34/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Мазепи, 11В <span class="dim">· 11V Mazepy St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: четвер</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Оновлення товару «ЛЮКС» — п’ятниця. · Clothing from Europe by weight, daily markdowns. &quot;Lux&quot; restock on Friday.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — 580 м, вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c103/">Second hand — Мазепи 26</a><span class="dim"> — 630 м, вул. Мазепи, 26</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c21/">Євро Тренд Секонд хенд — Чорновола 101</a><span class="dim"> — 1.3 км, проспект В&#39;ячеслава Чорновола, 101</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h3/">HUMANA — Chornovola</a><span class="dim"> — 1.4 км, просп. В. Чорновола, 95</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — 1.4 км, вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — 1.5 км, вул. Чорновола, 67</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c35/index.html
+++ b/store/c35/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Личаківська, 201 <span class="dim">· 201 Lychakivska St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: п’ятниця</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Оновлення товару «ЛЮКС» — субота. · Clothing from Europe by weight, daily markdowns. &quot;Lux&quot; restock on Saturday.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/s7/">Stocki Lviv</a><span class="dim"> — 700 м, вул. Промислова, 60</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c59/">Birka! Lux — Котика 2</a><span class="dim"> — 840 м, вул. Богдана Котика, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c74/">Світ секонд-хенду — Пасічна 51</a><span class="dim"> — 920 м, вул. Пасічна, 51</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c108/">Second hand — Пасічна 53</a><span class="dim"> — 1.0 км, вул. Пасічна, 53</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c104/">Second hand — Медової Печери 1</a><span class="dim"> — 1.1 км, вул. Медової Печери, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c89/">Сток та секонд хенд — Пасічна 96А</a><span class="dim"> — 1.6 км, вул. Пасічна, 96А</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c36/index.html
+++ b/store/c36/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Виговського, 49 <span class="dim">· 49 Vyhovskoho St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: п’ятниця</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Оновлення товару «ЛЮКС» — субота. · Clothing from Europe by weight, daily markdowns. &quot;Lux&quot; restock on Saturday.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c102/">Second hand — Любінська 120</a><span class="dim"> — 670 м, вул. Любінська, 120</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c101/">Second hand — Любінська 102</a><span class="dim"> — 690 м, вул. Любінська, 102</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h2/">HUMANA — Lyubinska</a><span class="dim"> — 740 м, вул. Любинська, 100 (2 поверх)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — 740 м, вул. Любінська, 100</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c75/">Світ секонд-хенду — Симона Петлюри 2а</a><span class="dim"> — 820 м, вул. Симона Петлюри, 2а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c110/">Second hand — Симона Петлюри 3</a><span class="dim"> — 890 м, вул. Симона Петлюри, 3</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c37/index.html
+++ b/store/c37/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Чорновола, 67 <span class="dim">· 67 Chornovola Ave</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: п’ятниця</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Оновлення товару «ЛЮКС» — субота. · Clothing from Europe by weight, daily markdowns. &quot;Lux&quot; restock on Saturday.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c40/">EconomClass — Drohobych, Shevchenka 1</a><span class="dim"> — м. Дрогобич, вул. Шевченка, 1</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/h3/">HUMANA — Chornovola</a><span class="dim"> — 230 м, просп. В. Чорновола, 95</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c122/">Second hand — Окуневського 3</a><span class="dim"> — 280 м, вулиця Теофіла Окуневського, 3</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c21/">Євро Тренд Секонд хенд — Чорновола 101</a><span class="dim"> — 470 м, проспект В&#39;ячеслава Чорновола, 101</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c118/">Second hand — Чорновола 57</a><span class="dim"> — 690 м, пр. В&#39;ячеслава Чорновола, 57</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c76/">Світ секонд-хенду — Чорновола 45</a><span class="dim"> — 800 м, просп. В&#39;ячеслава Чорновола, 45</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s4/">ObnovaNova</a><span class="dim"> — 1.3 км, просп. В. Чорновола, 16і</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c38/index.html
+++ b/store/c38/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Драгана, 2 <span class="dim">· 2 Drahana St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: субота</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Оновлення товару «ЛЮКС» — неділя. · Clothing from Europe by weight, daily markdowns. &quot;Lux&quot; restock on Sunday.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c40/">EconomClass — Drohobych, Shevchenka 1</a><span class="dim"> — м. Дрогобич, вул. Шевченка, 1</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c17/">Євро секонд-хенд</a><span class="dim"> — 240 м, пр. Червоної Калини, 105</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c16/">Euro Second Hand</a><span class="dim"> — 250 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c15/">Euro marke</a><span class="dim"> — 610 м, пр. Червоної Калини, 66А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — 1.0 км, вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c111/">Second hand — Сихівська 13</a><span class="dim"> — 1.0 км, вул. Сихівська, 13</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c99/">Second hand — Кавалерідзе 6</a><span class="dim"> — 1.0 км, вул. Івана Кавалерідзе, 6</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c39/index.html
+++ b/store/c39/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>м. Городок, вул. Перемишльська, 20 <span class="dim">· Horodok, 20 Peremyshlska St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: п’ятниця</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,25 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Оновлення товару «ЛЮКС» — субота. · Clothing from Europe by weight, daily markdowns. &quot;Lux&quot; restock on Saturday. Розташування та години перевірено на місці. · Location and hours verified on site.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c80/">Євро секонд-хенд</a><span class="dim"> — 40 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c82/">Family shop</a><span class="dim"> — 140 м</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c4/index.html
+++ b/store/c4/index.html
@@ -54,6 +54,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -91,6 +94,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">New stock arrives every day; the shop only does a full seasonal wardrobe change rather than following a fixed restock cycle.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c8/">Second Hand Bomba</a><span class="dim"> — 80 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h6/">HUMANA — Doroshenka</a><span class="dim"> — 120 м, вул. П. Дорошенка, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c5/">Euro second hand</a><span class="dim"> — 240 м, вулиця Юліуша Словацького, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c123/">МЮНХЕН — Вороного 2</a><span class="dim"> — 290 м, вулиця Миколи Вороного, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h7/">HUMANA Vintage</a><span class="dim"> — 480 м, вул. Валова, 13</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c88/">ЄвроБренд — Городоцька 33</a><span class="dim"> — 500 м, вул. Городоцька, 33</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c40/index.html
+++ b/store/c40/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>м. Дрогобич, вул. Шевченка, 1 <span class="dim">· Drohobych, 1 Shevchenka St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: середа</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,25 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Оновлення товару «ЛЮКС» — четвер. · Clothing from Europe by weight, daily markdowns. &quot;Lux&quot; restock on Thursday.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c83/">EconomClass — Drohobych, Shevchenka 1 (2nd floor)</a><span class="dim"> — 0 м, м. Дрогобич, вул. Шевченка, 1 (2 поверх)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — 90 м, м. Дрогобич, вул. Ковальська, 2</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c41/index.html
+++ b/store/c41/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>м. Дрогобич, вул. Ковальська, 2 <span class="dim">· Drohobych, 2 Kovalska St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: п’ятниця</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,25 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Оновлення товару «ЛЮКС» — субота. · Clothing from Europe by weight, daily markdowns. &quot;Lux&quot; restock on Saturday.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c40/">EconomClass — Drohobych, Shevchenka 1</a><span class="dim"> — м. Дрогобич, вул. Шевченка, 1</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c40/">EconomClass — Drohobych, Shevchenka 1</a><span class="dim"> — 90 м, м. Дрогобич, вул. Шевченка, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c83/">EconomClass — Drohobych, Shevchenka 1 (2nd floor)</a><span class="dim"> — 90 м, м. Дрогобич, вул. Шевченка, 1 (2 поверх)</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c42/index.html
+++ b/store/c42/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>м. Новояворівськ, вул. Бандери, 21а <span class="dim">· Novoyavorivsk, 21A Bandery St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: п’ятниця</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,19 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Оновлення товару «ЛЮКС» — субота. · Clothing from Europe by weight, daily markdowns. &quot;Lux&quot; restock on Saturday.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c43/index.html
+++ b/store/c43/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>м. Яворів, вул. Маковея, 62 <span class="dim">· Yavoriv, 62 Makoveia St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
   </table>
@@ -143,6 +146,19 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Повне оновлення — понеділок і п’ятниця, «ЛЮКС» — вівторок і субота (за календарем мережі). · Clothing from Europe by weight, daily markdowns. Full restock Monday and Friday, &quot;Lux&quot; Tuesday and Saturday, per the chain calendar.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c44/index.html
+++ b/store/c44/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>м. Самбір, вул. Торгова, 62 <span class="dim">· Sambir, 62 Torhova St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: вівторок</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,19 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Оновлення товару «ЛЮКС» — середа. · Clothing from Europe by weight, daily markdowns. &quot;Lux&quot; restock on Wednesday.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c45/index.html
+++ b/store/c45/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>м. Стрий, вул. Успенська, 36а <span class="dim">· Stryi, 36A Uspenska St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
   </table>
@@ -143,6 +146,19 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Повне оновлення — вівторок і п’ятниця, «ЛЮКС» — середа і субота (за календарем мережі). · Clothing from Europe by weight, daily markdowns. Full restock Tuesday and Friday, &quot;Lux&quot; Wednesday and Saturday, per the chain calendar.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c46/index.html
+++ b/store/c46/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>м. Червоноград, вул. Шептицького, 2 <span class="dim">· Chervonohrad, 2 Sheptytskoho St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: середа</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,26 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Оновлення товару «ЛЮКС» — четвер. · Clothing from Europe by weight, daily markdowns. &quot;Lux&quot; restock on Thursday.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c40/">EconomClass — Drohobych, Shevchenka 1</a><span class="dim"> — м. Дрогобич, вул. Шевченка, 1</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — 250 м, м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — 600 м, м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — 710 м, м. Червоноград, вул. Сокальська, 2</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c47/index.html
+++ b/store/c47/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>м. Червоноград, вул. Сокальська, 2 <span class="dim">· Chervonohrad, 2 Sokalska St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: четвер</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,26 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Оновлення товару «ЛЮКС» — п’ятниця. · Clothing from Europe by weight, daily markdowns. &quot;Lux&quot; restock on Friday.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c40/">EconomClass — Drohobych, Shevchenka 1</a><span class="dim"> — м. Дрогобич, вул. Шевченка, 1</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — 710 м, м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — 820 м, м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — 1.3 км, м. Червоноград, вул. С. Бандери, 14</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c48/index.html
+++ b/store/c48/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>м. Червоноград, вул. Шептицького, 1 <span class="dim">· Chervonohrad, 1 Sheptytskoho St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: п’ятниця</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,26 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Оновлення товару «ЛЮКС» — субота. · Clothing from Europe by weight, daily markdowns. &quot;Lux&quot; restock on Saturday.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c40/">EconomClass — Drohobych, Shevchenka 1</a><span class="dim"> — м. Дрогобич, вул. Шевченка, 1</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — 250 м, м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — 500 м, м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — 820 м, м. Червоноград, вул. Сокальська, 2</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c49/index.html
+++ b/store/c49/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>м. Сокаль, вул. Шептицького, 93 <span class="dim">· Sokal, 93 Sheptytskoho St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: четвер</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,19 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Оновлення товару «ЛЮКС» — п’ятниця. · Clothing from Europe by weight, daily markdowns. &quot;Lux&quot; restock on Friday.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c5/index.html
+++ b/store/c5/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Address from OpenStreetMap/Nominatim (a &quot;Євро секонд-хенд&quot; POI 3m from this pin) and the #208 community list, which also reports a Monday restock — conflicts with the Saturday implied by this store&#39;s existing restock_date; not overwritten, flagged for a field check.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c4/">Second Hand - Bomba womens</a><span class="dim"> — 240 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c8/">Second Hand Bomba</a><span class="dim"> — 310 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h6/">HUMANA — Doroshenka</a><span class="dim"> — 350 м, вул. П. Дорошенка, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c123/">МЮНХЕН — Вороного 2</a><span class="dim"> — 480 м, вулиця Миколи Вороного, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c97/">Second hand — Городоцька 45</a><span class="dim"> — 500 м, вул. Городоцька, 45</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c88/">ЄвроБренд — Городоцька 33</a><span class="dim"> — 510 м, вул. Городоцька, 33</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c50/index.html
+++ b/store/c50/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>м. Новий Розділ, просп. Шевченка, 16 <span class="dim">· Novyi Rozdil, 16 Shevchenka Ave</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: п’ятниця</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,19 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Оновлення товару «ЛЮКС» — субота. · Clothing from Europe by weight, daily markdowns. &quot;Lux&quot; restock on Saturday.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c51/index.html
+++ b/store/c51/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>м. Червоноград, вул. С. Бандери, 14 <span class="dim">· Chervonohrad, 14 S. Bandery St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: вівторок</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,26 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Оновлення товару «ЛЮКС» — середа. · Clothing from Europe by weight, daily markdowns. &quot;Lux&quot; restock on Wednesday.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c40/">EconomClass — Drohobych, Shevchenka 1</a><span class="dim"> — м. Дрогобич, вул. Шевченка, 1</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — 500 м, м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — 600 м, м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — 1.3 км, м. Червоноград, вул. Сокальська, 2</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c53/index.html
+++ b/store/c53/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Патона, 2 <span class="dim">· Patona St, 2</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Світ секонд-хенду</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Світ секонд-хенду</a> <span class="dim">· 18 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-11</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Part of the Світ секонд-хенду chain.</p>
+
+  <h2>Інші магазини мережі Світ секонд-хенду</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — вул. Горська, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — вул. Любінська, 100</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Усі 18 магазинів мережі Світ секонд-хенду →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c58/">Секонд Мікс</a><span class="dim"> — 280 м, вул. Патона</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c102/">Second hand — Любінська 120</a><span class="dim"> — 380 м, вул. Любінська, 120</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c101/">Second hand — Любінська 102</a><span class="dim"> — 510 м, вул. Любінська, 102</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — 610 м, вул. Любінська, 100</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h2/">HUMANA — Lyubinska</a><span class="dim"> — 610 м, вул. Любинська, 100 (2 поверх)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c110/">Second hand — Симона Петлюри 3</a><span class="dim"> — 930 м, вул. Симона Петлюри, 3</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c54/index.html
+++ b/store/c54/index.html
@@ -62,6 +62,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -100,6 +103,11 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From locator.lviv.ua listing. Phone number from the dlab.com.ua business directory, same name and address.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c58/">Секонд Мікс</a><span class="dim"> — 2.5 км, вул. Патона</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c55/index.html
+++ b/store/c55/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -98,6 +101,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From locator.lviv.ua listing.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c91/">Сток та секонд хенд — Стрийська 61</a><span class="dim"> — 0 м, вул. Стрийська, 61</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c121/">Комісійний — Гашека 15а</a><span class="dim"> — 210 м, вулиця Ярослава Гашека, 15а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c114/">Second hand — Стрийська 57</a><span class="dim"> — 360 м, вул. Стрийська, 57</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c113/">Одяг з Європи — Стрийська 45</a><span class="dim"> — 1.4 км, вул. Стрийська, 45</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c100/">Second hand — Княгині Ольги 114</a><span class="dim"> — 1.9 км, вул. Княгині Ольги, 114 (ринок &quot;Провесінь&quot;)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><span class="dim"> — 2.0 км, вулиця Володимира Великого, 59б</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c56/index.html
+++ b/store/c56/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From locator.lviv.ua listing. House number from the #208 community list, which also reports a Wednesday restock — conflicts with the Monday implied by this store&#39;s existing restock_date; not overwritten, flagged for a field check.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c116/">Second hand — Шолом-Алейхема 20</a><span class="dim"> — 50 м, вулиця Шолом-Алейхема, 20</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c61/">Євро секонд хенд</a><span class="dim"> — 60 м, вул. Базарна, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c79/">Супер секонд-хенд</a><span class="dim"> — 80 м, вул. Базарна, 8</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — 190 м, вулиця Котлярська, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c125/">Birka! Lux — Шпитальна 7</a><span class="dim"> — 250 м, вул. Шпитальна, 7</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c88/">ЄвроБренд — Городоцька 33</a><span class="dim"> — 280 м, вул. Городоцька, 33</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c57/index.html
+++ b/store/c57/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -98,6 +101,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From locator.lviv.ua listing.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c10/">Sekond Hand</a><span class="dim"> — 190 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c86/">Світ секонд-хенду — Степана Бандери 22</a><span class="dim"> — 210 м, вул. Степана Бандери, 22</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c9/">Sekond Hand</a><span class="dim"> — 380 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c67/">Супер-Бомба</a><span class="dim"> — 380 м, вул. Городоцька, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c87/">ЄвроБренд — Городоцька 94</a><span class="dim"> — 400 м, вул. Городоцька, 94</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c65/">Магазин Планета Секонд-хенд</a><span class="dim"> — 410 м, пл. Липнева, 6</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c58/index.html
+++ b/store/c58/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -98,6 +101,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From locator.lviv.ua listing.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c53/">Світ секонд-хенду — Патона 2</a><span class="dim"> — 280 м, вул. Патона, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c102/">Second hand — Любінська 120</a><span class="dim"> — 550 м, вул. Любінська, 120</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c101/">Second hand — Любінська 102</a><span class="dim"> — 800 м, вул. Любінська, 102</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — 890 м, вул. Любінська, 100</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h2/">HUMANA — Lyubinska</a><span class="dim"> — 890 м, вул. Любинська, 100 (2 поверх)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c110/">Second hand — Симона Петлюри 3</a><span class="dim"> — 1.2 км, вул. Симона Петлюри, 3</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c59/index.html
+++ b/store/c59/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Богдана Котика, 2 <span class="dim">· 2 Bohdana Kotyka St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Birka! Lux</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/birka-lux/">Birka! Lux</a> <span class="dim">· 3 магазини у Львові</span></td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
   </table>
@@ -143,6 +146,23 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Confirmed as a 3-location chain (Зелена 69а, Котика 2, Шпитальна 7) via a list.in.ua directory listing with published hours.</p>
+
+  <h2>Інші магазини мережі Birka! Lux</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/s6/">Birka! Lux — Зелена 69а</a><span class="dim"> — вул. Зелена, 69а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c125/">Birka! Lux — Шпитальна 7</a><span class="dim"> — вул. Шпитальна, 7</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/birka-lux/">Усі 3 магазини мережі Birka! Lux →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/s7/">Stocki Lviv</a><span class="dim"> — 800 м, вул. Промислова, 60</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c35/">EconomClass — Lychakivska 201</a><span class="dim"> — 840 м, вул. Личаківська, 201</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c19/">Second Hand super</a><span class="dim"> — 880 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c74/">Світ секонд-хенду — Пасічна 51</a><span class="dim"> — 1.3 км, вул. Пасічна, 51</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s6/">Birka! Lux — Зелена 69а</a><span class="dim"> — 1.4 км, вул. Зелена, 69а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c108/">Second hand — Пасічна 53</a><span class="dim"> — 1.4 км, вул. Пасічна, 53</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c60/index.html
+++ b/store/c60/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Наукова, 64 <span class="dim">· Naukova St, 64</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Світ секонд-хенду</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Світ секонд-хенду</a> <span class="dim">· 18 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-14</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Part of the Світ секонд-хенду chain. The #208 community list&#39;s &quot;Наукова, 64А&quot; entry (Friday, every 2 weeks) geocodes to ~2m from this pin — almost certainly this store. It agrees on the Friday and disagrees on the cycle (14 vs the 7 on record here); not changed, flagged for a field check.</p>
+
+  <h2>Інші магазини мережі Світ секонд-хенду</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — вул. Горська, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — вул. Любінська, 100</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Усі 18 магазинів мережі Світ секонд-хенду →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c26/">Євро Тренд Секонд хенд — Наукова 47</a><span class="dim"> — 180 м, вулиця Наукова, 47</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c105/">Second hand — Наукова 45</a><span class="dim"> — 180 м, вул. Наукова, 45</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c106/">Євро Секонд Хенд — Наукова 49а</a><span class="dim"> — 300 м, вул. Наукова, 49а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c100/">Second hand — Княгині Ольги 114</a><span class="dim"> — 370 м, вул. Княгині Ольги, 114 (ринок &quot;Провесінь&quot;)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c68/">Світ секонд-хенду — Наукова 53</a><span class="dim"> — 440 м, вул. Наукова, 53</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — 720 м, вул. Володимира Великого, 34</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c61/index.html
+++ b/store/c61/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -143,6 +146,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From locator.lviv.ua listing.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c79/">Супер секонд-хенд</a><span class="dim"> — 50 м, вул. Базарна, 8</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c56/">Luxovski</a><span class="dim"> — 60 м, вул. Шпитальна, 11</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c116/">Second hand — Шолом-Алейхема 20</a><span class="dim"> — 80 м, вулиця Шолом-Алейхема, 20</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — 260 м, вулиця Котлярська, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c88/">ЄвроБренд — Городоцька 33</a><span class="dim"> — 310 м, вул. Городоцька, 33</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c125/">Birka! Lux — Шпитальна 7</a><span class="dim"> — 310 м, вул. Шпитальна, 7</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c62/index.html
+++ b/store/c62/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -98,6 +101,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From locator.lviv.ua listing. New stock arrives every day; the shop only does a full seasonal wardrobe change rather than following a fixed restock cycle.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c84/">Світ секонд-хенду — Цехова 1</a><span class="dim"> — 120 м, вул. Цехова, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — 320 м, вулиця Котлярська, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s4/">ObnovaNova</a><span class="dim"> — 390 м, просп. В. Чорновола, 16і</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c56/">Luxovski</a><span class="dim"> — 410 м, вул. Шпитальна, 11</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c125/">Birka! Lux — Шпитальна 7</a><span class="dim"> — 420 м, вул. Шпитальна, 7</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c79/">Супер секонд-хенд</a><span class="dim"> — 420 м, вул. Базарна, 8</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c63/index.html
+++ b/store/c63/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -98,6 +101,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From locator.lviv.ua listing.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c64/">Ваш секонд-хенд</a><span class="dim"> — 10 м, вул. Широка</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c77/">Світ секонд-хенду — Широка 70б</a><span class="dim"> — 60 м, вул. Широка, 70б</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h5/">HUMANA — Shyroka</a><span class="dim"> — 220 м, вул. Широка, 81а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c22/">Євро Тренд Секонд хенд — Широка 31</a><span class="dim"> — 780 м, вулиця Широка, 31</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c115/">Second hand — Широка 29</a><span class="dim"> — 800 м, вул. Широка, 29</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c58/">Секонд Мікс</a><span class="dim"> — 2.1 км, вул. Патона</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c64/index.html
+++ b/store/c64/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -98,6 +101,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From locator.lviv.ua listing.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c63/">Конфі Склад</a><span class="dim"> — 10 м, вул. Широка</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c77/">Світ секонд-хенду — Широка 70б</a><span class="dim"> — 50 м, вул. Широка, 70б</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h5/">HUMANA — Shyroka</a><span class="dim"> — 210 м, вул. Широка, 81а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c22/">Євро Тренд Секонд хенд — Широка 31</a><span class="dim"> — 780 м, вулиця Широка, 31</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c115/">Second hand — Широка 29</a><span class="dim"> — 790 м, вул. Широка, 29</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c58/">Секонд Мікс</a><span class="dim"> — 2.1 км, вул. Патона</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c65/index.html
+++ b/store/c65/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -143,6 +146,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From locator.lviv.ua listing.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c98/">Second hand — Горської 5а</a><span class="dim"> — 220 м, вул. Алли Горської, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c10/">Sekond Hand</a><span class="dim"> — 250 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c9/">Sekond Hand</a><span class="dim"> — 310 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c7/">Second Hand</a><span class="dim"> — 340 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c57/">Оутлет Сток</a><span class="dim"> — 410 м, вул. Степана Бандери</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c87/">ЄвроБренд — Городоцька 94</a><span class="dim"> — 470 м, вул. Городоцька, 94</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c66/index.html
+++ b/store/c66/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -98,6 +101,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From locator.lviv.ua listing. New stock arrives every day; the shop only does a full seasonal wardrobe change rather than following a fixed restock cycle.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c3/">Euro second hand</a><span class="dim"> — 470 м, вул. Шота Руставелі, 42</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c2/">Second hand</a><span class="dim"> — 560 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c20/">Second hand Bomba</a><span class="dim"> — 620 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c123/">МЮНХЕН — Вороного 2</a><span class="dim"> — 660 м, вулиця Миколи Вороного, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h7/">HUMANA Vintage</a><span class="dim"> — 720 м, вул. Валова, 13</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s6/">Birka! Lux — Зелена 69а</a><span class="dim"> — 740 м, вул. Зелена, 69а</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c67/index.html
+++ b/store/c67/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -98,6 +101,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From locator.lviv.ua listing. New stock arrives every day; the shop only does a full seasonal wardrobe change rather than following a fixed restock cycle.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c87/">ЄвроБренд — Городоцька 94</a><span class="dim"> — 110 м, вул. Городоцька, 94</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c9/">Sekond Hand</a><span class="dim"> — 260 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c7/">Second Hand</a><span class="dim"> — 280 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c10/">Sekond Hand</a><span class="dim"> — 340 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c57/">Оутлет Сток</a><span class="dim"> — 380 м, вул. Степана Бандери</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c98/">Second hand — Горської 5а</a><span class="dim"> — 450 м, вул. Алли Горської, 5а</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c68/index.html
+++ b/store/c68/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Наукова, 53 <span class="dim">· Naukova St, 53</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Світ секонд-хенду</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Світ секонд-хенду</a> <span class="dim">· 18 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-06</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Part of the Світ секонд-хенду chain. The #208 community list&#39;s &quot;Наукова, 51&quot; entry (Thursday, every 2 weeks) geocodes to ~12m from this pin — almost certainly this store. It disagrees on the cycle (14 vs the 7 on record here); not changed, flagged for a field check.</p>
+
+  <h2>Інші магазини мережі Світ секонд-хенду</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — вул. Горська, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — вул. Любінська, 100</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Усі 18 магазинів мережі Світ секонд-хенду →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c106/">Євро Секонд Хенд — Наукова 49а</a><span class="dim"> — 150 м, вул. Наукова, 49а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c26/">Євро Тренд Секонд хенд — Наукова 47</a><span class="dim"> — 280 м, вулиця Наукова, 47</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c105/">Second hand — Наукова 45</a><span class="dim"> — 280 м, вул. Наукова, 45</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c60/">Світ секонд-хенду — Наукова 64</a><span class="dim"> — 440 м, вул. Наукова, 64</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c100/">Second hand — Княгині Ольги 114</a><span class="dim"> — 810 м, вул. Княгині Ольги, 114 (ринок &quot;Провесінь&quot;)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — 910 м, вул. Володимира Великого, 34</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c69/index.html
+++ b/store/c69/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Володимира Великого, 34 <span class="dim">· V. Velykoho St, 34</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Світ секонд-хенду</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Світ секонд-хенду</a> <span class="dim">· 18 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-07-29</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Part of the Світ секонд-хенду chain.</p>
+
+  <h2>Інші магазини мережі Світ секонд-хенду</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — вул. Горська, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — вул. Любінська, 100</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c68/">Світ секонд-хенду — Наукова 53</a><span class="dim"> — вул. Наукова, 53</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Усі 18 магазинів мережі Світ секонд-хенду →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c93/">Second hand — Володимира Великого 26А</a><span class="dim"> — 190 м, вул. Володимира Великого, 26A</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c95/">Second hand — Володимира Великого 59А</a><span class="dim"> — 590 м, вул. Володимира Великого, 59А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><span class="dim"> — 600 м, вулиця Володимира Великого, 59б</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c100/">Second hand — Княгині Ольги 114</a><span class="dim"> — 630 м, вул. Княгині Ольги, 114 (ринок &quot;Провесінь&quot;)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c94/">Second hand — Володимира Великого 51</a><span class="dim"> — 660 м, вул. Володимира Великого, 51</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c60/">Світ секонд-хенду — Наукова 64</a><span class="dim"> — 720 м, вул. Наукова, 64</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c7/index.html
+++ b/store/c7/index.html
@@ -98,6 +98,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -132,6 +135,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Неділя</th><td>09:00–19:00</td></tr>
     </tbody>
   </table>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c9/">Sekond Hand</a><span class="dim"> — 50 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c87/">ЄвроБренд — Городоцька 94</a><span class="dim"> — 170 м, вул. Городоцька, 94</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c98/">Second hand — Горської 5а</a><span class="dim"> — 170 м, вул. Алли Горської, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c10/">Sekond Hand</a><span class="dim"> — 260 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c67/">Супер-Бомба</a><span class="dim"> — 280 м, вул. Городоцька, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c65/">Магазин Планета Секонд-хенд</a><span class="dim"> — 340 м, пл. Липнева, 6</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c70/index.html
+++ b/store/c70/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Любінська, 100 <span class="dim">· Lyubinska St, 100</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Світ секонд-хенду</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Світ секонд-хенду</a> <span class="dim">· 18 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-05</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Part of the Світ секонд-хенду chain. Confirmed: shares this building with h2 (HUMANA) — two separate stores, not a duplicate.</p>
+
+  <h2>Інші магазини мережі Світ секонд-хенду</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — вул. Горська, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c68/">Світ секонд-хенду — Наукова 53</a><span class="dim"> — вул. Наукова, 53</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Усі 18 магазинів мережі Світ секонд-хенду →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/h2/">HUMANA — Lyubinska</a><span class="dim"> — 0 м, вул. Любинська, 100 (2 поверх)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c101/">Second hand — Любінська 102</a><span class="dim"> — 120 м, вул. Любінська, 102</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c75/">Світ секонд-хенду — Симона Петлюри 2а</a><span class="dim"> — 330 м, вул. Симона Петлюри, 2а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c110/">Second hand — Симона Петлюри 3</a><span class="dim"> — 330 м, вул. Симона Петлюри, 3</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c53/">Світ секонд-хенду — Патона 2</a><span class="dim"> — 610 м, вул. Патона, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c102/">Second hand — Любінська 120</a><span class="dim"> — 620 м, вул. Любінська, 120</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c71/index.html
+++ b/store/c71/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Гетьмана Мазепи, 24 <span class="dim">· Hetmana Mazepy St, 24</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Світ секонд-хенду</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Світ секонд-хенду</a> <span class="dim">· 18 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-11</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>14 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Part of the Світ секонд-хенду chain.</p>
+
+  <h2>Інші магазини мережі Світ секонд-хенду</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — вул. Горська, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — вул. Любінська, 100</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c68/">Світ секонд-хенду — Наукова 53</a><span class="dim"> — вул. Наукова, 53</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Усі 18 магазинів мережі Світ секонд-хенду →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c103/">Second hand — Мазепи 26</a><span class="dim"> — 60 м, вул. Мазепи, 26</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c34/">EconomClass — Mazepy 11V</a><span class="dim"> — 580 м, вул. Мазепи, 11В</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — 870 м, вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c30/">Євро Тренд Секонд хенд — Богдана Хмельницького 176</a><span class="dim"> — 1.3 км, вулиця Богдана Хмельницького, 176</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c92/">Second hand — Хмельницького 214</a><span class="dim"> — 1.4 км, вул. Богдана Хмельницького, 214</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — 1.5 км, вул. Б. Хмельницького, 275</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c72/index.html
+++ b/store/c72/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Грінченка, 6а <span class="dim">· Hrinchenka St, 6a</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Світ секонд-хенду</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Світ секонд-хенду</a> <span class="dim">· 18 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-07</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Part of the Світ секонд-хенду chain.</p>
+
+  <h2>Інші магазини мережі Світ секонд-хенду</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — вул. Горська, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — вул. Любінська, 100</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c68/">Світ секонд-хенду — Наукова 53</a><span class="dim"> — вул. Наукова, 53</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Усі 18 магазинів мережі Світ секонд-хенду →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — 590 м, вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c92/">Second hand — Хмельницького 214</a><span class="dim"> — 630 м, вул. Богдана Хмельницького, 214</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c103/">Second hand — Мазепи 26</a><span class="dim"> — 810 м, вул. Мазепи, 26</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — 870 м, вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c30/">Євро Тренд Секонд хенд — Богдана Хмельницького 176</a><span class="dim"> — 1.2 км, вулиця Богдана Хмельницького, 176</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c34/">EconomClass — Mazepy 11V</a><span class="dim"> — 1.4 км, вул. Мазепи, 11В</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c73/index.html
+++ b/store/c73/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Бориса Антоненка-Давидовича, 10 <span class="dim">· Antonenka-Davydovycha St, 10</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Світ секонд-хенду</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Світ секонд-хенду</a> <span class="dim">· 18 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
   </table>
@@ -143,6 +146,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Part of the Світ секонд-хенду chain.</p>
+
+  <h2>Інші магазини мережі Світ секонд-хенду</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — вул. Горська, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — вул. Любінська, 100</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c68/">Світ секонд-хенду — Наукова 53</a><span class="dim"> — вул. Наукова, 53</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Усі 18 магазинів мережі Світ секонд-хенду →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c99/">Second hand — Кавалерідзе 6</a><span class="dim"> — 40 м, вул. Івана Кавалерідзе, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c111/">Second hand — Сихівська 13</a><span class="dim"> — 250 м, вул. Сихівська, 13</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c28/">Євро Тренд Секонд хенд — Сихівська 18</a><span class="dim"> — 300 м, вулиця Сихівська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h4/">HUMANA — Sykhivska</a><span class="dim"> — 300 м, вул. Сиховська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c15/">Euro marke</a><span class="dim"> — 510 м, пр. Червоної Калини, 66А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c17/">Євро секонд-хенд</a><span class="dim"> — 800 м, пр. Червоної Калини, 105</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c74/index.html
+++ b/store/c74/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Пасічна, 51 <span class="dim">· Pasichna St, 51</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Світ секонд-хенду</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Світ секонд-хенду</a> <span class="dim">· 18 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-07-29</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Part of the Світ секонд-хенду chain.</p>
+
+  <h2>Інші магазини мережі Світ секонд-хенду</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — вул. Горська, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — вул. Любінська, 100</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Усі 18 магазинів мережі Світ секонд-хенду →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c108/">Second hand — Пасічна 53</a><span class="dim"> — 90 м, вул. Пасічна, 53</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c104/">Second hand — Медової Печери 1</a><span class="dim"> — 210 м, вул. Медової Печери, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c89/">Сток та секонд хенд — Пасічна 96А</a><span class="dim"> — 720 м, вул. Пасічна, 96А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c35/">EconomClass — Lychakivska 201</a><span class="dim"> — 920 м, вул. Личаківська, 201</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c59/">Birka! Lux — Котика 2</a><span class="dim"> — 1.3 км, вул. Богдана Котика, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — 1.3 км, вул. Джорджа Вашингтона, 5А</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c75/index.html
+++ b/store/c75/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Симона Петлюри, 2а <span class="dim">· Symona Petliury St, 2a</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Світ секонд-хенду</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Світ секонд-хенду</a> <span class="dim">· 18 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-13</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>14 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Part of the Світ секонд-хенду chain.</p>
+
+  <h2>Інші магазини мережі Світ секонд-хенду</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — вул. Горська, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — вул. Любінська, 100</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Усі 18 магазинів мережі Світ секонд-хенду →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c110/">Second hand — Симона Петлюри 3</a><span class="dim"> — 80 м, вул. Симона Петлюри, 3</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h2/">HUMANA — Lyubinska</a><span class="dim"> — 330 м, вул. Любинська, 100 (2 поверх)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — 330 м, вул. Любінська, 100</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c101/">Second hand — Любінська 102</a><span class="dim"> — 440 м, вул. Любінська, 102</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s3/">Yevromiks</a><span class="dim"> — 660 м, вул. Городоцька, 123</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c36/">EconomClass — Vyhovskoho 49</a><span class="dim"> — 820 м, вул. Виговського, 49</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c76/index.html
+++ b/store/c76/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>просп. В&#39;ячеслава Чорновола, 45 <span class="dim">· Chornovola Ave, 45</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Світ секонд-хенду</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Світ секонд-хенду</a> <span class="dim">· 18 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-13</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Part of the Світ секонд-хенду chain.</p>
+
+  <h2>Інші магазини мережі Світ секонд-хенду</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — вул. Горська, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — вул. Любінська, 100</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Усі 18 магазинів мережі Світ секонд-хенду →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c118/">Second hand — Чорновола 57</a><span class="dim"> — 110 м, пр. В&#39;ячеслава Чорновола, 57</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c122/">Second hand — Окуневського 3</a><span class="dim"> — 530 м, вулиця Теофіла Окуневського, 3</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s4/">ObnovaNova</a><span class="dim"> — 580 м, просп. В. Чорновола, 16і</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c84/">Світ секонд-хенду — Цехова 1</a><span class="dim"> — 650 м, вул. Цехова, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c62/">Бомба</a><span class="dim"> — 780 м, вул. Пантелеймона Куліша</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — 800 м, вул. Чорновола, 67</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c77/index.html
+++ b/store/c77/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Широка, 70б <span class="dim">· Shyroka St, 70b</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Світ секонд-хенду</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Світ секонд-хенду</a> <span class="dim">· 18 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-14</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Part of the Світ секонд-хенду chain.</p>
+
+  <h2>Інші магазини мережі Світ секонд-хенду</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — вул. Горська, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — вул. Любінська, 100</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Усі 18 магазинів мережі Світ секонд-хенду →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c64/">Ваш секонд-хенд</a><span class="dim"> — 50 м, вул. Широка</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c63/">Конфі Склад</a><span class="dim"> — 60 м, вул. Широка</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h5/">HUMANA — Shyroka</a><span class="dim"> — 190 м, вул. Широка, 81а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c22/">Євро Тренд Секонд хенд — Широка 31</a><span class="dim"> — 730 м, вулиця Широка, 31</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c115/">Second hand — Широка 29</a><span class="dim"> — 750 м, вул. Широка, 29</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c58/">Секонд Мікс</a><span class="dim"> — 2.1 км, вул. Патона</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c78/index.html
+++ b/store/c78/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Тараса Шевченка, 358 <span class="dim">· Shevchenka St, 358</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Світ секонд-хенду</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Світ секонд-хенду</a> <span class="dim">· 18 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-15</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,24 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Part of the Світ секонд-хенду chain.</p>
+
+  <h2>Інші магазини мережі Світ секонд-хенду</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — вул. Горська, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — вул. Любінська, 100</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Усі 18 магазинів мережі Світ секонд-хенду →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c90/">Сток та секонд хенд — Величковського 30а</a><span class="dim"> — 1.5 км, вул. Величковського, 30а</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c79/index.html
+++ b/store/c79/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Address from the #208 community list (31m from this pin). New stock arrives every day; the shop only does a full seasonal wardrobe change rather than following a fixed restock cycle — resolves the earlier cycle-length conflict (this was never a fixed 7- or 35-day cycle to begin with).</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c61/">Євро секонд хенд</a><span class="dim"> — 50 м, вул. Базарна, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c56/">Luxovski</a><span class="dim"> — 80 м, вул. Шпитальна, 11</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c116/">Second hand — Шолом-Алейхема 20</a><span class="dim"> — 110 м, вулиця Шолом-Алейхема, 20</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — 260 м, вулиця Котлярська, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c125/">Birka! Lux — Шпитальна 7</a><span class="dim"> — 330 м, вул. Шпитальна, 7</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c88/">ЄвроБренд — Городоцька 33</a><span class="dim"> — 350 м, вул. Городоцька, 33</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c8/index.html
+++ b/store/c8/index.html
@@ -54,6 +54,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -90,6 +93,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">New stock arrives every day; the shop only does a full seasonal wardrobe change rather than following a fixed restock cycle.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/h6/">HUMANA — Doroshenka</a><span class="dim"> — 40 м, вул. П. Дорошенка, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c4/">Second Hand - Bomba womens</a><span class="dim"> — 80 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c123/">МЮНХЕН — Вороного 2</a><span class="dim"> — 250 м, вулиця Миколи Вороного, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c5/">Euro second hand</a><span class="dim"> — 310 м, вулиця Юліуша Словацького, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h7/">HUMANA Vintage</a><span class="dim"> — 420 м, вул. Валова, 13</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c120/">ЕЛІТ</a><span class="dim"> — 490 м, вул. Театральна, 23</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c80/index.html
+++ b/store/c80/index.html
@@ -98,6 +98,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -132,6 +135,12 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Неділя</th><td>08:00–18:00</td></tr>
     </tbody>
   </table>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c39/">EconomClass — Horodok, Peremyshlska 20</a><span class="dim"> — 40 м, м. Городок, вул. Перемишльська, 20</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c82/">Family shop</a><span class="dim"> — 130 м</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c82/index.html
+++ b/store/c82/index.html
@@ -54,6 +54,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -88,6 +91,12 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Неділя</th><td class="dim">Невідомо</td></tr>
     </tbody>
   </table>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c80/">Євро секонд-хенд</a><span class="dim"> — 130 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c39/">EconomClass — Horodok, Peremyshlska 20</a><span class="dim"> — 140 м, м. Городок, вул. Перемишльська, 20</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c83/index.html
+++ b/store/c83/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>м. Дрогобич, вул. Шевченка, 1 (2 поверх) <span class="dim">· Drohobych, 1 Shevchenka St (2nd floor)</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>EconomClass</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a> <span class="dim">· 22 магазини у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: понеділок</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,25 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Одяг з Європи на вагу, щоденне зниження цін. Оновлення товару «ЛЮКС» — вівторок. · Clothing from Europe by weight, daily markdowns. &quot;Lux&quot; restock on Tuesday. Новий магазин, 2 поверх. · New shop, second floor.</p>
+
+  <h2>Інші магазини мережі EconomClass</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c51/">EconomClass — Chervonohrad, S. Bandery 14</a><span class="dim"> — м. Червоноград, вул. С. Бандери, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c48/">EconomClass — Chervonohrad, Sheptytskoho 1</a><span class="dim"> — м. Червоноград, вул. Шептицького, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c46/">EconomClass — Chervonohrad, Sheptytskoho 2</a><span class="dim"> — м. Червоноград, вул. Шептицького, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c47/">EconomClass — Chervonohrad, Sokalska 2</a><span class="dim"> — м. Червоноград, вул. Сокальська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c38/">EconomClass — Drahana 2</a><span class="dim"> — вул. Драгана, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — м. Дрогобич, вул. Ковальська, 2</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/economclass/">Усі 22 магазини мережі EconomClass →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c40/">EconomClass — Drohobych, Shevchenka 1</a><span class="dim"> — 0 м, м. Дрогобич, вул. Шевченка, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c41/">EconomClass — Drohobych, Kovalska 2</a><span class="dim"> — 90 м, м. Дрогобич, вул. Ковальська, 2</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c84/index.html
+++ b/store/c84/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Цехова, 1 <span class="dim">· 1 Tsekhova St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Світ секонд-хенду</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Світ секонд-хенду</a> <span class="dim">· 18 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-07</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Надіслано користувачем; адресу визначено за координатами — потребує перевірки на місці. · Submitted by a contributor; address derived from the pin — needs a field check.</p>
+
+  <h2>Інші магазини мережі Світ секонд-хенду</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — вул. Горська, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — вул. Любінська, 100</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Усі 18 магазинів мережі Світ секонд-хенду →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c62/">Бомба</a><span class="dim"> — 120 м, вул. Пантелеймона Куліша</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s4/">ObnovaNova</a><span class="dim"> — 340 м, просп. В. Чорновола, 16і</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — 440 м, вулиця Котлярська, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c79/">Супер секонд-хенд</a><span class="dim"> — 500 м, вул. Базарна, 8</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c56/">Luxovski</a><span class="dim"> — 510 м, вул. Шпитальна, 11</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c125/">Birka! Lux — Шпитальна 7</a><span class="dim"> — 540 м, вул. Шпитальна, 7</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c85/index.html
+++ b/store/c85/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Джорджа Вашингтона, 5А <span class="dim">· 5A Dzhordzha Vashynhtona St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Світ секонд-хенду</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Світ секонд-хенду</a> <span class="dim">· 18 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-15</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>14 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Part of the Світ секонд-хенду chain.</p>
+
+  <h2>Інші магазини мережі Світ секонд-хенду</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — вул. Горська, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — вул. Любінська, 100</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c68/">Світ секонд-хенду — Наукова 53</a><span class="dim"> — вул. Наукова, 53</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Усі 18 магазинів мережі Світ секонд-хенду →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c89/">Сток та секонд хенд — Пасічна 96А</a><span class="dim"> — 740 м, вул. Пасічна, 96А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c104/">Second hand — Медової Печери 1</a><span class="dim"> — 1.2 км, вул. Медової Печери, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c108/">Second hand — Пасічна 53</a><span class="dim"> — 1.2 км, вул. Пасічна, 53</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c74/">Світ секонд-хенду — Пасічна 51</a><span class="dim"> — 1.3 км, вул. Пасічна, 51</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c24/">Євро Тренд Секонд хенд — Горська 2А</a><span class="dim"> — 1.4 км, вулиця Горська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — 1.4 км, вул. Горська, 5а</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c86/index.html
+++ b/store/c86/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Степана Бандери, 22 <span class="dim">· 22 Stepana Bandery St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Світ секонд-хенду</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Світ секонд-хенду</a> <span class="dim">· 18 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-15</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>14 дн.</td></tr>
     </tbody>
@@ -144,6 +147,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">By weight. Part of the Світ секонд-хенду chain. 209 m from c57 (&quot;Оутлет Сток&quot;) — different name, different brand; treated as a separate shop.</p>
+
+  <h2>Інші магазини мережі Світ секонд-хенду</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — вул. Горська, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — вул. Любінська, 100</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Усі 18 магазинів мережі Світ секонд-хенду →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c57/">Оутлет Сток</a><span class="dim"> — 210 м, вул. Степана Бандери</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c10/">Sekond Hand</a><span class="dim"> — 390 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c67/">Супер-Бомба</a><span class="dim"> — 450 м, вул. Городоцька, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c87/">ЄвроБренд — Городоцька 94</a><span class="dim"> — 520 м, вул. Городоцька, 94</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c9/">Sekond Hand</a><span class="dim"> — 550 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c7/">Second Hand</a><span class="dim"> — 600 м</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c87/index.html
+++ b/store/c87/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Городоцька, 94 <span class="dim">· 94 Horodotska St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
-      <tr><th scope="row">Мережа</th><td>ЄвроБренд</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/yevrobrend/">ЄвроБренд</a> <span class="dim">· 2 магазини у Львові</span></td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
   </table>
@@ -143,6 +146,22 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Submitted by the owner (@evrobrand_lviv). No restock schedule given.</p>
+
+  <h2>Інші магазини мережі ЄвроБренд</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c88/">ЄвроБренд — Городоцька 33</a><span class="dim"> — вул. Городоцька, 33</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/yevrobrend/">Усі 2 магазини мережі ЄвроБренд →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c67/">Супер-Бомба</a><span class="dim"> — 110 м, вул. Городоцька, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c9/">Sekond Hand</a><span class="dim"> — 160 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c7/">Second Hand</a><span class="dim"> — 170 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c10/">Sekond Hand</a><span class="dim"> — 300 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c98/">Second hand — Горської 5а</a><span class="dim"> — 340 м, вул. Алли Горської, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c57/">Оутлет Сток</a><span class="dim"> — 400 м, вул. Степана Бандери</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c88/index.html
+++ b/store/c88/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Городоцька, 33 <span class="dim">· 33 Horodotska St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
-      <tr><th scope="row">Мережа</th><td>ЄвроБренд</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/yevrobrend/">ЄвроБренд</a> <span class="dim">· 2 магазини у Львові</span></td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
   </table>
@@ -143,6 +146,22 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Submitted by the owner (@evrobrand_lviv). No restock schedule given.</p>
+
+  <h2>Інші магазини мережі ЄвроБренд</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c87/">ЄвроБренд — Городоцька 94</a><span class="dim"> — вул. Городоцька, 94</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/yevrobrend/">Усі 2 магазини мережі ЄвроБренд →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c97/">Second hand — Городоцька 45</a><span class="dim"> — 150 м, вул. Городоцька, 45</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c124/">МЮНХЕН — Городоцька 10</a><span class="dim"> — 200 м, Городоцька вулиця, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c125/">Birka! Lux — Шпитальна 7</a><span class="dim"> — 220 м, вул. Шпитальна, 7</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c116/">Second hand — Шолом-Алейхема 20</a><span class="dim"> — 240 м, вулиця Шолом-Алейхема, 20</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c56/">Luxovski</a><span class="dim"> — 280 м, вул. Шпитальна, 11</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — 290 м, вулиця Котлярська, 6</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c89/index.html
+++ b/store/c89/index.html
@@ -62,6 +62,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -81,7 +84,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Адреса</th><td>вул. Пасічна, 96А <span class="dim">· 96A Pasichna St</span></td></tr>
       <tr><th scope="row">Телефон</th><td><a href="tel:+380934228870">+380934228870</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Сток та секонд хенд</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/stok-ta-sekond-khend/">Сток та секонд хенд</a> <span class="dim">· 3 магазини у Львові</span></td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
   </table>
@@ -101,6 +104,23 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Address confirmed only to street level (house number not in OSM) — needs a field check. · Address resolved to street level only — needs field verification.</p>
+
+  <h2>Інші магазини мережі Сток та секонд хенд</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c90/">Сток та секонд хенд — Величковського 30а</a><span class="dim"> — вул. Величковського, 30а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c91/">Сток та секонд хенд — Стрийська 61</a><span class="dim"> — вул. Стрийська, 61</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/stok-ta-sekond-khend/">Усі 3 магазини мережі Сток та секонд хенд →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c104/">Second hand — Медової Печери 1</a><span class="dim"> — 540 м, вул. Медової Печери, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c108/">Second hand — Пасічна 53</a><span class="dim"> — 640 м, вул. Пасічна, 53</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c74/">Світ секонд-хенду — Пасічна 51</a><span class="dim"> — 720 м, вул. Пасічна, 51</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — 740 м, вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c35/">EconomClass — Lychakivska 201</a><span class="dim"> — 1.6 км, вул. Личаківська, 201</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c24/">Євро Тренд Секонд хенд — Горська 2А</a><span class="dim"> — 2.0 км, вулиця Горська, 2</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c9/index.html
+++ b/store/c9/index.html
@@ -98,6 +98,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -131,6 +134,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Неділя</th><td>10:00–20:00</td></tr>
     </tbody>
   </table>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c7/">Second Hand</a><span class="dim"> — 50 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c87/">ЄвроБренд — Городоцька 94</a><span class="dim"> — 160 м, вул. Городоцька, 94</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c98/">Second hand — Горської 5а</a><span class="dim"> — 180 м, вул. Алли Горської, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c10/">Sekond Hand</a><span class="dim"> — 210 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c67/">Супер-Бомба</a><span class="dim"> — 260 м, вул. Городоцька, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c65/">Магазин Планета Секонд-хенд</a><span class="dim"> — 310 м, пл. Липнева, 6</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c90/index.html
+++ b/store/c90/index.html
@@ -62,6 +62,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -81,7 +84,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Адреса</th><td>вул. Величковського, 30а <span class="dim">· 30a Velychkivskoho St</span></td></tr>
       <tr><th scope="row">Телефон</th><td><a href="tel:+380934228870">+380934228870</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Сток та секонд хенд</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/stok-ta-sekond-khend/">Сток та секонд хенд</a> <span class="dim">· 3 магазини у Львові</span></td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
   </table>
@@ -98,6 +101,18 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Неділя</th><td class="dim">Невідомо</td></tr>
     </tbody>
   </table>
+
+  <h2>Інші магазини мережі Сток та секонд хенд</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c89/">Сток та секонд хенд — Пасічна 96А</a><span class="dim"> — вул. Пасічна, 96А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c91/">Сток та секонд хенд — Стрийська 61</a><span class="dim"> — вул. Стрийська, 61</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/stok-ta-sekond-khend/">Усі 3 магазини мережі Сток та секонд хенд →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c78/">Світ секонд-хенду — Шевченка 358</a><span class="dim"> — 1.5 км, вул. Тараса Шевченка, 358</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c91/index.html
+++ b/store/c91/index.html
@@ -62,6 +62,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -81,7 +84,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Адреса</th><td>вул. Стрийська, 61 <span class="dim">· 61 Stryiska St</span></td></tr>
       <tr><th scope="row">Телефон</th><td><a href="tel:+380934228870">+380934228870</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Сток та секонд хенд</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/stok-ta-sekond-khend/">Сток та секонд хенд</a> <span class="dim">· 3 магазини у Львові</span></td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
   </table>
@@ -101,6 +104,23 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Pin reused from c55 (&quot;Точка Секонд Хенд&quot;) pending a field check — geocoding could not confirm house number 61 on this street and placed c55 at the same point under a different name. Possible duplicate, not merged: different name, this record has a phone number. · Needs a field check to confirm whether this and c55 are the same shop.</p>
+
+  <h2>Інші магазини мережі Сток та секонд хенд</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c90/">Сток та секонд хенд — Величковського 30а</a><span class="dim"> — вул. Величковського, 30а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c89/">Сток та секонд хенд — Пасічна 96А</a><span class="dim"> — вул. Пасічна, 96А</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/stok-ta-sekond-khend/">Усі 3 магазини мережі Сток та секонд хенд →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c55/">Точка Секонд Хенд</a><span class="dim"> — 0 м, вул. Стрийська</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c121/">Комісійний — Гашека 15а</a><span class="dim"> — 210 м, вулиця Ярослава Гашека, 15а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c114/">Second hand — Стрийська 57</a><span class="dim"> — 360 м, вул. Стрийська, 57</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c113/">Одяг з Європи — Стрийська 45</a><span class="dim"> — 1.4 км, вул. Стрийська, 45</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c100/">Second hand — Княгині Ольги 114</a><span class="dim"> — 1.9 км, вул. Княгині Ольги, 114 (ринок &quot;Провесінь&quot;)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><span class="dim"> — 2.0 км, вулиця Володимира Великого, 59б</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c92/index.html
+++ b/store/c92/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown).</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c32/">EconomClass — B. Khmelnytskoho 275</a><span class="dim"> — 600 м, вул. Б. Хмельницького, 275</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — 630 м, вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c30/">Євро Тренд Секонд хенд — Богдана Хмельницького 176</a><span class="dim"> — 1.0 км, вулиця Богдана Хмельницького, 176</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c103/">Second hand — Мазепи 26</a><span class="dim"> — 1.3 км, вул. Мазепи, 26</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — 1.4 км, вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c34/">EconomClass — Mazepy 11V</a><span class="dim"> — 1.9 км, вул. Мазепи, 11В</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c93/index.html
+++ b/store/c93/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown).</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — 190 м, вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c95/">Second hand — Володимира Великого 59А</a><span class="dim"> — 400 м, вул. Володимира Великого, 59А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><span class="dim"> — 420 м, вулиця Володимира Великого, 59б</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c94/">Second hand — Володимира Великого 51</a><span class="dim"> — 470 м, вул. Володимира Великого, 51</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c100/">Second hand — Княгині Ольги 114</a><span class="dim"> — 540 м, вул. Княгині Ольги, 114 (ринок &quot;Провесінь&quot;)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c60/">Світ секонд-хенду — Наукова 64</a><span class="dim"> — 730 м, вул. Наукова, 64</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c94/index.html
+++ b/store/c94/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown).</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c95/">Second hand — Володимира Великого 59А</a><span class="dim"> — 70 м, вул. Володимира Великого, 59А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><span class="dim"> — 120 м, вулиця Володимира Великого, 59б</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c93/">Second hand — Володимира Великого 26А</a><span class="dim"> — 470 м, вул. Володимира Великого, 26A</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c100/">Second hand — Княгині Ольги 114</a><span class="dim"> — 520 м, вул. Княгині Ольги, 114 (ринок &quot;Провесінь&quot;)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — 660 м, вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c60/">Світ секонд-хенду — Наукова 64</a><span class="dim"> — 870 м, вул. Наукова, 64</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c95/index.html
+++ b/store/c95/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -98,6 +101,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown). Community list (#208) reports both Tuesday and Friday restocks at this address — possibly two stores sharing a building. Restock day left unset pending a field check. Nominatim could not pin down house 59А on this long street; placed near c29 (59б, one letter over) as a best-effort estimate.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c94/">Second hand — Володимира Великого 51</a><span class="dim"> — 70 м, вул. Володимира Великого, 51</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><span class="dim"> — 130 м, вулиця Володимира Великого, 59б</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c93/">Second hand — Володимира Великого 26А</a><span class="dim"> — 400 м, вул. Володимира Великого, 26A</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c100/">Second hand — Княгині Ольги 114</a><span class="dim"> — 520 м, вул. Княгині Ольги, 114 (ринок &quot;Провесінь&quot;)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — 590 м, вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c60/">Світ секонд-хенду — Наукова 64</a><span class="dim"> — 860 м, вул. Наукова, 64</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c96/index.html
+++ b/store/c96/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,12 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown). In Vynnyky, an eastern suburb of Lviv.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c109/">Second hand — Петра Дорошенка 1</a><span class="dim"> — 1.1 км, вул. Петра Дорошенка, 1 (2 поверх)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c119/">MOSTOK</a><span class="dim"> — 1.3 км, вул. Шептицького, 19а</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c97/index.html
+++ b/store/c97/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown).</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c88/">ЄвроБренд — Городоцька 33</a><span class="dim"> — 150 м, вул. Городоцька, 33</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c23/">Євро Тренд Секонд хенд — Городоцька 67</a><span class="dim"> — 250 м, вулиця Городоцька, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c116/">Second hand — Шолом-Алейхема 20</a><span class="dim"> — 300 м, вулиця Шолом-Алейхема, 20</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c61/">Євро секонд хенд</a><span class="dim"> — 340 м, вул. Базарна, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c56/">Luxovski</a><span class="dim"> — 340 м, вул. Шпитальна, 11</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c124/">МЮНХЕН — Городоцька 10</a><span class="dim"> — 350 м, Городоцька вулиця, 10</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c98/index.html
+++ b/store/c98/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown).</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c7/">Second Hand</a><span class="dim"> — 170 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c9/">Sekond Hand</a><span class="dim"> — 180 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c65/">Магазин Планета Секонд-хенд</a><span class="dim"> — 220 м, пл. Липнева, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c10/">Sekond Hand</a><span class="dim"> — 290 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c87/">ЄвроБренд — Городоцька 94</a><span class="dim"> — 340 м, вул. Городоцька, 94</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c67/">Супер-Бомба</a><span class="dim"> — 450 м, вул. Городоцька, 6</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/c99/index.html
+++ b/store/c99/index.html
@@ -61,6 +61,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -99,6 +102,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">From the #208 community-maintained restock list, cross-checked against OpenStreetMap/Nominatim geocoding — not yet confirmed against the map&#39;s other sources (name, phone, hours unknown).</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — 40 м, вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c111/">Second hand — Сихівська 13</a><span class="dim"> — 270 м, вул. Сихівська, 13</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c28/">Євро Тренд Секонд хенд — Сихівська 18</a><span class="dim"> — 280 м, вулиця Сихівська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h4/">HUMANA — Sykhivska</a><span class="dim"> — 280 м, вул. Сиховська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c15/">Euro marke</a><span class="dim"> — 550 м, пр. Червоної Калини, 66А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c17/">Євро секонд-хенд</a><span class="dim"> — 830 м, пр. Червоної Калини, 105</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/h1/index.html
+++ b/store/h1/index.html
@@ -106,6 +106,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -125,7 +128,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Адреса</th><td>вул. Княгині Ольги, 5а <span class="dim">· Knyahyni Olhy St, 5a</span></td></tr>
       <tr><th scope="row">Телефон</th><td><a href="tel:0322455009">(032) 245-50-09</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
-      <tr><th scope="row">Мережа</th><td>HUMANA</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/humana/">HUMANA</a> <span class="dim">· 8 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-17 (за офіційним календарем)</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>35 дн.</td></tr>
     </tbody>
@@ -163,6 +166,28 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Large store. 5-week inventory cycle. Prices drop every day after delivery. Lucky hours: 30% off all items. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.</p>
+
+  <h2>Інші магазини мережі HUMANA</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/h3/">HUMANA — Chornovola</a><span class="dim"> — просп. В. Чорновола, 95</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h6/">HUMANA — Doroshenka</a><span class="dim"> — вул. П. Дорошенка, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h2/">HUMANA — Lyubinska</a><span class="dim"> — вул. Любинська, 100 (2 поверх)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h8/">HUMANA — Shevchenka</a><span class="dim"> — вул. Тараса Шевченка, 31</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h5/">HUMANA — Shyroka</a><span class="dim"> — вул. Широка, 81а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h4/">HUMANA — Sykhivska</a><span class="dim"> — вул. Сиховська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h7/">HUMANA Vintage</a><span class="dim"> — вул. Валова, 13</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/humana/">Усі 8 магазинів мережі HUMANA →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/s8/">Umka</a><span class="dim"> — 600 м, вул. Генерала Чупринки, 59</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c31/">EconomClass — Heroiv UPA 73</a><span class="dim"> — 1.2 км, вул. Героїв УПА, 73</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c65/">Магазин Планета Секонд-хенд</a><span class="dim"> — 1.3 км, пл. Липнева, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c57/">Оутлет Сток</a><span class="dim"> — 1.3 км, вул. Степана Бандери</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c86/">Світ секонд-хенду — Степана Бандери 22</a><span class="dim"> — 1.3 км, вул. Степана Бандери, 22</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c10/">Sekond Hand</a><span class="dim"> — 1.4 км</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/h2/index.html
+++ b/store/h2/index.html
@@ -106,6 +106,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -125,7 +128,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Адреса</th><td>вул. Любинська, 100 (2 поверх) <span class="dim">· Lyubinska St, 100 (2nd floor)</span></td></tr>
       <tr><th scope="row">Телефон</th><td><a href="tel:032240440">(032) 24-04-40</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
-      <tr><th scope="row">Мережа</th><td>HUMANA</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/humana/">HUMANA</a> <span class="dim">· 8 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Цикл знижок</th><td>14 дн.</td></tr>
     </tbody>
   </table>
@@ -145,6 +148,28 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">2nd floor entrance. 2-week inventory cycle. Confirmed: shares this building with c70 (Світ секонд-хенду) — two separate stores, not a duplicate. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.</p>
+
+  <h2>Інші магазини мережі HUMANA</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/h3/">HUMANA — Chornovola</a><span class="dim"> — просп. В. Чорновола, 95</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h6/">HUMANA — Doroshenka</a><span class="dim"> — вул. П. Дорошенка, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h1/">HUMANA — Knyahyni Olhy</a><span class="dim"> — вул. Княгині Ольги, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h8/">HUMANA — Shevchenka</a><span class="dim"> — вул. Тараса Шевченка, 31</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h5/">HUMANA — Shyroka</a><span class="dim"> — вул. Широка, 81а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h4/">HUMANA — Sykhivska</a><span class="dim"> — вул. Сиховська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h7/">HUMANA Vintage</a><span class="dim"> — вул. Валова, 13</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/humana/">Усі 8 магазинів мережі HUMANA →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — 0 м, вул. Любінська, 100</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c101/">Second hand — Любінська 102</a><span class="dim"> — 120 м, вул. Любінська, 102</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c75/">Світ секонд-хенду — Симона Петлюри 2а</a><span class="dim"> — 330 м, вул. Симона Петлюри, 2а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c110/">Second hand — Симона Петлюри 3</a><span class="dim"> — 330 м, вул. Симона Петлюри, 3</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c53/">Світ секонд-хенду — Патона 2</a><span class="dim"> — 610 м, вул. Патона, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c102/">Second hand — Любінська 120</a><span class="dim"> — 620 м, вул. Любінська, 120</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/h3/index.html
+++ b/store/h3/index.html
@@ -106,6 +106,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -125,7 +128,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Адреса</th><td>просп. В. Чорновола, 95 <span class="dim">· V. Chornovola Ave, 95</span></td></tr>
       <tr><th scope="row">Телефон</th><td><a href="tel:0322445398">(032) 244-53-98</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
-      <tr><th scope="row">Мережа</th><td>HUMANA</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/humana/">HUMANA</a> <span class="dim">· 8 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-17 (за офіційним календарем)</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>35 дн.</td></tr>
     </tbody>
@@ -163,6 +166,28 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">5-week inventory cycle. Prices decrease daily. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.</p>
+
+  <h2>Інші магазини мережі HUMANA</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/h6/">HUMANA — Doroshenka</a><span class="dim"> — вул. П. Дорошенка, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h1/">HUMANA — Knyahyni Olhy</a><span class="dim"> — вул. Княгині Ольги, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h2/">HUMANA — Lyubinska</a><span class="dim"> — вул. Любинська, 100 (2 поверх)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h8/">HUMANA — Shevchenka</a><span class="dim"> — вул. Тараса Шевченка, 31</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h5/">HUMANA — Shyroka</a><span class="dim"> — вул. Широка, 81а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h4/">HUMANA — Sykhivska</a><span class="dim"> — вул. Сиховська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h7/">HUMANA Vintage</a><span class="dim"> — вул. Валова, 13</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/humana/">Усі 8 магазинів мережі HUMANA →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — 230 м, вул. Чорновола, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c21/">Євро Тренд Секонд хенд — Чорновола 101</a><span class="dim"> — 250 м, проспект В&#39;ячеслава Чорновола, 101</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c122/">Second hand — Окуневського 3</a><span class="dim"> — 510 м, вулиця Теофіла Окуневського, 3</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c118/">Second hand — Чорновола 57</a><span class="dim"> — 910 м, пр. В&#39;ячеслава Чорновола, 57</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c76/">Світ секонд-хенду — Чорновола 45</a><span class="dim"> — 1.0 км, просп. В&#39;ячеслава Чорновола, 45</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c34/">EconomClass — Mazepy 11V</a><span class="dim"> — 1.4 км, вул. Мазепи, 11В</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/h4/index.html
+++ b/store/h4/index.html
@@ -106,6 +106,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -125,7 +128,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Адреса</th><td>вул. Сиховська, 18 <span class="dim">· Sykhivska St, 18</span></td></tr>
       <tr><th scope="row">Телефон</th><td><a href="tel:0322210140">(032) 221-01-40</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
-      <tr><th scope="row">Мережа</th><td>HUMANA</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/humana/">HUMANA</a> <span class="dim">· 8 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Цикл знижок</th><td>14 дн.</td></tr>
     </tbody>
   </table>
@@ -145,6 +148,28 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Sykhiv district. 2-week inventory cycle. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.</p>
+
+  <h2>Інші магазини мережі HUMANA</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/h3/">HUMANA — Chornovola</a><span class="dim"> — просп. В. Чорновола, 95</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h6/">HUMANA — Doroshenka</a><span class="dim"> — вул. П. Дорошенка, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h1/">HUMANA — Knyahyni Olhy</a><span class="dim"> — вул. Княгині Ольги, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h2/">HUMANA — Lyubinska</a><span class="dim"> — вул. Любинська, 100 (2 поверх)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h8/">HUMANA — Shevchenka</a><span class="dim"> — вул. Тараса Шевченка, 31</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h5/">HUMANA — Shyroka</a><span class="dim"> — вул. Широка, 81а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h7/">HUMANA Vintage</a><span class="dim"> — вул. Валова, 13</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/humana/">Усі 8 магазинів мережі HUMANA →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c28/">Євро Тренд Секонд хенд — Сихівська 18</a><span class="dim"> — 0 м, вулиця Сихівська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c111/">Second hand — Сихівська 13</a><span class="dim"> — 180 м, вул. Сихівська, 13</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c99/">Second hand — Кавалерідзе 6</a><span class="dim"> — 280 м, вул. Івана Кавалерідзе, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — 300 м, вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c15/">Euro marke</a><span class="dim"> — 620 м, пр. Червоної Калини, 66А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c25/">Євро Тренд Секонд хенд — Червоної Калини 59</a><span class="dim"> — 710 м, проспект Червоної Калини, 59</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/h5/index.html
+++ b/store/h5/index.html
@@ -106,6 +106,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -125,7 +128,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Адреса</th><td>вул. Широка, 81а <span class="dim">· Shyroka St, 81a</span></td></tr>
       <tr><th scope="row">Телефон</th><td><a href="tel:0322458780">(032) 245-87-80</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
-      <tr><th scope="row">Мережа</th><td>HUMANA</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/humana/">HUMANA</a> <span class="dim">· 8 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Цикл знижок</th><td>14 дн.</td></tr>
     </tbody>
   </table>
@@ -145,6 +148,28 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">⚠️ Магазин закривається назавжди 23.08.2026. Розпродаж: одяг/взуття/текстиль — 56 грн, дрібнички — 30 грн, ексклюзивні знахідки — знижка -50%. · 2-week inventory cycle. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · ⚠️ Permanently closing 2026-08-23. Clearance sale: clothing/shoes/textiles 56 UAH, small items 30 UAH, exclusive finds -50% off. · Hours can change the day before a new collection; some stores close or open short.</p>
+
+  <h2>Інші магазини мережі HUMANA</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/h3/">HUMANA — Chornovola</a><span class="dim"> — просп. В. Чорновола, 95</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h6/">HUMANA — Doroshenka</a><span class="dim"> — вул. П. Дорошенка, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h1/">HUMANA — Knyahyni Olhy</a><span class="dim"> — вул. Княгині Ольги, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h2/">HUMANA — Lyubinska</a><span class="dim"> — вул. Любинська, 100 (2 поверх)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h8/">HUMANA — Shevchenka</a><span class="dim"> — вул. Тараса Шевченка, 31</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h4/">HUMANA — Sykhivska</a><span class="dim"> — вул. Сиховська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h7/">HUMANA Vintage</a><span class="dim"> — вул. Валова, 13</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/humana/">Усі 8 магазинів мережі HUMANA →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c77/">Світ секонд-хенду — Широка 70б</a><span class="dim"> — 190 м, вул. Широка, 70б</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c64/">Ваш секонд-хенд</a><span class="dim"> — 210 м, вул. Широка</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c63/">Конфі Склад</a><span class="dim"> — 220 м, вул. Широка</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c22/">Євро Тренд Секонд хенд — Широка 31</a><span class="dim"> — 610 м, вулиця Широка, 31</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c115/">Second hand — Широка 29</a><span class="dim"> — 610 м, вул. Широка, 29</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c53/">Світ секонд-хенду — Патона 2</a><span class="dim"> — 2.0 км, вул. Патона, 2</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/h6/index.html
+++ b/store/h6/index.html
@@ -106,6 +106,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -125,7 +128,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Адреса</th><td>вул. П. Дорошенка, 1 <span class="dim">· P. Doroshenka St, 1</span></td></tr>
       <tr><th scope="row">Телефон</th><td><a href="tel:0322611260">(032) 261-12-60</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
-      <tr><th scope="row">Мережа</th><td>HUMANA</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/humana/">HUMANA</a> <span class="dim">· 8 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-17 (за офіційним календарем)</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>35 дн.</td></tr>
     </tbody>
@@ -163,6 +166,28 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">City centre. 5-week cycle. Luxury items in separate section. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.</p>
+
+  <h2>Інші магазини мережі HUMANA</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/h3/">HUMANA — Chornovola</a><span class="dim"> — просп. В. Чорновола, 95</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h1/">HUMANA — Knyahyni Olhy</a><span class="dim"> — вул. Княгині Ольги, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h2/">HUMANA — Lyubinska</a><span class="dim"> — вул. Любинська, 100 (2 поверх)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h8/">HUMANA — Shevchenka</a><span class="dim"> — вул. Тараса Шевченка, 31</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h5/">HUMANA — Shyroka</a><span class="dim"> — вул. Широка, 81а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h4/">HUMANA — Sykhivska</a><span class="dim"> — вул. Сиховська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h7/">HUMANA Vintage</a><span class="dim"> — вул. Валова, 13</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/humana/">Усі 8 магазинів мережі HUMANA →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c8/">Second Hand Bomba</a><span class="dim"> — 40 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c4/">Second Hand - Bomba womens</a><span class="dim"> — 120 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c123/">МЮНХЕН — Вороного 2</a><span class="dim"> — 260 м, вулиця Миколи Вороного, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c5/">Euro second hand</a><span class="dim"> — 350 м, вулиця Юліуша Словацького, 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h7/">HUMANA Vintage</a><span class="dim"> — 400 м, вул. Валова, 13</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c120/">ЕЛІТ</a><span class="dim"> — 450 м, вул. Театральна, 23</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/h7/index.html
+++ b/store/h7/index.html
@@ -106,6 +106,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -125,7 +128,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Адреса</th><td>вул. Валова, 13 <span class="dim">· Valova St, 13</span></td></tr>
       <tr><th scope="row">Телефон</th><td><a href="tel:0322355021">(032) 235-50-21</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
-      <tr><th scope="row">Мережа</th><td>HUMANA</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/humana/">HUMANA</a> <span class="dim">· 8 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-17 (за офіційним календарем)</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>35 дн.</td></tr>
     </tbody>
@@ -163,6 +166,28 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Central Lviv. 5-week cycle. Luxury section separate. Weekly promos. Next restock 17.08.2026 Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.</p>
+
+  <h2>Інші магазини мережі HUMANA</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/h3/">HUMANA — Chornovola</a><span class="dim"> — просп. В. Чорновола, 95</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h6/">HUMANA — Doroshenka</a><span class="dim"> — вул. П. Дорошенка, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h1/">HUMANA — Knyahyni Olhy</a><span class="dim"> — вул. Княгині Ольги, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h2/">HUMANA — Lyubinska</a><span class="dim"> — вул. Любинська, 100 (2 поверх)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h8/">HUMANA — Shevchenka</a><span class="dim"> — вул. Тараса Шевченка, 31</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h5/">HUMANA — Shyroka</a><span class="dim"> — вул. Широка, 81а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h4/">HUMANA — Sykhivska</a><span class="dim"> — вул. Сиховська, 18</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/humana/">Усі 8 магазинів мережі HUMANA →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c20/">Second hand Bomba</a><span class="dim"> — 230 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c2/">Second hand</a><span class="dim"> — 240 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c123/">МЮНХЕН — Вороного 2</a><span class="dim"> — 260 м, вулиця Миколи Вороного, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h6/">HUMANA — Doroshenka</a><span class="dim"> — 400 м, вул. П. Дорошенка, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c8/">Second Hand Bomba</a><span class="dim"> — 420 м</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c4/">Second Hand - Bomba womens</a><span class="dim"> — 480 м</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/h8/index.html
+++ b/store/h8/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Тараса Шевченка, 31 <span class="dim">· Shevchenka St, 31</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
-      <tr><th scope="row">Мережа</th><td>HUMANA</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/humana/">HUMANA</a> <span class="dim">· 8 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Останнє завезення: 2026-08-17 (за офіційним календарем)</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>35 дн.</td></tr>
     </tbody>
@@ -161,6 +164,28 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Нещодавно відкрита точка HUMANA — оновлення товару за тим самим графіком мережі (5-тижневий цикл), що й інші точки. Пін потребує перевірки на місці; години встановлено за стандартним графіком мережі (10:00–20:00 щодня, як у решти 7 точок HUMANA). · Recently opened HUMANA location — restocks on the same brand-wide schedule (5-week cycle) as the other locations. Pin still needs field verification; hours are set to the brand&#39;s standard 10:00–20:00 daily schedule, matching all 7 other HUMANA locations. Напередодні нової колекції години можуть змінюватися — частина магазинів зачинена або працює скорочено. · Hours can change the day before a new collection; some stores close or open short.</p>
+
+  <h2>Інші магазини мережі HUMANA</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/h3/">HUMANA — Chornovola</a><span class="dim"> — просп. В. Чорновола, 95</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h6/">HUMANA — Doroshenka</a><span class="dim"> — вул. П. Дорошенка, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h1/">HUMANA — Knyahyni Olhy</a><span class="dim"> — вул. Княгині Ольги, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h2/">HUMANA — Lyubinska</a><span class="dim"> — вул. Любинська, 100 (2 поверх)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h5/">HUMANA — Shyroka</a><span class="dim"> — вул. Широка, 81а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h4/">HUMANA — Sykhivska</a><span class="dim"> — вул. Сиховська, 18</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h7/">HUMANA Vintage</a><span class="dim"> — вул. Валова, 13</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/humana/">Усі 8 магазинів мережі HUMANA →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c23/">Євро Тренд Секонд хенд — Городоцька 67</a><span class="dim"> — 780 м, вулиця Городоцька, 67</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c67/">Супер-Бомба</a><span class="dim"> — 840 м, вул. Городоцька, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c87/">ЄвроБренд — Городоцька 94</a><span class="dim"> — 870 м, вул. Городоцька, 94</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c61/">Євро секонд хенд</a><span class="dim"> — 890 м, вул. Базарна, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c79/">Супер секонд-хенд</a><span class="dim"> — 890 м, вул. Базарна, 8</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c56/">Luxovski</a><span class="dim"> — 1.0 км, вул. Шпитальна, 11</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/index.html
+++ b/store/index.html
@@ -826,6 +826,7 @@ h1{font-size:26px;line-height:1.25;margin:0 0 6px}
 ul{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
 li{padding:11px 14px;border-bottom:1px solid var(--line);font-size:15px}
 li:last-child{border-bottom:0}
+h2{font-size:17px;margin:26px 0 10px}
 .dim{color:var(--muted);font-size:14px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 0 22px}
 footer{margin-top:30px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
@@ -837,6 +838,20 @@ footer{margin-top:30px;padding-top:16px;border-top:1px solid var(--line);font-si
   <h1>Усі секонд-хенди Львова — список магазинів</h1>
   <p class="sub">131 магазинів на карті Львова — адреси, години, ціни та дні завезення.</p>
   <a class="cta" href="https://www.lvivsecondhand.com/">Відкрити карту</a>
+
+  <h2>Мережі секонд-хендів</h2>
+  <ul>
+      <li><a href="https://www.lvivsecondhand.com/chain/economclass/">EconomClass</a><span class="dim"> — 22 магазини</span></li>
+      <li><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Світ секонд-хенду</a><span class="dim"> — 18 магазинів</span></li>
+      <li><a href="https://www.lvivsecondhand.com/chain/yevro-trend-sekond-khend/">Євро Тренд Секонд хенд</a><span class="dim"> — 10 магазинів</span></li>
+      <li><a href="https://www.lvivsecondhand.com/chain/humana/">HUMANA</a><span class="dim"> — 8 магазинів</span></li>
+      <li><a href="https://www.lvivsecondhand.com/chain/stok-ta-sekond-khend/">Сток та секонд хенд</a><span class="dim"> — 3 магазини</span></li>
+      <li><a href="https://www.lvivsecondhand.com/chain/birka-lux/">Birka! Lux</a><span class="dim"> — 3 магазини</span></li>
+      <li><a href="https://www.lvivsecondhand.com/chain/yevrobrend/">ЄвроБренд</a><span class="dim"> — 2 магазини</span></li>
+      <li><a href="https://www.lvivsecondhand.com/chain/myunkhen/">МЮНХЕН</a><span class="dim"> — 2 магазини</span></li>
+  </ul>
+
+  <h2>Усі магазини</h2>
   <ul>
       <li><a href="https://www.lvivsecondhand.com/store/c62/">Бомба</a><span class="dim"> — вул. Пантелеймона Куліша</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c64/">Ваш секонд-хенд</a><span class="dim"> — вул. Широка</span></li>

--- a/store/s10/index.html
+++ b/store/s10/index.html
@@ -100,6 +100,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -119,7 +122,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Адреса</th><td>вул. Драгана, 4 <span class="dim">· 4 Drahana St</span></td></tr>
       <tr><th scope="row">Телефон</th><td><a href="tel:0971467226">097 146 7226</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Світ секонд-хенду</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Світ секонд-хенду</a> <span class="dim">· 18 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Завезення</th><td>Завезення щотижня: субота</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -140,6 +143,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">⭐ 3.8 (187 reviews). Listed as &quot;Planeta Second Hand&quot; (an English rendering of Світ секонд-хенду) prior to being confirmed as part of the chain.</p>
+
+  <h2>Інші магазини мережі Світ секонд-хенду</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — вул. Горська, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — вул. Любінська, 100</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c68/">Світ секонд-хенду — Наукова 53</a><span class="dim"> — вул. Наукова, 53</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Усі 18 магазинів мережі Світ секонд-хенду →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c113/">Одяг з Європи — Стрийська 45</a><span class="dim"> — 1.0 км, вул. Стрийська, 45</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s9/">Світ секонд-хенду — Горська 5а</a><span class="dim"> — 1.4 км, вул. Горська, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c33/">EconomClass — Horska 5A</a><span class="dim"> — 1.4 км, вул. Горська, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c24/">Євро Тренд Секонд хенд — Горська 2А</a><span class="dim"> — 1.4 км, вулиця Горська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c114/">Second hand — Стрийська 57</a><span class="dim"> — 1.9 км, вул. Стрийська, 57</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c3/">Euro second hand</a><span class="dim"> — 1.9 км, вул. Шота Руставелі, 42</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/s3/index.html
+++ b/store/s3/index.html
@@ -99,6 +99,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -136,6 +139,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Mixed new and used. Men&#39;s, women&#39;s, shoes, accessories. Closed Sundays.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c75/">Світ секонд-хенду — Симона Петлюри 2а</a><span class="dim"> — 660 м, вул. Симона Петлюри, 2а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c110/">Second hand — Симона Петлюри 3</a><span class="dim"> — 710 м, вул. Симона Петлюри, 3</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h2/">HUMANA — Lyubinska</a><span class="dim"> — 940 м, вул. Любинська, 100 (2 поверх)</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — 940 м, вул. Любінська, 100</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c36/">EconomClass — Vyhovskoho 49</a><span class="dim"> — 940 м, вул. Виговського, 49</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c31/">EconomClass — Heroiv UPA 73</a><span class="dim"> — 1.0 км, вул. Героїв УПА, 73</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/s4/index.html
+++ b/store/s4/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -143,6 +146,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Stock and used. Branded items. Updated daily. Frequent sales.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c84/">Світ секонд-хенду — Цехова 1</a><span class="dim"> — 340 м, вул. Цехова, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c62/">Бомба</a><span class="dim"> — 390 м, вул. Пантелеймона Куліша</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c79/">Супер секонд-хенд</a><span class="dim"> — 470 м, вул. Базарна, 8</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c61/">Євро секонд хенд</a><span class="dim"> — 510 м, вул. Базарна, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c56/">Luxovski</a><span class="dim"> — 520 м, вул. Шпитальна, 11</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c116/">Second hand — Шолом-Алейхема 20</a><span class="dim"> — 560 м, вулиця Шолом-Алейхема, 20</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/s6/index.html
+++ b/store/s6/index.html
@@ -105,6 +105,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -123,7 +126,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
     <tbody>
       <tr><th scope="row">Адреса</th><td>вул. Зелена, 69а <span class="dim">· Zelena St, 69a</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Birka! Lux</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/birka-lux/">Birka! Lux</a> <span class="dim">· 3 магазини у Львові</span></td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
   </table>
@@ -143,6 +146,23 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Stock and used. Popular for children&#39;s clothing, shoes and toys. Confirmed as a 3-location chain (Зелена 69а, Котика 2, Шпитальна 7) via a list.in.ua directory listing with published hours.</p>
+
+  <h2>Інші магазини мережі Birka! Lux</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c59/">Birka! Lux — Котика 2</a><span class="dim"> — вул. Богдана Котика, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c125/">Birka! Lux — Шпитальна 7</a><span class="dim"> — вул. Шпитальна, 7</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/birka-lux/">Усі 3 магазини мережі Birka! Lux →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c66/">Секонд-хенд Супер Бомба</a><span class="dim"> — 740 м, вул. Шота Руставелі, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c3/">Euro second hand</a><span class="dim"> — 840 м, вул. Шота Руставелі, 42</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c2/">Second hand</a><span class="dim"> — 1.1 км</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c19/">Second Hand super</a><span class="dim"> — 1.1 км</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c20/">Second hand Bomba</a><span class="dim"> — 1.1 км</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/h7/">HUMANA Vintage</a><span class="dim"> — 1.3 км, вул. Валова, 13</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/s7/index.html
+++ b/store/s7/index.html
@@ -99,6 +99,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -136,6 +139,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">Wholesale + retail. Direct from UK, Germany, Poland, Netherlands warehouses. A Lviv business directory (dlab.com.ua) lists a &quot;Брендовий сток з Європи&quot; (ua-opt.com) at this exact address, phone +38 (067) 197-68-27 — description matches closely enough that it&#39;s plausibly this same business under its formal registered name, but not confirmed.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c35/">EconomClass — Lychakivska 201</a><span class="dim"> — 700 м, вул. Личаківська, 201</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c59/">Birka! Lux — Котика 2</a><span class="dim"> — 800 м, вул. Богдана Котика, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c19/">Second Hand super</a><span class="dim"> — 1.4 км</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c74/">Світ секонд-хенду — Пасічна 51</a><span class="dim"> — 1.6 км, вул. Пасічна, 51</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c108/">Second hand — Пасічна 53</a><span class="dim"> — 1.7 км, вул. Пасічна, 53</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c104/">Second hand — Медової Печери 1</a><span class="dim"> — 1.8 км, вул. Медової Печери, 1</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/s8/index.html
+++ b/store/s8/index.html
@@ -99,6 +99,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -136,6 +139,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">European brands. Furs, leather, bags, jewellery. Accepts items by appointment Mon/Wed/Fri.</p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/h1/">HUMANA — Knyahyni Olhy</a><span class="dim"> — 600 м, вул. Княгині Ольги, 5а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c95/">Second hand — Володимира Великого 59А</a><span class="dim"> — 900 м, вул. Володимира Великого, 59А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c94/">Second hand — Володимира Великого 51</a><span class="dim"> — 930 м, вул. Володимира Великого, 51</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c93/">Second hand — Володимира Великого 26А</a><span class="dim"> — 1.0 км, вул. Володимира Великого, 26A</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c29/">Євро Тренд Секонд хенд — Володимира Великого 59Б</a><span class="dim"> — 1.0 км, вулиця Володимира Великого, 59б</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — 1.1 км, вул. Володимира Великого, 34</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у

--- a/store/s9/index.html
+++ b/store/s9/index.html
@@ -106,6 +106,9 @@ h2{font-size:17px;margin:26px 0 10px}
 .cta{display:inline-block;background:var(--green);color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600;margin:0 8px 10px 0}
 .cta.alt{background:transparent;color:var(--green);border:1px solid var(--green)}
 .note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--green);border-radius:10px;padding:12px 14px;color:var(--muted);font-size:14px}
+ul.links{list-style:none;padding:0;margin:0;background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+ul.links li{padding:10px 14px;border-bottom:1px solid var(--line);font-size:15px}
+ul.links li:last-child{border-bottom:0}
 footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 </style>
 </head>
@@ -125,7 +128,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <tr><th scope="row">Адреса</th><td>вул. Горська, 5а <span class="dim">· 5a Horska St</span></td></tr>
       <tr><th scope="row">Телефон</th><td><a href="tel:0969461702">096 946 1702</a></td></tr>
       <tr><th scope="row">Тип цін</th><td>На вагу (ціна за кілограм)</td></tr>
-      <tr><th scope="row">Мережа</th><td>Світ секонд-хенду</td></tr>
+      <tr><th scope="row">Мережа</th><td><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Світ секонд-хенду</a> <span class="dim">· 18 магазинів у Львові</span></td></tr>
       <tr><th scope="row">Цикл знижок</th><td>14 дн.</td></tr>
     </tbody>
   </table>
@@ -145,6 +148,29 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Примітки</h2>
   <p class="note">⭐ 4.1 (179 reviews). Open 7 days. Listed as &quot;Planet of Second-Hand&quot; (an English rendering of Світ секонд-хенду) prior to being confirmed as part of the chain.</p>
+
+  <h2>Інші магазини мережі Світ секонд-хенду</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c73/">Світ секонд-хенду — Антоненка-Давидовича 10</a><span class="dim"> — вул. Бориса Антоненка-Давидовича, 10</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c69/">Світ секонд-хенду — Володимира Великого 34</a><span class="dim"> — вул. Володимира Великого, 34</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c71/">Світ секонд-хенду — Гетьмана Мазепи 24</a><span class="dim"> — вул. Гетьмана Мазепи, 24</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c72/">Світ секонд-хенду — Грінченка 6а</a><span class="dim"> — вул. Грінченка, 6а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c70/">Світ секонд-хенду — Любінська 100</a><span class="dim"> — вул. Любінська, 100</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c68/">Світ секонд-хенду — Наукова 53</a><span class="dim"> — вул. Наукова, 53</span></li>
+  </ul>
+  <p class="dim" style="font-size:14px;margin:8px 0 0;"><a href="https://www.lvivsecondhand.com/chain/svit-sekond-khendu/">Усі 18 магазинів мережі Світ секонд-хенду →</a></p>
+
+  <h2>Секонд-хенди поруч</h2>
+  <ul class="links">
+      <li><a href="https://www.lvivsecondhand.com/store/c33/">EconomClass — Horska 5A</a><span class="dim"> — 0 м, вул. Горська, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c24/">Євро Тренд Секонд хенд — Горська 2А</a><span class="dim"> — 20 м, вулиця Горська, 2</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s10/">Світ секонд-хенду — Драгана 4</a><span class="dim"> — 1.4 км, вул. Драгана, 4</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c85/">Світ секонд-хенду — Джорджа Вашингтона 5А</a><span class="dim"> — 1.4 км, вул. Джорджа Вашингтона, 5А</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/s6/">Birka! Lux — Зелена 69а</a><span class="dim"> — 1.7 км, вул. Зелена, 69а</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c89/">Сток та секонд хенд — Пасічна 96А</a><span class="dim"> — 2.0 км, вул. Пасічна, 96А</span></li>
+  </ul>
 
   <footer>
     Дані оновлюються спільнотою. Помітили помилку — виправте у


### PR DESCRIPTION
Implements the top two items from the SEO review. The technical baseline (canonicals, `Store` schema, sitemap, OG) was already fine, so both of these are **structural** — the shape of the site, not its tags.

## 1. Chain landing pages — `/chain/<slug>/`

A chain existed here only as N unconnected store pages, so the highest-intent query this dataset can serve — brand plus city, **"HUMANA Львів"** — matched nothing.

8 chains, covering **68 of 131 stores**:

| Chain | Branches | | Chain | Branches |
|---|---|---|---|---|
| EconomClass | 22 | | Birka! Lux | 3 |
| Світ секонд-хенду | 18 | | Сток та секонд хенд | 3 |
| Євро Тренд | 10 | | ЄвроБренд | 2 |
| HUMANA | 8 | | МЮНХЕН | 2 |

Each page: branch table (address, pricing, restock), a factual summary, and an `Organization` + `location` JSON-LD graph whose entries `@id`-link to each branch's own `#store` entity — so the chain and its shops resolve as one connected graph instead of N unrelated Stores sharing a name.

Single-location brands are **deliberately excluded** — a second URL for one shop would just compete with its own store page.

## 2. Cross-linked store pages

Store pages were a flat set of leaves linking only up to `/` and `/store/`. Each now carries its **chain siblings** and a **"Секонд-хенди поруч"** block of the nearest shops within 2.5km.

The radius cap matters: for an isolated store the 6th-nearest shop is 4km away, so the block shrinks or disappears rather than padding the page with links that help neither a reader nor a crawler.

### Measured effect

| | Before | After |
|---|---|---|
| Inbound links per store page (from other store pages) | ~0 | **median 7** |
| Median store page length | 122 words | **224 words** |
| Pages reachable from a hub | — | **131 / 131** |

Thin content was the *other* half of why these pages don't rank, so the word-count change matters as much as the linking. The 7 EconomClass branches in other towns (Sambir, Stryi, Sokal…) have no neighbour within 2.5km and would still be orphans — the chain page is what now reaches them.

## Notes on the implementation

- **Slugs** are a fixed KMU-2010 transliteration table, not anything runtime- or locale-dependent, because they're URLs that must stay stable. `main` asserts they can't collide — two brands sharing a slug would otherwise silently overwrite each other's page.
- **Ukrainian numerals take three forms**, so counts go through `plural()`; a naive `n === 1` check renders "22 магазинів" and gets the 11–14 teens wrong.
- **All three workflows** that regenerate these files now stage `chain/` (`ci.yml`'s drift guard, `refresh-pages.yml`, `update-map.yml`). Chain pages carry date-derived restock lines exactly as store pages do, so omitting them would have reintroduced the stale-output bug `refresh-pages.yml` was written to prevent — *and* hidden it from the CI guard meant to catch it.

## Test plan
- [x] `validate-stores` / `check-inline-js` / `check-wiring` / `node --check` both Workers — all pass
- [x] **JSON-LD parsed on every generated page** (139 pages) — zero failures
- [x] **Determinism**: re-running the generator produces byte-identical output, so the CI drift guard is stable
- [x] Link graph audited programmatically — 131/131 reachable, no orphans, 68 chain-linked pages as expected
- [x] `robots.txt` confirmed not blocking `/chain/`
- [x] Rendered `/chain/humana/` and `/store/h1/` in a browser — screenshots reviewed, design matches existing pages

> Caught during this work: the container restart had left a **stale clone** (missing the Birka! Lux merge and 4 others), which produced a first build with 130 stores / 7 chains. Reset to true `main` and regenerated — the committed output is from 132-entry `stores.json`.

Not included (offered separately): `BreadcrumbList` schema, category pages (by-KG / daily-drop), and `hreflang` — the last needs per-language URLs first, since the toggle is currently client-side only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_