### PR TITLE
Instagram: resolve publish target from the token, add dry_run

### DIFF
--- a/.github/workflows/instagram-post.yml
+++ b/.github/workflows/instagram-post.yml
@@ -121,10 +121,14 @@ jobs:
 
       # /debug_token lives on graph.facebook.com and has no equivalent here, so
       # this path cannot report days-remaining. `me` is the substitute: it fails
-      # on an expired or wrong-scoped token, and the user_id it returns is
-      # checked against IG_USER_ID — catching the case where the two secrets
-      # come from different accounts, which otherwise fails much later with a
-      # permissions error that points at the wrong thing.
+      # on an expired or wrong-scoped token.
+      #
+      # It also resolves WHICH account to post to. The token already determines
+      # that — it can only publish to its own account — so the id from `me` is
+      # authoritative and IG_USER_ID is a cross-check, not the source of truth.
+      # An earlier version errored on a mismatch and blocked a perfectly good
+      # token; the dashboard shows an Instagram *app* id next to the account id,
+      # and copying the wrong one should not be fatal.
       - name: Pre-flight — token validity
         if: steps.guard.outputs.ready == 'true'
         env:
@@ -132,20 +136,27 @@ jobs:
           IG_ACCESS_TOKEN: ${{ secrets.IG_ACCESS_TOKEN }}
         run: |
           RESP=$(curl -sG "$GRAPH/me" \
-            --data-urlencode "fields=user_id,username" \
+            --data-urlencode "fields=id,user_id,username" \
             --data-urlencode "access_token=$IG_ACCESS_TOKEN")
           # Not UID: that name is readonly in bash and the assignment fails.
-          TOKEN_UID=$(echo "$RESP" | jq -r '.user_id // empty')
+          ME_ID=$(echo "$RESP" | jq -r '.id // empty')
+          ME_USER_ID=$(echo "$RESP" | jq -r '.user_id // empty')
           NAME=$(echo "$RESP" | jq -r '.username // empty')
-          if [ -z "$TOKEN_UID" ]; then
+          if [ -z "$ME_ID" ] && [ -z "$ME_USER_ID" ]; then
             echo "::error::Token rejected by Instagram: $(echo "$RESP" | jq -c '.error // .')"
             exit 1
           fi
-          if [ "$TOKEN_UID" != "$IG_USER_ID" ]; then
-            echo "::error::Token belongs to Instagram user $TOKEN_UID but IG_USER_ID is set to $IG_USER_ID. The two secrets are from different accounts."
-            exit 1
+          # This path exposes both an app-scoped id and the professional-account
+          # id, and which one the publish endpoints want has moved between API
+          # versions. Prefer user_id, fall back to id.
+          PUBLISH_ID="${ME_USER_ID:-$ME_ID}"
+          echo "Token valid — authenticated as @$NAME."
+          if [ "$IG_USER_ID" = "$ME_USER_ID" ] || [ "$IG_USER_ID" = "$ME_ID" ]; then
+            echo "IG_USER_ID matches the token's account."
+          else
+            echo "::warning::IG_USER_ID (${#IG_USER_ID} chars) matches neither id on this token (user_id ${#ME_USER_ID} chars, id ${#ME_ID} chars). Posting to the token's own account. Most likely the Instagram *app* id was copied from the dashboard instead of the account id — harmless, but worth correcting in the secret."
           fi
-          echo "Token valid — authenticated as @$NAME ($TOKEN_UID)."
+          echo "PUBLISH_ID=$PUBLISH_ID" >> "$GITHUB_ENV"
           # Instagram Login tokens last 60 days and this path exposes no expiry
           # to check, so the reminder is unconditional rather than a threshold.
           echo "::notice::Instagram Login tokens expire 60 days after issue and cannot be inspected here. Refresh via the refresh_access_token endpoint (docs/INSTAGRAM.md) roughly every 50 days."
@@ -158,7 +169,7 @@ jobs:
           IG_ACCESS_TOKEN: ${{ secrets.IG_ACCESS_TOKEN }}
           CAPTION: ${{ github.event.inputs.caption }}
         run: |
-          RESP=$(curl -s -X POST "$GRAPH/$IG_USER_ID/media" \
+          RESP=$(curl -s -X POST "$GRAPH/$PUBLISH_ID/media" \
             --data-urlencode "image_url=$IMAGE_URL" \
             --data-urlencode "caption=$CAPTION" \
             --data-urlencode "access_token=$IG_ACCESS_TOKEN")
@@ -202,7 +213,7 @@ jobs:
           IG_USER_ID: ${{ secrets.IG_USER_ID }}
           IG_ACCESS_TOKEN: ${{ secrets.IG_ACCESS_TOKEN }}
         run: |
-          RESP=$(curl -s -X POST "$GRAPH/$IG_USER_ID/media_publish" \
+          RESP=$(curl -s -X POST "$GRAPH/$PUBLISH_ID/media_publish" \
             --data-urlencode "creation_id=$CREATION_ID" \
             --data-urlencode "access_token=$IG_ACCESS_TOKEN")
           MEDIA_ID=$(echo "$RESP" | jq -r '.id // empty')

--- a/.github/workflows/instagram-post.yml
+++ b/.github/workflows/instagram-post.yml
@@ -10,6 +10,11 @@ name: Post to Instagram
 # live at https://www.lvivsecondhand.com/... the moment it is committed. So the
 # workflow just points Meta at a URL that already exists.
 #
+# CHECKING CONFIG WITHOUT POSTING
+# Tick `dry_run` to run the three pre-flights and stop. Use it after changing a
+# secret or refreshing the token — verifying those by posting costs a real post
+# on a real feed, which is a bad way to test a config change.
+#
 # SAFE UNTIL CONFIGURED
 # workflow_dispatch only — there is no schedule, so this never fires on its own.
 # It also exits cleanly (not red) when the secrets are missing, so an
@@ -60,6 +65,11 @@ on:
           Безкоштовно, без реєстрації → www.lvivsecondhand.com
 
           #секондхенд #секондхендльвів #львів #lviv #сектор #шопінгльвів #thrifting #secondhand #вінтаж #ukraine
+      dry_run:
+        description: "Check config only — run the pre-flights and stop before posting"
+        type: boolean
+        required: false
+        default: false
   # Uncomment once a manual run has succeeded and you want it automatic.
   # schedule:
   #   - cron: "0 9 * * 1"   # Mondays 09:00 UTC (~12:00 Europe/Kyiv)
@@ -163,7 +173,7 @@ jobs:
 
       # Step 1 of 2: create the media container. Meta downloads the image here.
       - name: Create media container
-        if: steps.guard.outputs.ready == 'true'
+        if: steps.guard.outputs.ready == 'true' && github.event.inputs.dry_run != 'true'
         env:
           IG_USER_ID: ${{ secrets.IG_USER_ID }}
           IG_ACCESS_TOKEN: ${{ secrets.IG_ACCESS_TOKEN }}
@@ -186,7 +196,7 @@ jobs:
       # Images are usually ready immediately, but publishing a container that is
       # still processing fails — so wait for FINISHED rather than assuming.
       - name: Wait for the container to finish processing
-        if: steps.guard.outputs.ready == 'true'
+        if: steps.guard.outputs.ready == 'true' && github.event.inputs.dry_run != 'true'
         env:
           IG_ACCESS_TOKEN: ${{ secrets.IG_ACCESS_TOKEN }}
         run: |
@@ -206,9 +216,22 @@ jobs:
           echo "::error::Container never reached FINISHED after ~2 minutes."
           exit 1
 
+      # Without this a dry run ends green with no output, which reads exactly
+      # like a successful post — the one confusion this feature must not create.
+      - name: Dry run — report and stop
+        if: steps.guard.outputs.ready == 'true' && github.event.inputs.dry_run == 'true'
+        run: |
+          {
+            echo "### Dry run — nothing was posted"
+            echo ""
+            echo "Pre-flights passed: the image is reachable and the token is valid."
+            echo "Re-run with **dry_run unchecked** to publish."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice::Dry run complete — config is good, nothing posted."
+
       # Step 2 of 2: publish. This is the irreversible one — it goes live.
       - name: Publish
-        if: steps.guard.outputs.ready == 'true'
+        if: steps.guard.outputs.ready == 'true' && github.event.inputs.dry_run != 'true'
         env:
           IG_USER_ID: ${{ secrets.IG_USER_ID }}
           IG_ACCESS_TOKEN: ${{ secrets.IG_ACCESS_TOKEN }}


### PR DESCRIPTION
Two changes, both verified against the live API.

## 1. The publish target comes from the token, not the secret

The first live run failed at pre-flight with "the two secrets are from different accounts", blocking a token that was **working perfectly** — the `me` call had already authenticated `@secondhandlvivbot`.

The check was wrong in principle. A token can only publish to its own account, so the token already determines the target and `IG_USER_ID` cannot override it. Erroring on a mismatch gave the secret authority it doesn't have.

Now the id comes from `me`, and `IG_USER_ID` is a cross-check that **warns** instead of failing. The warning reports character counts rather than values, so it survives GitHub's secret masking — which is what diagnosed the real cause in the live run:

```
IG_USER_ID (18 chars) matches neither id on this token
(user_id 17 chars, id 17 chars)
```

18 digits is the Instagram *app* id; the account id is 17. The dashboard shows them side by side.

Also queries both `id` and `user_id`, preferring `user_id` with a fallback: which one the publish endpoints accept has moved between API versions.

**Verified:** this is the version that published https://www.instagram.com/p/DcTJiRAoArz/

## 2. A `dry_run` input

There was no way to check configuration without publishing. Verifying a corrected secret or a refreshed token meant posting something real to find out — a bad way to test a config change, and one that costs a post on a real feed every time.

`dry_run` runs the three pre-flights and stops before container creation. The publishing steps are gated off, so nothing can reach the feed regardless of the other inputs.

It also writes an explicit "nothing was posted" summary. Without that a dry run ends green and silent, which looks exactly like a successful post — the one confusion this feature must not introduce.

**Verified** (run #3, after the `IG_USER_ID` secret was corrected):

```
Token valid — authenticated as @secondhandlvivbot.
IG_USER_ID matches the token's account.
Dry run complete — config is good, nothing posted.
```

Steps `Create media container`, `Wait for the container`, and `Publish` all reported **skipped**.

## Verification summary

| Check | Result |
|---|---|
| Simulation under `set -e`, all four id cases | exit 0, usable publish id |
| Live post | published, 13s end to end |
| Dry run gating | 3 publish steps skipped, nothing posted |
| Cross-check after secret fix | matches |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN