### PR TITLE
Fix the ad approval message never being sent

### DIFF
--- a/.github/workflows/instagram-ad.yml
+++ b/.github/workflows/instagram-ad.yml
@@ -156,9 +156,13 @@ jobs:
           CAP: ${{ steps.cfg.outputs.cap }}
           STORE: ${{ steps.cfg.outputs.store }}
         run: |
+          # An error, not a warning. This workflow's job is "queue AND ask" —
+          # an ad nobody can be asked about sits in the queue forever, and the
+          # run going green would say the opposite. The image and caption are
+          # already committed at this point, so nothing is lost by failing here.
           if [ -z "$BOT_TOKEN" ] || [ -z "$OWNER_ID" ]; then
-            echo "::warning::BOT_TOKEN / OWNER_ID not set — the ad is queued but nobody was told. Approve manually via the Worker."
-            exit 0
+            echo "::error::BOT_TOKEN / OWNER_ID are not set as repository secrets, so the approval request cannot be sent and this ad can never be approved. Add both under Settings → Secrets and variables → Actions."
+            exit 1
           fi
           if [ -z "$ADMIN_KEY" ]; then
             echo "::error::WORKER_ADMIN_KEY not set — an approval link without it cannot work."
@@ -177,8 +181,19 @@ jobs:
             "✅ Опублікувати · Publish:" "$APPROVE" \
             "❌ Відхилити · Reject:" "$REJECT")
           # sendPhoto so the owner decides on the actual image, not a filename.
-          curl -s -o /dev/null -X POST "https://api.telegram.org/bot$BOT_TOKEN/sendPhoto" \
+          #
+          # The response is checked. The first version discarded it with
+          # `-o /dev/null || true`, so the step went green whether Telegram
+          # accepted the message or not — and when BOT_TOKEN was missing it
+          # reported success for an ad nobody was ever told about. A send that
+          # does not arrive is a failed run, because approval is the feature.
+          RESP=$(curl -s -X POST "https://api.telegram.org/bot$BOT_TOKEN/sendPhoto" \
             -H 'Content-Type: application/json' \
             -d "$(jq -nc --arg c "$OWNER_ID" --arg p "$SITE/$IMG" --arg cap "$MSG" \
-                  '{chat_id:$c, photo:$p, caption:$cap}')" || true
+                  '{chat_id:$c, photo:$p, caption:$cap}')" || echo '{}')
+          if [ "$(echo "$RESP" | jq -r '.ok // false')" != "true" ]; then
+            echo "::error::Telegram rejected the approval request: $(echo "$RESP" | jq -c '{error_code, description}' 2>/dev/null || echo "$RESP")"
+            echo "The ad is committed at $IMG but nobody was asked about it."
+            exit 1
+          fi
           echo "::notice::Ad $AD_ID queued and sent for approval. Nothing has been posted."

--- a/.github/workflows/instagram-ad.yml
+++ b/.github/workflows/instagram-ad.yml
@@ -148,7 +148,11 @@ jobs:
       - name: Send it to the owner for approval
         working-directory: .
         env:
-          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          # Same fallback chain deploy-bot.yml and deploy-worker.yml use — this
+          # repo's token has lived under TELEGRAM_BOT_TOKEN since before
+          # BOT_TOKEN existed, and looking only for the latter silently found
+          # nothing.
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN || secrets.TELEGRAM_BOT_TOKEN }}
           OWNER_ID: ${{ secrets.OWNER_ID }}
           ADMIN_KEY: ${{ secrets.WORKER_ADMIN_KEY }}
           AD_ID: ${{ steps.cfg.outputs.ad_id }}
@@ -160,8 +164,15 @@ jobs:
           # an ad nobody can be asked about sits in the queue forever, and the
           # run going green would say the opposite. The image and caption are
           # already committed at this point, so nothing is lost by failing here.
+          # OWNER_ID is a chat id, not a credential — it is already committed as
+          # a plain var in worker/wrangler.toml. Read it from there rather than
+          # asking for a secret that duplicates a value the repo already holds.
+          if [ -z "$OWNER_ID" ]; then
+            OWNER_ID=$(sed -n 's/^OWNER_ID *= *"\([0-9-]*\)".*/\1/p' worker/wrangler.toml | head -1)
+            [ -n "$OWNER_ID" ] && echo "OWNER_ID taken from worker/wrangler.toml"
+          fi
           if [ -z "$BOT_TOKEN" ] || [ -z "$OWNER_ID" ]; then
-            echo "::error::BOT_TOKEN / OWNER_ID are not set as repository secrets, so the approval request cannot be sent and this ad can never be approved. Add both under Settings → Secrets and variables → Actions."
+            echo "::error::No Telegram bot token (BOT_TOKEN or TELEGRAM_BOT_TOKEN) or no OWNER_ID, so the approval request cannot be sent and this ad can never be approved."
             exit 1
           fi
           if [ -z "$ADMIN_KEY" ]; then

--- a/.github/workflows/instagram-token-check.yml
+++ b/.github/workflows/instagram-token-check.yml
@@ -34,11 +34,15 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+      # Needed only to read OWNER_ID out of worker/wrangler.toml, where it
+      # already lives as a plain var — it is a chat id, not a credential.
+      - uses: actions/checkout@v7
+
       - name: Check the token, and shout on Telegram if it is dead
         env:
           IG_USER_ID: ${{ secrets.IG_USER_ID }}
           IG_ACCESS_TOKEN: ${{ secrets.IG_ACCESS_TOKEN }}
-          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN || secrets.TELEGRAM_BOT_TOKEN }}
           OWNER_ID: ${{ secrets.OWNER_ID }}
         run: |
           if [ -z "$IG_ACCESS_TOKEN" ]; then
@@ -49,6 +53,9 @@ jobs:
           # Telegram is best-effort throughout: a watchdog that fails because
           # its own alerting is misconfigured is worse than one that stays
           # quiet, since the run log still records what happened either way.
+          if [ -z "$OWNER_ID" ]; then
+            OWNER_ID=$(sed -n 's/^OWNER_ID *= *"\([0-9-]*\)".*/\1/p' worker/wrangler.toml | head -1)
+          fi
           notify() {
             [ -n "$BOT_TOKEN" ] && [ -n "$OWNER_ID" ] || return 0
             R=$(curl -s -X POST \

--- a/.github/workflows/instagram-token-check.yml
+++ b/.github/workflows/instagram-token-check.yml
@@ -51,11 +51,16 @@ jobs:
           # quiet, since the run log still records what happened either way.
           notify() {
             [ -n "$BOT_TOKEN" ] && [ -n "$OWNER_ID" ] || return 0
-            curl -s -o /dev/null -X POST \
+            R=$(curl -s -X POST \
               "https://api.telegram.org/bot$BOT_TOKEN/sendMessage" \
               -H 'Content-Type: application/json' \
               -d "$(jq -nc --arg c "$OWNER_ID" --arg t "$1" \
-                    '{chat_id:$c, text:$t, disable_web_page_preview:true}')" || true
+                    '{chat_id:$c, text:$t, disable_web_page_preview:true}')" || echo '{}')
+            # Still best-effort — a watchdog must not die because its own
+            # alerting is misconfigured — but the failure is now logged rather
+            # than swallowed, so a silent watchdog is visible in the run.
+            [ "$(echo "$R" | jq -r '.ok // false')" = "true" ] \
+              || echo "::warning::Telegram did not accept the alert: $(echo "$R" | jq -c '.description // .' 2>/dev/null)"
           }
 
           RESP=$(curl -sG "$GRAPH/me" \

--- a/README.md
+++ b/README.md
@@ -309,7 +309,15 @@ Renewal is deliberately excluded. A subscription bills every month, so queueing 
 
 An offer line is required because inventing copy for someone else's paid advertisement is not ours to write. A tier bought without one still gets every on-map placement it paid for.
 
-Needs one secret beyond the Instagram pair: **`WORKER_ADMIN_KEY`**, matching the Worker's `ADMIN_KEY` — it is what makes your approve link work and everyone else's fail.
+**Three repository secrets** are needed — all under *Settings → Secrets and variables → Actions*, and note these are GitHub secrets, separate from the Cloudflare Worker secrets of the same name:
+
+| Secret | Value | Without it |
+| --- | --- | --- |
+| `WORKER_ADMIN_KEY` | same string as the Worker's `ADMIN_KEY` | the approve link returns `unauthorized` |
+| `BOT_TOKEN` | the Telegram bot token (BotFather → *My bots* → *API Token*) | no approval request is sent, and the token watchdog cannot warn you either |
+| `OWNER_ID` | your Telegram chat id — `1212541015`, already a plain var in both `wrangler.toml` files | same |
+
+A missing `BOT_TOKEN`/`OWNER_ID` **fails the run**, deliberately: this workflow's job is to queue *and ask*, and an ad nobody can be asked about would otherwise sit in the queue behind a green tick.
 
 Every ad carries **`РЕКЛАМА · SPONSORED`** at the top of the image. The app tells shoppers "paid placements are always labelled", and an ad that quietly drops the mark to perform better would break that promise.
 


### PR DESCRIPTION
The first live ad run went green **while telling nobody**. Two separate causes, both mine.

## Cause 1 — wrong secret name

`instagram-ad.yml` and `instagram-token-check.yml` looked only for a `BOT_TOKEN` secret. This repo's token has lived under **`TELEGRAM_BOT_TOKEN`** since before `BOT_TOKEN` existed, and every older workflow reads:

```yaml
${{ secrets.BOT_TOKEN || secrets.TELEGRAM_BOT_TOKEN }}
```

My two new ones didn't, so they found nothing while `deploy-bot.yml` and `deploy-worker.yml` found the same secret fine. Both now use the same chain.

**`OWNER_ID` no longer needs a secret at all.** It's a chat id, not a credential, and it's already committed as a plain var in `worker/wrangler.toml`. Both workflows now parse it from there — one source of truth instead of a secret duplicating a file already in the repo.

**Net effect: nothing needs adding.** The credentials were already configured; they were being looked up under the wrong name.

## Cause 2 — the run reported success anyway

Even with no token, the notify step warned and exited 0, and the send used `-o /dev/null || true` so it couldn't fail either. An ad was rendered, committed, served — and the run was green.

Now: missing credentials **fail** the run, and Telegram's response is checked for `ok:true`, failing with `error_code` and `description` otherwise. Exercised against the four shapes that occur:

| Response | Result |
|---|---|
| `{"ok":true,...}` | exit 0 |
| `400 chat not found` | exit 1, quotes Telegram |
| `401 Unauthorized` | exit 1, quotes Telegram |
| `{}` (network failure) | exit 1 |

## The watchdog had the same bug — and that mattered more

`instagram-token-check.yml`'s `notify()` used the same `|| true`, so **the workflow built to prevent a silent two-month token failure was itself silently unable to warn.** Kept best-effort there deliberately — a watchdog shouldn't die because its own alerting is misconfigured — but it now logs the rejection.

## Verification

`OWNER_ID` parse checked against four `wrangler.toml` shapes: spaced, unspaced, a negative group id with a trailing comment, and a commented-out line (correctly yields nothing).

Both workflows parse; `check-wiring` and `validate-stores` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN