### PR TITLE
Fix ensureSchema throwing on every call, which 500'd the whole Worker

### DIFF
--- a/scripts/check-wiring.mjs
+++ b/scripts/check-wiring.mjs
@@ -17,6 +17,12 @@
 //      Cloudflare answers such a subrequest with HTTP 404 "error code: 1042".
 //      Six bot features failed this way, invisibly, for months.
 //
+//   4. ensureSchema actually runs to completion.
+//      A stray `.run()` chained onto `.catch()` made every call to it throw
+//      TypeError, so the Worker answered HTTP 500 "error code: 1101" on every
+//      D1-backed route at once. The statement was valid JavaScript, so
+//      `node --check` passed it; only executing the chain finds it.
+//
 // Exit code 1 on any violation.
 
 import fs from 'node:fs';
@@ -92,6 +98,59 @@ const errors = [];
     }
   }
   console.log('worker-to-worker: no unbound public-URL calls');
+}
+
+// ── 4 · ensureSchema survives execution ───────────────────────────────
+{
+  // Checks 1–3 read the source as text. This one runs it, because the bug it
+  // exists for was invisible to any amount of reading: `.run().catch(() => {}
+  // ).run()` is syntactically perfect and throws on every invocation.
+  //
+  // The stub rejects ALTER, which is what D1 really does once the column is
+  // there — so the idempotent-ALTER pattern is exercised in its failing case,
+  // the only case that matters after the first deploy.
+  const wanted = [...worker.matchAll(/(?:CREATE TABLE IF NOT EXISTS|ALTER TABLE) [a-z_]+/g)].length;
+  const ran = [];
+  const DB = {
+    prepare(sql) {
+      return {
+        bind() { return this; },
+        async run() {
+          ran.push(sql);
+          if (/^\s*ALTER TABLE/.test(sql)) throw new Error('duplicate column name');
+          return { success: true };
+        },
+        async first() { return null; },
+        async all() { return { results: [] }; },
+      };
+    },
+  };
+  try {
+    const worker_mod = await import('../worker/worker.js');
+    const res = await worker_mod.default.fetch(
+      new Request('https://x/api/sub', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ storeId: 's10', chatId: '1' }),
+      }),
+      { DB },
+      { waitUntil() {} },
+    );
+    if (res.status >= 500) {
+      errors.push(`ensureSchema left the Worker answering HTTP ${res.status} on a D1 route.`);
+    }
+    // Compare schema statements only — the probe route runs its own INSERT on
+    // top, which is not what this check is counting. A throw partway through
+    // stops the rest, so a short count localises the failure even when nothing
+    // propagates out as a 500.
+    const schemaRan = ran.filter((q) => /^\s*(?:CREATE TABLE IF NOT EXISTS|ALTER TABLE)\b/.test(q));
+    if (schemaRan.length !== wanted) {
+      errors.push(`ensureSchema ran ${schemaRan.length} of ${wanted} schema statements — it threw partway. Last: ${(schemaRan[schemaRan.length - 1] || '(none)').slice(0, 70)}`);
+    }
+    console.log(`ensureSchema: ${schemaRan.length}/${wanted} schema statements executed, ALTER rejection absorbed`);
+  } catch (e) {
+    errors.push(`ensureSchema threw: ${(e && e.message) || e}`);
+  }
 }
 
 if (errors.length) {

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -108,13 +108,17 @@ async function ensureSchema(env) {
   await env.DB.prepare(
     "CREATE TABLE IF NOT EXISTS instagram_ads (id TEXT PRIMARY KEY, store_id TEXT NOT NULL, ad_text TEXT NOT NULL, tier TEXT NOT NULL DEFAULT '', image_path TEXT NOT NULL, caption_path TEXT NOT NULL, token TEXT NOT NULL DEFAULT '', status TEXT NOT NULL DEFAULT 'rendering', created TEXT NOT NULL DEFAULT (datetime('now')), decided TEXT)"
   ).run();
-  // Older rows predate the per-ad token; ALTER is a no-op once applied and
-  // errors harmlessly if the column is already there, so it stays idempotent
-  // alongside the CREATE IF NOT EXISTS above.
-  await env.DB.prepare(
-    "ALTER TABLE instagram_ads ADD COLUMN token TEXT NOT NULL DEFAULT ''"
-  ).run().catch(() => {}
-  ).run();
+  // Older rows predate the per-ad token. Same try/catch shape as the promos
+  // ALTER above (SQLite has no ADD COLUMN IF NOT EXISTS), deliberately, rather
+  // than a second idiom for the same job: the version written as
+  // `.run().catch(() => {} ).run()` carried a stray second .run(), which made
+  // ensureSchema throw TypeError on every call and took every D1-backed route
+  // down with HTTP 500 until it was found.
+  try {
+    await env.DB.prepare(
+      "ALTER TABLE instagram_ads ADD COLUMN token TEXT NOT NULL DEFAULT ''"
+    ).run();
+  } catch {}
   // Crowdsourced moderation (Feature 6). A web-submitted correction sits as a
   // 'draft' (no contributor identity yet — the web app has no login) until
   // claimed by whoever opens the Telegram deep link, which is the first


### PR DESCRIPTION
## Live outage on `main`

`POST /api/sub` against the deployed Worker returns **HTTP 500** right now. Cause:

```js
  ).run().catch(() => {}
  ).run();
```

The paren placement puts a second `.run()` on the Promise that `.catch()` returns. Promises have no `.run`, so `ensureSchema` throws `TypeError` before it can await anything — on **every** invocation, from all **28** call sites. Cloudflare surfaces an uncaught exception as `HTTP 500 error code: 1101`.

Introduced by the idempotent ALTER in #263 (the per-ad token). It went unnoticed because the ad-queue path was blocked behind a separate 401 at the time, so the first thing to actually reach the Worker after that deploy was the run that found this.

**Blast radius is everything backed by D1**, not just ads: restock subscriptions, flash deals, store submissions, the leaderboard, edit stash/resolve, visitor stats, and the cron sweeps.

## Changes

**`worker/worker.js`** — rewritten as the `try { … } catch {}` already used four lines above for the `promos` ALTER. One idiom for one job; the second idiom is exactly where the bug came from, and the comment now says so.

**`scripts/check-wiring.mjs`** — new check 4. Checks 1–3 read the source as text and could never have seen this: the statement is valid JavaScript. Check 4 *executes* `ensureSchema` against a stub D1 that rejects `ALTER` the way D1 really does once the column exists — the failing case is the only one that matters after the first deploy — and asserts all 18 schema statements run.

## Verification

| | result |
| --- | --- |
| Live probe before fix | `POST /api/sub` → **500** |
| `node --check` on the buggy file | **passes** — which is why nothing caught it |
| `check-wiring.mjs` on the buggy file | **fails**: `ensureSchema threw: env.DB.prepare(...).run(...).catch(...).run is not a function` |
| `check-wiring.mjs` on the fixed file | `ensureSchema: 18/18 schema statements executed, ALTER rejection absorbed` |
| Stubbed `/api/sub` after fix | **204**, 19 statements, ALTER rejection swallowed |

Bug was reintroduced deliberately to confirm the check catches it, then reverted.

Also green: `validate-stores.mjs`, `check-inline-js.mjs`, `node --check` on both Workers.

## Deploy

`deploy-worker.yml` auto-deploys on merge for changes under `worker/`, so merging restores the D1 routes. Worth confirming `POST /api/sub` returns 204 rather than 500 shortly after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_