### PR TITLE
Fix /api/ad/register being unreachable

### DIFF
--- a/.github/workflows/instagram-ad.yml
+++ b/.github/workflows/instagram-ad.yml
@@ -71,12 +71,19 @@ jobs:
             # Previously it invented an id locally, so its approve link hit a
             # row that did not exist and 404'd — meaning the approve→publish
             # half could not be tested without taking an actual payment.
-            R=$(curl -s -X POST "$WORKER/api/ad/register" \
+            # -w writes the status onto its own trailing line. The first
+            # version reported only `.reason`, so when the route was missing
+            # entirely the error read "Worker refused to register the ad:" with
+            # nothing after the colon — the one failure it needed to explain.
+            R=$(curl -s -w '\n%{http_code}' -X POST "$WORKER/api/ad/register" \
               -H "X-Admin-Key: $ADMIN_KEY" -H 'Content-Type: application/json' \
               -d "$(jq -nc --arg s "$STORE" --arg t "$TEXT" --arg r "$TIER" \
-                    '{storeId:$s, text:$t, tier:$r}')" || echo '{}')
-            if [ "$(echo "$R" | jq -r '.ok // false')" != "true" ]; then
-              echo "::error::Worker refused to register the ad: $(echo "$R" | jq -c '.reason // .' 2>/dev/null)"
+                    '{storeId:$s, text:$t, tier:$r}')" || printf '\n000')
+            CODE=$(printf '%s' "$R" | tail -n1)
+            R=$(printf '%s' "$R" | sed '$d')
+            if [ "$(printf '%s' "$R" | jq -r '.ok // false' 2>/dev/null)" != "true" ]; then
+              echo "::error::Worker refused to register the ad (HTTP $CODE): ${R:-<empty body>}"
+              echo "A 204 with an empty body means the route did not match — check it is in the POST section of worker.js and that the Worker has deployed."
               exit 1
             fi
             AD_ID=$(echo "$R" | jq -r '.id')

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1195,27 +1195,6 @@ export default {
         if (row.alert) await broadcastFlashDeal(env, ctx, row.store_id, row.text, row.expires_at);
         return new Response(`✅ Flash deal approved and published for ${row.store_id}.`, { status: 200 });
       }
-      // Creates a queue row for an ad the workflow is already rendering — the
-      // hand-run test path. Without it a hand-queued ad has no row, so its
-      // approve link 404s and the whole approve→publish half cannot be
-      // exercised without taking a real payment.
-      //
-      // POST with the key in a header, not a URL: this one IS the admin
-      // credential, and it travels machine-to-machine, never through Telegram.
-      if (url.pathname === '/api/ad/register' && request.method === 'POST') {
-        if (!env.ADMIN_KEY || !safeEqual(request.headers.get('X-Admin-Key') || '', env.ADMIN_KEY)) {
-          return json({ ok: false, reason: 'unauthorized' }, 401, origin);
-        }
-        const storeId = body && body.storeId;
-        const text = body && body.text;
-        if (typeof storeId !== 'string' || !/^[a-z0-9_]{1,24}$/i.test(storeId) || typeof text !== 'string' || !text.trim()) {
-          return json({ ok: false, reason: 'bad_request' }, 400, origin);
-        }
-        const made = await createAdRow(env, {
-          storeId, text: text.slice(0, 120), tier: (body && body.tier) || '',
-        });
-        return json({ ok: true, ...made }, 200, origin);
-      }
       // Owner taps the approve link on a queued Instagram advertisement. Same
       // GET-so-Telegram-linkifies-it shape and same ADMIN_KEY gate as
       // /flash-deal/approve above. This is the ONLY route from a paid ad to the
@@ -1524,6 +1503,27 @@ export default {
     // or sends /stop. Low-stakes (opting a chat id into a marketing message,
     // nothing sensitive), so no signature — the per-IP rate limit above and
     // basic shape validation are enough.
+      // Creates a queue row for an ad the workflow is already rendering — the
+    // hand-run test path. Without it a hand-queued ad has no row, so its
+    // approve link 404s and the whole approve→publish half cannot be
+    // exercised without taking a real payment.
+    //
+    // POST with the key in a header, not a URL: this one IS the admin
+    // credential, and it travels machine-to-machine, never through Telegram.
+    if (url.pathname === '/api/ad/register') {
+      if (!env.ADMIN_KEY || !safeEqual(request.headers.get('X-Admin-Key') || '', env.ADMIN_KEY)) {
+        return json({ ok: false, reason: 'unauthorized' }, 401, origin);
+      }
+      const storeId = body && body.storeId;
+      const text = body && body.text;
+      if (typeof storeId !== 'string' || !/^[a-z0-9_]{1,24}$/i.test(storeId) || typeof text !== 'string' || !text.trim()) {
+        return json({ ok: false, reason: 'bad_request' }, 400, origin);
+      }
+      const made = await createAdRow(env, {
+        storeId, text: text.slice(0, 120), tier: (body && body.tier) || '',
+      });
+      return json({ ok: true, ...made }, 200, origin);
+    }
     if (url.pathname === '/api/sub') {
       const storeId = body && body.storeId;
       const chatId = body && body.chatId;


### PR DESCRIPTION
The first run on a real store failed. Two bugs, both mine, and the second is the more embarrassing one.

## The route could never match

`/api/ad/register` was added **inside** `if (request.method === 'GET')`, carrying its own `&& request.method === 'POST'` guard. That condition is unsatisfiable. It fell through to the catch-all, which answers `204` with an empty body — **the same response an unknown path gives** — so the endpoint looked deployed and silently did nothing.

It was also reading a `body` that doesn't exist in the GET branch.

Moved into the POST section beside `/api/sub`, after `body` is parsed.

## The error message hid it

The run failed with:

```
##[error]Worker refused to register the ad:
```

Nothing after the colon. The check reported only `.reason` from a response that contained no JSON at all — so the one failure it most needed to explain was the one it couldn't.

It now prints the HTTP status and raw body, and names this specific case: *a 204 with an empty body means the route did not match.*

I initially assumed a deploy race and was about to re-run. Checking the code instead of retrying is what found it.

## Verification

Route placement asserted structurally — the register route now sits at a line **after** `let body` and outside the GET block.

Workflow parse exercised against the four responses that occur:

| Response | Result |
|---|---|
| `{"ok":true,...}` 200 | proceed |
| `{"ok":false,"reason":"unauthorized"}` 401 | error, shows status + body |
| empty 204 | error, shows `<empty body>` + the route-mismatch hint |
| empty 000 (connection failure) | error, shows `<empty body>` |

`node --check`, `check-wiring`, `validate-stores` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_