### PR TITLE
Queue Instagram ads for paid tiers, not just flash deals

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,19 @@ Approving the ad is **deliberately separate** from approving the flash deal for 
 | Queue for approval | `.github/workflows/instagram-ad.yml` (also hand-runnable for a test render) |
 | Publish after approval | `.github/workflows/instagram-ad-publish.yml` |
 
+**What queues an ad, and what doesn't:**
+
+| Event | Queues an ad? |
+| --- | --- |
+| Flash deal paid | Yes — the deal text is a required checkout field |
+| Tier bought (Verified+ / Featured / Spotlight, monthly, annual or one-off run) | Yes, **if** the store supplied the optional offer line |
+| Tier bought with no offer line | No — the Telegram notification says so, so you can ask the store for one |
+| **Subscription renewal** | **No** |
+
+Renewal is deliberately excluded. A subscription bills every month, so queueing there would hand you one approval per paying store per month, forever, each showing the same offer as the last. Recurring presence is what the weekly deals post already provides.
+
+An offer line is required because inventing copy for someone else's paid advertisement is not ours to write. A tier bought without one still gets every on-map placement it paid for.
+
 Needs one secret beyond the Instagram pair: **`WORKER_ADMIN_KEY`**, matching the Worker's `ADMIN_KEY` — it is what makes your approve link work and everyone else's fail.
 
 Every ad carries **`РЕКЛАМА · SPONSORED`** at the top of the image. The app tells shoppers "paid placements are always labelled", and an ad that quietly drops the mark to perform better would break that promise.

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -511,6 +511,24 @@ async function applyPromoEvent(env, ev, ctx) {
       "INSERT INTO promos (store_id, tier, offer, until, sub_id, cadence, cust_id, status, updated) VALUES (?, ?, ?, ?, ?, ?, ?, 'active', datetime('now')) " +
       "ON CONFLICT(store_id) DO UPDATE SET tier=excluded.tier, offer=excluded.offer, until=excluded.until, sub_id=excluded.sub_id, cadence=excluded.cadence, cust_id=excluded.cust_id, status='active', updated=datetime('now')"
     ).bind(storeId, tier, offer, until, o.subscription || null, cadence, run ? null : (o.customer || null)).run();
+    // A paid tier also queues an Instagram advertisement — on PURCHASE only.
+    //
+    // Deliberately not on renewal (invoice.paid, below). A subscription bills
+    // every month, so queueing there would hand you one approval per paying
+    // store per month, forever, each showing the same offer the last one did.
+    // That is a chore rather than a feature, and recurring presence is what the
+    // weekly deals post already provides.
+    //
+    // And only when the store supplied an offer line. It is optional at
+    // checkout, and inventing copy for someone else's paid advertisement is not
+    // ours to do — so a tier bought without one gets the on-map placement it
+    // paid for, and the notification below says why no ad appeared.
+    if (offer) {
+      ctx.waitUntil(
+        queueInstagramAd(env, { storeId, text: offer, tier })
+          .catch((e) => tgNotify(env, ctx, `⚠️ Could not queue the Instagram ad for ${storeId}: ${e.message}`))
+      );
+    }
     // A promotion fulfils itself, so this is information rather than a task.
     tgNotify(env, ctx,
       `💸 PROMOTION PAID — already live, nothing to do\n\n` +
@@ -519,8 +537,13 @@ async function applyPromoEvent(env, ev, ctx) {
       `Paid:  ${uah(o.amount_total)}\n` +
       (offer ? `Offer: ${offer}\n` : '') +
       `Until: ${until}\n` +
-      `\n${storeLink(storeId)}`);
+      (offer
+        ? `\n📣 An Instagram ad is being prepared — you'll get it here to approve.`
+        : `\n📣 No Instagram ad: this purchase carried no offer line. Ask the store for one and queue it by hand (Actions → Queue an Instagram ad).`) +
+      `\n\n${storeLink(storeId)}`);
   } else if (type === 'invoice.paid' || type === 'invoice.payment_succeeded') {
+    // Renewal: extends the placement, queues no advertisement. See the comment
+    // at the purchase branch above for why.
     const subId = o.subscription;
     if (!subId) return;
     const row = await env.DB.prepare('SELECT cadence FROM promos WHERE sub_id = ?').bind(subId).first();


### PR DESCRIPTION
Verified+, Featured and Spotlight now queue an Instagram ad the same way a flash deal does — rendered, committed, sent to you for approval, posted only if you approve. Covers monthly, annual and one-off runs, since those are the same placements bought for a different duration.

## Two decisions the code forced

**Purchase queues an ad. Renewal does not.**

`applyPromoEvent` also handles `invoice.paid`, which fires *every month for every subscriber*. Queueing there would hand you one approval per paying store per month, forever — each showing the same offer line as the month before. That's a chore, not a feature, and recurring presence is already what the weekly deals post provides.

The renewal branch now carries a comment saying so, so the omission reads as a decision rather than an oversight.

**An ad is queued only when the store supplied an offer line.**

It's optional at tier checkout. Writing copy for someone else's paid advertisement isn't ours to do, and the alternative — a house-written generic ad running under a store's name — is worse than no ad.

A tier bought without one still gets every on-map placement it paid for, and the Telegram notification now says why no ad appeared and how to queue one by hand once the store gives you words.

| Event | Queues an ad? |
|---|---|
| Flash deal paid | Yes — deal text is a required checkout field |
| Tier bought **with** an offer line | Yes |
| Tier bought **without** one | No — notification explains |
| Subscription renewal | No |

## Verified

`PROMO_TIERS` is `{verified, featured, spotlight}` and every one resolves a label in `ad-image.mjs`'s `TIER_LABEL` — checked by comparing the two sets programmatically rather than by eye, so no tier renders a blank label line. All three render.

`node --check`, `check-wiring`, `check-inline-js`, `validate-stores` pass.

## One thing I did not decide for you

All three tiers now get identical Instagram treatment, which **flattens a ladder running from ₴250 to ₴1,200**. Verified+ and Spotlight buying the same feed presence is a pricing question, not a code one, so I left it as you asked it.

If they should differ, **frequency is the natural lever** — for example, letting Spotlight alone re-queue on renewal while the others stay purchase-only. That's a two-line change to the branch this PR just documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_