### PR TITLE
Instagram: switch to the Instagram Login API path

### DIFF
--- a/.github/workflows/instagram-post.yml
+++ b/.github/workflows/instagram-post.yml
@@ -69,7 +69,7 @@ permissions:
 
 env:
   SITE: https://www.lvivsecondhand.com
-  GRAPH: https://graph.instagram.com/v25.0
+  GRAPH: https://graph.instagram.com/v26.0
 
 jobs:
   post:

--- a/.github/workflows/instagram-post.yml
+++ b/.github/workflows/instagram-post.yml
@@ -16,10 +16,19 @@ name: Post to Instagram
 # unconfigured repo does not accumulate failed runs. Add a schedule below only
 # once you have posted successfully by hand a few times.
 #
+# WHICH API PATH THIS TARGETS
+# Meta ships two incompatible Instagram APIs. This targets **Instagram API with
+# Instagram Login** — host graph.instagram.com, permissions instagram_business_*,
+# no Facebook Page involved in the calls. The other path (Facebook Login, host
+# graph.facebook.com, permissions instagram_basic/instagram_content_publish)
+# needs different endpoints and will not work with these secrets. Your app
+# dashboard names which one you set up.
+#
 # SETUP: see docs/INSTAGRAM.md. In short you need an Instagram Business or
-# Creator account linked to a Facebook Page, a Meta app, and two repo secrets:
-#   IG_USER_ID       — the Instagram *Business* account id (not the handle)
-#   IG_ACCESS_TOKEN  — a long-lived token with content-publishing permission
+# Creator account, a Meta app set up for Instagram login, and two repo secrets:
+#   IG_USER_ID       — the Instagram user id from `me?fields=user_id`
+#   IG_ACCESS_TOKEN  — a long-lived Instagram User token with
+#                      instagram_business_content_publish
 #
 # NO APP REVIEW NEEDED. Meta's docs push you toward App Review with a screencast
 # submission, but that gate only applies to publishing on behalf of accounts you
@@ -28,9 +37,10 @@ name: Post to Instagram
 # the case here.
 #
 # TOKEN EXPIRY IS THE THING THAT BITES
-# Long-lived tokens last ~60 days. The pre-flight step below reports days
-# remaining on every run so it fails loudly and early rather than silently
-# going quiet two months from now.
+# Long-lived tokens last 60 days. Unlike the Facebook Login path there is no
+# debug_token endpoint here, so days-remaining cannot be reported — the
+# pre-flight verifies the token still works and prints a standing reminder
+# instead. Refresh roughly every 50 days; see docs/INSTAGRAM.md.
 
 on:
   workflow_dispatch:
@@ -59,7 +69,7 @@ permissions:
 
 env:
   SITE: https://www.lvivsecondhand.com
-  GRAPH: https://graph.facebook.com/v25.0
+  GRAPH: https://graph.instagram.com/v25.0
 
 jobs:
   post:
@@ -109,33 +119,36 @@ jobs:
           echo "IMAGE_URL=$URL" >> "$GITHUB_ENV"
           echo "Image OK: $URL"
 
-      # Surfaces days-remaining so the ~60-day expiry is visible on every run
-      # instead of discovered when a post silently stops going out.
+      # /debug_token lives on graph.facebook.com and has no equivalent here, so
+      # this path cannot report days-remaining. `me` is the substitute: it fails
+      # on an expired or wrong-scoped token, and the user_id it returns is
+      # checked against IG_USER_ID — catching the case where the two secrets
+      # come from different accounts, which otherwise fails much later with a
+      # permissions error that points at the wrong thing.
       - name: Pre-flight — token validity
         if: steps.guard.outputs.ready == 'true'
         env:
+          IG_USER_ID: ${{ secrets.IG_USER_ID }}
           IG_ACCESS_TOKEN: ${{ secrets.IG_ACCESS_TOKEN }}
         run: |
-          RESP=$(curl -sG "$GRAPH/debug_token" \
-            --data-urlencode "input_token=$IG_ACCESS_TOKEN" \
+          RESP=$(curl -sG "$GRAPH/me" \
+            --data-urlencode "fields=user_id,username" \
             --data-urlencode "access_token=$IG_ACCESS_TOKEN")
-          EXP=$(echo "$RESP" | jq -r '.data.expires_at // empty')
-          VALID=$(echo "$RESP" | jq -r '.data.is_valid // empty')
-          if [ "$VALID" != "true" ]; then
-            echo "::error::Token rejected by Meta: $(echo "$RESP" | jq -c '.data.error // .error // .')"
+          # Not UID: that name is readonly in bash and the assignment fails.
+          TOKEN_UID=$(echo "$RESP" | jq -r '.user_id // empty')
+          NAME=$(echo "$RESP" | jq -r '.username // empty')
+          if [ -z "$TOKEN_UID" ]; then
+            echo "::error::Token rejected by Instagram: $(echo "$RESP" | jq -c '.error // .')"
             exit 1
           fi
-          if [ -n "$EXP" ] && [ "$EXP" != "0" ]; then
-            DAYS=$(( (EXP - $(date +%s)) / 86400 ))
-            echo "Token valid — about $DAYS day(s) left."
-            # A real if, not `[ ... ] && echo`: under `set -e` a false trailing
-            # test returns 1 and fails the step on every *healthy* run.
-            if [ "$DAYS" -lt 10 ]; then
-              echo "::warning::Token expires in $DAYS day(s). Refresh it (docs/INSTAGRAM.md) or posting will start failing."
-            fi
-          else
-            echo "Token valid — no expiry reported (long-lived / never-expiring)."
+          if [ "$TOKEN_UID" != "$IG_USER_ID" ]; then
+            echo "::error::Token belongs to Instagram user $TOKEN_UID but IG_USER_ID is set to $IG_USER_ID. The two secrets are from different accounts."
+            exit 1
           fi
+          echo "Token valid — authenticated as @$NAME ($TOKEN_UID)."
+          # Instagram Login tokens last 60 days and this path exposes no expiry
+          # to check, so the reminder is unconditional rather than a threshold.
+          echo "::notice::Instagram Login tokens expire 60 days after issue and cannot be inspected here. Refresh via the refresh_access_token endpoint (docs/INSTAGRAM.md) roughly every 50 days."
 
       # Step 1 of 2: create the media container. Meta downloads the image here.
       - name: Create media container

--- a/docs/INSTAGRAM.md
+++ b/docs/INSTAGRAM.md
@@ -98,7 +98,7 @@ path it does *not* come from a Facebook Page lookup. In the
 app and an **Instagram** token, then:
 
 ```
-GET https://graph.instagram.com/v25.0/me?fields=user_id,username
+GET https://graph.instagram.com/v26.0/me?fields=user_id,username
 ```
 
 **`IG_ACCESS_TOKEN`** — an Instagram User access token. The Explorer issues a

--- a/docs/INSTAGRAM.md
+++ b/docs/INSTAGRAM.md
@@ -17,9 +17,12 @@ absent, so an unconfigured repo produces no failed runs.
 Instagram has no simple "post this file" API. Publishing requires:
 
 1. the account to be **Business or Creator**, not personal;
-2. it to be **linked to a Facebook Page**;
-3. a **Meta app** with content-publishing permission;
+2. a **Meta app** set up for Instagram login, with content-publishing permission;
+3. your Instagram account added to it as an **Instagram Tester**;
 4. a **long-lived access token**.
+
+(A linked Facebook Page is *not* required on this path — that's the other one.
+Having a Page does no harm if you already made one, it just isn't used.)
 
 > **You do not need App Review.** Meta's docs lead with a review process that
 > wants a screencast submission, which makes this look like a two-week project.
@@ -31,7 +34,7 @@ Instagram has no simple "post this file" API. Publishing requires:
 There are two paths, and mixing them up is the most common way to get stuck,
 because the permission names differ:
 
-| | **Facebook Login** (what this repo uses) | Instagram Login |
+| | Facebook Login | **Instagram Login** (what this repo uses) |
 | --- | --- | --- |
 | Host | `graph.facebook.com` | `graph.instagram.com` |
 | Facebook Page | **required** | not needed |
@@ -54,10 +57,9 @@ so anything committed under `marketing/` is immediately live at
 Instagram app → **Settings → Account type and tools → Switch to professional
 account** → Business or Creator.
 
-### 2. Link it to a Facebook Page
-Create a Page if there isn't one (it can be minimal — it exists to satisfy the
-API). Link it from the Instagram professional dashboard, or from the Page's
-**Linked accounts** settings.
+### 2. Link it to a Facebook Page — *optional on this path*
+Only the Facebook Login path needs this. Skip it unless you're switching paths.
+If you already linked a Page, leave it; it's unused, not harmful.
 
 ### 3. Create a Meta app
 
@@ -78,45 +80,39 @@ you want the first two, **not** Basic Display, which cannot publish.
 dashboard. Do not switch to Live and do not submit for App Review: review only
 governs publishing to accounts you don't own.
 
-**3d — check your Page role. There is no Instagram Tester step.**
+**3d — add yourself as an Instagram Tester and accept the invite.**
 
-On the Facebook Login path the grant is *Page-based*, not Instagram-based. Meta's
-requirement is that the Instagram professional account is connected to a Facebook
-Page, and that you "be able to perform admin-equivalent tasks on the linked
-Facebook Page" — specifically the `PROFILE_PLUS_CREATE_CONTENT` task, which is
-what backs the `instagram_content_publish` permission.
+Under **App roles → Roles → Instagram Testers**, add your Instagram handle. Then
+open Instagram, log in, and accept it: **Settings → Apps and websites → Tester
+invites → Accept**.
 
-So all you need is: a role on the app (3c) **and** admin on the Page. If you
-created the Page, you already have both, and step 3 is done.
-
-> **The `Instagram Tester` role is not part of this path.** It belongs to
-> Instagram Login / Basic Display, where the app authenticates *as* the Instagram
-> user rather than through the Page. If you go looking for
-> *Instagram → Settings → Apps and websites → Tester invites*, you will not find a
-> pending invite, because none was ever sent — and there is nothing wrong with
-> your setup. This doc previously said to accept one; that was wrong, and it is
-> an easy mistake to make because most tutorials online cover the other path.
+The invite sits pending by default and nothing in the Meta dashboard says so, so
+skipping it surfaces two steps later as a token that looks correctly scoped but
+won't publish.
 
 ### 4. Get the two values
 
-**`IG_USER_ID`** — the Instagram *Business account* id, a number. Not the
-handle. The Graph API Explorer returns it from:
+**`IG_USER_ID`** — your Instagram user id, a number, not the handle. On this
+path it does *not* come from a Facebook Page lookup. In the
+[Graph API Explorer](https://developers.facebook.com/tools/explorer/), pick your
+app and an **Instagram** token, then:
 
 ```
-GET /me/accounts                       → find the Page, note its id
-GET /{page-id}?fields=instagram_business_account
+GET https://graph.instagram.com/v25.0/me?fields=user_id,username
 ```
 
-**`IG_ACCESS_TOKEN`** — start from a User token in the Graph API Explorer, then
-exchange it for a long-lived one:
+**`IG_ACCESS_TOKEN`** — an Instagram User access token. The Explorer issues a
+short-lived one (1 hour); exchange it for a 60-day token server-side:
 
 ```
-GET /oauth/access_token
-  ?grant_type=fb_exchange_token
-  &client_id={app-id}
+GET https://graph.instagram.com/access_token
+  ?grant_type=ig_exchange_token
   &client_secret={app-secret}
-  &fb_exchange_token={short-lived-token}
+  &access_token={short-lived-token}
 ```
+
+The exchange includes your app secret, so run it from a terminal — never from a
+browser page you've shared or a client-side script.
 
 ### 5. Add them as repo secrets
 **Settings → Secrets and variables → Actions → New repository secret.**
@@ -147,17 +143,32 @@ only after a few successful manual runs.
 
 ## The failure mode to plan for
 
-**Long-lived tokens expire in about 60 days.** An automated poster that is
-working fine today will simply stop, quietly, roughly two months later.
+**Long-lived tokens expire 60 days after issue.** An automated poster working
+fine today will simply stop, quietly, two months later.
 
-The workflow guards against the silent version of that: every run prints the
-days remaining, and warns loudly under 10 days. When it warns, repeat step 4's
-exchange and update the `IG_ACCESS_TOKEN` secret.
+This path gives no way to check how long is left — `debug_token` is a
+`graph.facebook.com` endpoint with no equivalent on `graph.instagram.com`. So
+the workflow verifies the token still *works* and prints a standing reminder,
+rather than reporting days-remaining the way the other path can.
 
-Fully unattended posting would need the token refreshed and written back
-automatically, which means a PAT with secrets-write permission — more moving
-parts, and worth adding only if manual refresh every couple of months proves
-annoying.
+Refresh it roughly every 50 days — the token must be at least 24 hours old, and
+refreshing resets the clock to 60 days from the refresh date:
+
+```
+GET https://graph.instagram.com/refresh_access_token
+  ?grant_type=ig_refresh_token
+  &access_token={current-long-lived-token}
+```
+
+Then update the `IG_ACCESS_TOKEN` secret with what it returns. Note this one
+needs no app secret, so it's a much lighter operation than the initial exchange.
+
+Miss the 60-day window entirely and there's no refresh path — you start again
+from step 4.
+
+Fully unattended posting would need the refresh automated and written back to
+the secret, which means a PAT with secrets-write permission — more moving parts,
+worth adding only if the manual refresh proves annoying.
 
 ## Other limits worth knowing
 

--- a/docs/INSTAGRAM.md
+++ b/docs/INSTAGRAM.md
@@ -78,31 +78,24 @@ you want the first two, **not** Basic Display, which cannot publish.
 dashboard. Do not switch to Live and do not submit for App Review: review only
 governs publishing to accounts you don't own.
 
-**3d — add the Instagram Tester, then accept the invite.** This is two separate
-roles and conflating them is the usual reason a correct-looking setup fails at
-the token step:
+**3d — check your Page role. There is no Instagram Tester step.**
 
-| Role | Where | What it does |
-| --- | --- | --- |
-| App admin/developer | **App roles → Roles** | Lets *you* administer the app |
-| **Instagram Tester** | **App roles → Roles → Instagram Testers** | Lets the app *act on your Instagram account* |
+On the Facebook Login path the grant is *Page-based*, not Instagram-based. Meta's
+requirement is that the Instagram professional account is connected to a Facebook
+Page, and that you "be able to perform admin-equivalent tasks on the linked
+Facebook Page" — specifically the `PROFILE_PLUS_CREATE_CONTENT` task, which is
+what backs the `instagram_content_publish` permission.
 
-Add your Instagram handle as an **Instagram Tester** — then open Instagram
-itself and accept it: **Settings → Apps and websites → Tester invites →
-Accept**. The invite is pending by default and nothing in the Meta dashboard
-warns you it is unaccepted, so this failure surfaces much later as a token that
-inexplicably won't publish.
+So all you need is: a role on the app (3c) **and** admin on the Page. If you
+created the Page, you already have both, and step 3 is done.
 
-The permissions to grant on the token are `instagram_basic`,
-`instagram_content_publish`, `pages_show_list`, and `pages_read_engagement`.
-`pages_show_list` is the one people miss — without it `/me/accounts` comes back
-empty and step 4 looks broken when the token is the actual problem.
-
-> Meta renames these product flows fairly often. Follow their current
-> [Content Publishing guide](https://developers.facebook.com/docs/instagram-platform/content-publishing)
-> rather than any fixed click-path written here — the four things you need
-> (professional account, linked Page, app, long-lived token) are stable even
-> when the UI moves.
+> **The `Instagram Tester` role is not part of this path.** It belongs to
+> Instagram Login / Basic Display, where the app authenticates *as* the Instagram
+> user rather than through the Page. If you go looking for
+> *Instagram → Settings → Apps and websites → Tester invites*, you will not find a
+> pending invite, because none was ever sent — and there is nothing wrong with
+> your setup. This doc previously said to accept one; that was wrong, and it is
+> an easy mistake to make because most tutorials online cover the other path.
 
 ### 4. Get the two values
 

--- a/docs/INSTAGRAM.md
+++ b/docs/INSTAGRAM.md
@@ -92,27 +92,41 @@ won't publish.
 
 ### 4. Get the two values
 
-**`IG_USER_ID`** — your Instagram user id, a number, not the handle. On this
-path it does *not* come from a Facebook Page lookup. In the
-[Graph API Explorer](https://developers.facebook.com/tools/explorer/), pick your
-app and an **Instagram** token, then:
+**Do not use the Graph API Explorer.** It is a Facebook tool and mints Facebook
+tokens; on this path it returns
+
+```
+"An active access token must be used to query information about the current
+ user." (code 2500)
+```
+
+which reads like a missing token but actually means *this token has no Instagram
+user context*. Both values come from the app dashboard instead.
+
+**App Dashboard → Instagram → API setup with Instagram login → 1. Generate
+access tokens.**
+
+- **Add an Instagram account** and log in with the Instagram Business/Creator
+  account, if it isn't listed already.
+- **`IG_USER_ID`** is shown next to the connected account.
+- Click **Generate token** for **`IG_ACCESS_TOKEN`**.
+
+**Copy the token immediately.** The dashboard will not show it again — generating
+a replacement is easy, but there is no "view existing token".
+
+This token is already long-lived (60 days), so no exchange step is needed — the
+`ig_exchange_token` call belongs to the OAuth flow, not to this one. If the token
+stops working after about an hour, it was short-lived and you're on the OAuth
+route instead; exchange it as described under token expiry below.
+
+To confirm before saving it anywhere:
 
 ```
 GET https://graph.instagram.com/v26.0/me?fields=user_id,username
+  &access_token={the-token}
 ```
 
-**`IG_ACCESS_TOKEN`** — an Instagram User access token. The Explorer issues a
-short-lived one (1 hour); exchange it for a 60-day token server-side:
-
-```
-GET https://graph.instagram.com/access_token
-  ?grant_type=ig_exchange_token
-  &client_secret={app-secret}
-  &access_token={short-lived-token}
-```
-
-The exchange includes your app secret, so run it from a terminal — never from a
-browser page you've shared or a client-side script.
+`username` should be your handle, and `user_id` should equal `IG_USER_ID`.
 
 ### 5. Add them as repo secrets
 **Settings → Secrets and variables → Actions → New repository secret.**

--- a/docs/INSTAGRAM.md
+++ b/docs/INSTAGRAM.md
@@ -60,12 +60,38 @@ API). Link it from the Instagram professional dashboard, or from the Page's
 **Linked accounts** settings.
 
 ### 3. Create a Meta app
-[developers.facebook.com](https://developers.facebook.com/) → **My Apps →
-Create App** → type **Business**. Add the **Instagram** product.
 
-**Leave it in Development mode** (the toggle at the top of the dashboard). Then
-add yourself under **App roles → Roles** as an admin or tester, and accept the
-invite. That's what makes publishing work without App Review.
+**3a — create it.** [developers.facebook.com](https://developers.facebook.com/)
+→ **My Apps → Create app**.
+
+Meta replaced app *types* with *use cases*, so you will likely be asked "What do
+you want your app to do?" rather than shown a type list. None of the use cases
+describe content publishing — pick **Other → Next**, and the old type list
+appears on the following screen. Choose **Business** there.
+
+**3b — add the Instagram product.** On the app dashboard, find **Instagram** in
+the product list and click **Set up**. Depending on the entry point this is
+labelled *Instagram*, *Instagram Graph API*, or *Instagram Basic Display* —
+you want the first two, **not** Basic Display, which cannot publish.
+
+**3c — leave it in Development mode.** The toggle sits at the top of the app
+dashboard. Do not switch to Live and do not submit for App Review: review only
+governs publishing to accounts you don't own.
+
+**3d — add the Instagram Tester, then accept the invite.** This is two separate
+roles and conflating them is the usual reason a correct-looking setup fails at
+the token step:
+
+| Role | Where | What it does |
+| --- | --- | --- |
+| App admin/developer | **App roles → Roles** | Lets *you* administer the app |
+| **Instagram Tester** | **App roles → Roles → Instagram Testers** | Lets the app *act on your Instagram account* |
+
+Add your Instagram handle as an **Instagram Tester** — then open Instagram
+itself and accept it: **Settings → Apps and websites → Tester invites →
+Accept**. The invite is pending by default and nothing in the Meta dashboard
+warns you it is unaccepted, so this failure surfaces much later as a token that
+inexplicably won't publish.
 
 The permissions to grant on the token are `instagram_basic`,
 `instagram_content_publish`, `pages_show_list`, and `pages_read_engagement`.


### PR DESCRIPTION
Your app is set up as **"API setup with Instagram login"**, and that turned out to matter a lot: Meta ships two incompatible Instagram APIs, and the workflow targeted the wrong one end to end — right shape, wrong host, wrong id source, wrong token type.

## The switch

| | Was (Facebook Login) | Now (Instagram Login) |
|---|---|---|
| Host | `graph.facebook.com` | `graph.instagram.com` |
| `IG_USER_ID` from | `/{page-id}?fields=instagram_business_account` | `me?fields=user_id` |
| Facebook Page | required | not involved at all |
| Permissions | `instagram_basic`, `instagram_content_publish` | `instagram_business_basic`, `instagram_business_content_publish` |

The two-step container→publish flow is identical, so most of the workflow didn't move.

## Token pre-flight had to be rebuilt

`debug_token` is a `graph.facebook.com` endpoint with **no equivalent** on `graph.instagram.com`, so this path simply cannot report days-remaining. Replaced with a `me` call, which:

- fails on an expired or wrong-scoped token, and
- checks the returned `user_id` against `IG_USER_ID` — catching the case where the two secrets come from **different accounts**, which otherwise fails much later with a permissions error pointing at the wrong thing.

Since the threshold warning is gone, the docs now cover `refresh_access_token` properly: 60 days, token must be >24h old, no app secret needed, and missing the window means starting over from step 4.

## This reverses my earlier 3d correction, deliberately

The previous commit removed the Instagram Tester step as belonging to "the other path." That was correct for Facebook Login and wrong here — the tester invite is exactly how *this* path grants access, which is why there was one to accept. Restored, and the docs now lead with which path is in use so the two instruction sets stop getting mistaken for each other.

## Bug caught before it shipped

The token's user id was initially named `UID`. That name is **readonly in bash**, so the assignment fails the step outright. Confirmed by reproduction (`bash: UID: readonly variable`) and renamed to `TOKEN_UID`.

## Verification

- YAML parses; trigger still `workflow_dispatch`-only; 7 steps
- No `graph.facebook.com` call sites remain — the four textual matches are deliberate contrast in comments and the path-comparison table
- Still exits 0 when the secrets are absent

Untested against the live API — that needs the secrets, and the first real run is the test. The three pre-flight steps are designed so a misconfiguration costs a failed run rather than a bad post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN