### PR TITLE
Read the admin key from ADMIN_KEY, the secret the Worker actually has

### DIFF
--- a/.github/workflows/instagram-ad.yml
+++ b/.github/workflows/instagram-ad.yml
@@ -12,8 +12,9 @@ name: Queue an Instagram ad for approval
 # client_payload: { ad_id, store_id, text, tier, image_path, caption_path }
 #
 # SECRETS: BOT_TOKEN / OWNER_ID (same pair the token watchdog uses),
-#          WORKER_ADMIN_KEY (must equal the Worker's ADMIN_KEY — it is what
-#          makes the approve link work, and what stops anyone else's)
+#          ADMIN_KEY (the same repo secret deploy-worker.yml installs on the
+#          Worker, so the two match by construction — it is what lets this
+#          workflow register a queue row, and what stops anyone else's)
 
 on:
   repository_dispatch:
@@ -53,7 +54,15 @@ jobs:
           D_TEXT:  ${{ github.event.client_payload.text }}
           D_TIER:  ${{ github.event.client_payload.tier }}
           D_TOKEN: ${{ github.event.client_payload.token }}
-          ADMIN_KEY: ${{ secrets.WORKER_ADMIN_KEY }}
+          # ADMIN_KEY first, and it is the authoritative name: deploy-worker.yml
+          # pipes secrets.ADMIN_KEY into the Worker with `wrangler secret put
+          # ADMIN_KEY`, so that secret IS the value the Worker compares against.
+          # WORKER_ADMIN_KEY was a second name for the same thing, asked for after
+          # the repo already had one — the same duplicate-secret mistake as
+          # BOT_TOKEN vs TELEGRAM_BOT_TOKEN below. Kept as a fallback so an
+          # existing WORKER_ADMIN_KEY still works, but it can never be the one
+          # that is right when the two disagree.
+          ADMIN_KEY: ${{ secrets.ADMIN_KEY || secrets.WORKER_ADMIN_KEY }}
           W_STORE: ${{ inputs.store_id }}
           W_TEXT:  ${{ inputs.text }}
           W_TIER:  ${{ inputs.tier }}
@@ -80,11 +89,11 @@ jobs:
             # key would be "right" everywhere a human looked and still 401.
             CLEAN_KEY=$(printf '%s' "$ADMIN_KEY" | tr -d '\r\n')
             if [ -z "$CLEAN_KEY" ]; then
-              echo "::error::WORKER_ADMIN_KEY is empty. It must hold the same value as the metrics Worker's ADMIN_KEY."
+              echo "::error::No admin key. Set the repo secret ADMIN_KEY — deploy-worker.yml installs that same value on the Worker."
               exit 1
             fi
             if [ "${#CLEAN_KEY}" -ne "${#ADMIN_KEY}" ]; then
-              echo "::warning::WORKER_ADMIN_KEY contained a line break; it was stripped before sending."
+              echo "::warning::The admin key contained a line break; it was stripped before sending."
             fi
             R=$(curl -s -w '\n%{http_code}' -X POST "$WORKER/api/ad/register" \
               -H "X-Admin-Key: $CLEAN_KEY" -H 'Content-Type: application/json' \
@@ -99,7 +108,7 @@ jobs:
               # 401, which reads as "the route is missing" when the route in
               # fact answered correctly and only rejected the credential.
               case "$CODE" in
-                401) echo "401 means the route matched and the Worker rejected the key. The GitHub secret WORKER_ADMIN_KEY must equal the metrics Worker ADMIN_KEY exactly. To confirm the Worker has one set, open /admin in the bot and tap the visitors button - that call uses the same key from the bot side." ;;
+                401) echo "401 means the route matched and the Worker rejected the key. The repo secret ADMIN_KEY is the one the Worker holds - deploy-worker.yml installs it there. If only a stale WORKER_ADMIN_KEY is set, that is the wrong value; set ADMIN_KEY instead." ;;
                 204|000) echo "An empty body means the route did not match, or the Worker was unreachable - check /api/ad/register sits in the POST section of worker.js and that the Worker has deployed." ;;
                 400) echo "400 means the store id or offer text failed validation - the id must exist in stores.json and the text must be non-empty." ;;
               esac

--- a/.github/workflows/instagram-ad.yml
+++ b/.github/workflows/instagram-ad.yml
@@ -75,15 +75,34 @@ jobs:
             # version reported only `.reason`, so when the route was missing
             # entirely the error read "Worker refused to register the ad:" with
             # nothing after the colon — the one failure it needed to explain.
+            # A secret pasted through a web form very often carries a trailing
+            # newline, and the Worker compares the header byte-for-byte, so the
+            # key would be "right" everywhere a human looked and still 401.
+            CLEAN_KEY=$(printf '%s' "$ADMIN_KEY" | tr -d '\r\n')
+            if [ -z "$CLEAN_KEY" ]; then
+              echo "::error::WORKER_ADMIN_KEY is empty. It must hold the same value as the metrics Worker's ADMIN_KEY."
+              exit 1
+            fi
+            if [ "${#CLEAN_KEY}" -ne "${#ADMIN_KEY}" ]; then
+              echo "::warning::WORKER_ADMIN_KEY contained a line break; it was stripped before sending."
+            fi
             R=$(curl -s -w '\n%{http_code}' -X POST "$WORKER/api/ad/register" \
-              -H "X-Admin-Key: $ADMIN_KEY" -H 'Content-Type: application/json' \
+              -H "X-Admin-Key: $CLEAN_KEY" -H 'Content-Type: application/json' \
               -d "$(jq -nc --arg s "$STORE" --arg t "$TEXT" --arg r "$TIER" \
                     '{storeId:$s, text:$t, tier:$r}')" || printf '\n000')
             CODE=$(printf '%s' "$R" | tail -n1)
             R=$(printf '%s' "$R" | sed '$d')
             if [ "$(printf '%s' "$R" | jq -r '.ok // false' 2>/dev/null)" != "true" ]; then
               echo "::error::Worker refused to register the ad (HTTP $CODE): ${R:-<empty body>}"
-              echo "A 204 with an empty body means the route did not match — check it is in the POST section of worker.js and that the Worker has deployed."
+              # The hint has to match the status, or it sends you after the
+              # wrong bug: the first version printed the 204 explanation on a
+              # 401, which reads as "the route is missing" when the route in
+              # fact answered correctly and only rejected the credential.
+              case "$CODE" in
+                401) echo "401 means the route matched and the Worker rejected the key. The GitHub secret WORKER_ADMIN_KEY must equal the metrics Worker ADMIN_KEY exactly. To confirm the Worker has one set, open /admin in the bot and tap the visitors button - that call uses the same key from the bot side." ;;
+                204|000) echo "An empty body means the route did not match, or the Worker was unreachable - check /api/ad/register sits in the POST section of worker.js and that the Worker has deployed." ;;
+                400) echo "400 means the store id or offer text failed validation - the id must exist in stores.json and the text must be non-empty." ;;
+              esac
               exit 1
             fi
             AD_ID=$(echo "$R" | jq -r '.id')

--- a/README.md
+++ b/README.md
@@ -309,13 +309,18 @@ Renewal is deliberately excluded. A subscription bills every month, so queueing 
 
 An offer line is required because inventing copy for someone else's paid advertisement is not ours to write. A tier bought without one still gets every on-map placement it paid for.
 
-**Three repository secrets** are needed — all under *Settings → Secrets and variables → Actions*, and note these are GitHub secrets, separate from the Cloudflare Worker secrets of the same name:
+**No new repository secrets are needed** — every value this workflow wants is one the repo already holds, under *Settings → Secrets and variables → Actions*. Each row below reads an existing name first and only falls back to an alias, so there is nothing to add and nothing to keep in sync:
 
-| Secret | Value | Without it |
+| Reads | Value | Without it |
 | --- | --- | --- |
-| `WORKER_ADMIN_KEY` | same string as the Worker's `ADMIN_KEY` | a hand-run test cannot register its ad (sent as a header, never in a URL) |
-| `BOT_TOKEN` | the Telegram bot token (BotFather → *My bots* → *API Token*) | no approval request is sent, and the token watchdog cannot warn you either |
-| `OWNER_ID` | your Telegram chat id — `1212541015`, already a plain var in both `wrangler.toml` files | same |
+| `ADMIN_KEY`, else `WORKER_ADMIN_KEY` | the admin key. `deploy-worker.yml` installs `ADMIN_KEY` on the Worker with `wrangler secret put`, so the two match by construction — which is exactly why a second name for it is a liability, not a spare | a hand-run test cannot register its ad, and fails with HTTP 401 (sent as a header, never in a URL) |
+| `BOT_TOKEN`, else `TELEGRAM_BOT_TOKEN` | the Telegram bot token (BotFather → *My bots* → *API Token*). This repo has held it under the second name since before the first existed | no approval request is sent, and the token watchdog cannot warn you either |
+| `OWNER_ID`, else `worker/wrangler.toml` | your Telegram chat id — `1212541015`, already a plain var in both `wrangler.toml` files, so the secret is optional. A chat id is not a credential | same |
+
+> Resist adding a second secret for a value the repo already stores. It has now
+> gone wrong twice — `WORKER_ADMIN_KEY` beside `ADMIN_KEY`, and `BOT_TOKEN`
+> beside `TELEGRAM_BOT_TOKEN` — and both times the duplicate silently held a
+> different value while looking correct in the settings list.
 
 A missing `BOT_TOKEN`/`OWNER_ID` **fails the run**, deliberately: this workflow's job is to queue *and ask*, and an ad nobody can be asked about would otherwise sit in the queue behind a green tick.
 


### PR DESCRIPTION
## Root cause

Run `32491844042` (store `s10`) failed with:

```
Worker refused to register the ad (HTTP 401): {"ok":false,"reason":"unauthorized"}
```

`instagram-ad.yml` read the key from a repo secret named `WORKER_ADMIN_KEY`. But `deploy-worker.yml:45` pipes `secrets.ADMIN_KEY` into the Worker with `wrangler secret put ADMIN_KEY` — so `secrets.ADMIN_KEY` **is** the value `worker/worker.js:1514` compares against, by construction. There is no arrangement in which a different secret is the right one.

The repo has held `ADMIN_KEY` for three weeks. `WORKER_ADMIN_KEY` was a second name for the same value, created an hour ago because this workflow asked for it, filled with something else, and rejected on the wire. A key that looks correct in the settings list and is wrong at the Worker.

This is the `BOT_TOKEN` / `TELEGRAM_BOT_TOKEN` mistake, one file later — same shape, same silent failure mode.

## Changes

**`.github/workflows/instagram-ad.yml`**

- Reads `${{ secrets.ADMIN_KEY || secrets.WORKER_ADMIN_KEY }}`, matching the fallback convention already used for the bot token. `ADMIN_KEY` leads because it is authoritative; the alias survives only so an existing setup doesn't break, and can never be the correct one when the two differ.
- **Status-selected error hint.** The failing run printed `401` *and* the leftover advice "a 204 with an empty body means the route did not match" — pointing at routing code that was fine. Now `401` blames the key and names `ADMIN_KEY`, `204`/`000` blames routing or reachability, `400` blames the store id or offer text.
- **Strips CR/LF from the key before sending**, with a `::warning::` when it changes anything. The Worker compares byte-for-byte via `safeEqual`, and a value pasted through a web form commonly carries a trailing newline — invisible to every human inspection, still a 401.
- An empty key fails with its own message rather than sending a blank header.

**`README.md`** — the advertising section claimed three new repository secrets were required. All three already existed under names the workflows read. Rewritten to state that no new secret is needed, list the fallback each row uses, and warn against adding a duplicate for a value the repo already stores.

## What this does not change

Nothing in the Worker, nothing in the credential check, nothing about publishing. This workflow still only queues and asks; the only route to the feed remains a human tapping approve.

## Verification

- `yaml.safe_load` parses the workflow; the `cfg` step's `run` block passes `bash -n`.
- Trim logic exercised directly: clean key passes through unchanged, trailing newline stripped with a warning, empty exits 1.
- `grep` across workflows confirms `deploy-worker.yml` and `deploy-bot.yml` both already use `secrets.ADMIN_KEY`; `instagram-ad.yml` was the only file reading the duplicate name.
- No remaining reference to `WORKER_ADMIN_KEY` outside the deliberate fallback and the note explaining it.

## After merge

`WORKER_ADMIN_KEY` can be deleted from repository secrets — nothing needs it once `ADMIN_KEY` is read first. Leaving it costs nothing but is one more duplicate to get wrong later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN