### PR TITLE
Fix the three critical review findings, and keep the harnesses that found them

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -89,9 +89,29 @@ jobs:
         run: npx cap add android
 
       - name: Set versionName / versionCode
+        env:
+          # Via env, never interpolated into the script body. A dispatch input
+          # written as ${{ }} inside `run:` is pasted into the shell before bash
+          # parses it, so a value carrying a quote or a semicolon runs as its own
+          # command — in a job that holds the signing keystore and both of its
+          # passwords. Only collaborators can dispatch this, but every other
+          # workflow here already routes inputs through env, and a benign value
+          # broke it anyway: a version_name containing "/" ends the sed
+          # expression and fails with "unknown option to `s'".
+          VERSION_NAME: ${{ github.event.inputs.version_name }}
+          VERSION_CODE: ${{ github.event.inputs.version_code }}
         run: |
-          sed -i "s/versionCode 1/versionCode ${{ github.event.inputs.version_code }}/" android/app/build.gradle
-          sed -i "s/versionName \"1.0\"/versionName \"${{ github.event.inputs.version_name }}\"/" android/app/build.gradle
+          # Shape-checked before use: a versionCode must be an integer and a
+          # versionName must look like one, which also keeps sed's delimiter and
+          # every shell metacharacter out of the substitution.
+          case "$VERSION_CODE" in
+            ''|*[!0-9]*) echo "::error::version_code must be a positive integer, got '$VERSION_CODE'."; exit 1 ;;
+          esac
+          case "$VERSION_NAME" in
+            ''|*[!0-9.]*) echo "::error::version_name must be digits and dots, e.g. 1.0.0 — got '$VERSION_NAME'."; exit 1 ;;
+          esac
+          sed -i "s/versionCode 1/versionCode ${VERSION_CODE}/" android/app/build.gradle
+          sed -i "s/versionName \"1.0\"/versionName \"${VERSION_NAME}\"/" android/app/build.gradle
           grep -nE "versionCode|versionName" android/app/build.gradle
 
       - name: Sync web assets & config

--- a/index.html
+++ b/index.html
@@ -1132,7 +1132,7 @@ const DAY_NAMES = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','
 const DAY_NAMES_UA = ['Неділя','Понеділок','Вівторок','Середа','Четвер','П\'ятниця','Субота'];
 function dayName(d){ const i = DAYS.indexOf(d); return (lang==='ua' ? DAY_NAMES_UA : DAY_NAMES)[i] || d; }
 // DAYS key ('mon'..'sun') for a "YYYY-MM-DD" string. JS getDay() is 0=Sun..6=Sat.
-function weekdayOf(str){ const d = parseLocalDate(str); return d ? DAYS[(d.getDay()+6)%7] : ''; }
+function weekdayOf(str){ const d = parseLocalDate(str); return d ? DAYS[d.getDay()] : ''; }
 // First restock on/after today, given a last-restock date and cycle length (days).
 // (Kept distinct from the storeId-keyed nextRestockDate() below — they used to
 // share a name, which meant this one silently never ran: the later function
@@ -1142,7 +1142,11 @@ function nextRestockFromAnchor(str, cycle){
   const d = parseLocalDate(str); if(!d || !cycle) return '';
   const today = new Date(); today.setHours(0,0,0,0); d.setHours(0,0,0,0);
   while(d < today){ d.setDate(d.getDate() + cycle); }
-  return d.toISOString().slice(0,10);
+  // Local fields, not toISOString(): the date was normalised to LOCAL midnight,
+  // and serialising that as UTC rolls it back a day everywhere east of
+  // Greenwich — so this returned yesterday for every user in Kyiv while being
+  // correct in CI, which runs in UTC.
+  return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
 }
 let currentFilter = 'all';
 let currentTab = 'map';   // v3: the map is the app's front door

--- a/scripts/check-wiring.mjs
+++ b/scripts/check-wiring.mjs
@@ -23,6 +23,22 @@
 //      D1-backed route at once. The statement was valid JavaScript, so
 //      `node --check` passed it; only executing the chain finds it.
 //
+//   5. The app's date helpers are right OUTSIDE UTC.
+//      nextRestockFromAnchor() normalised to local midnight and serialised
+//      with toISOString(), so it returned yesterday for every user in Kyiv
+//      while being correct in CI. A check that only ever runs in UTC cannot
+//      see that class of bug, so this one sets TZ deliberately.
+//
+//   6. A queued Instagram ad can actually be approved.
+//      createAdRow wrote status 'rendering' while /ad/approve demanded
+//      'pending' and nothing transitioned between them, so every approve tap
+//      published nothing. Both halves were valid code; only executing the
+//      route together with the row it creates reveals it.
+//
+//   7. The bot ranks by day-in-cycle, not by elapsed days.
+//      cheapText() reported days since the restock anchor without reducing
+//      modulo the cycle, inverting its own "longest since a restock" list.
+//
 // Exit code 1 on any violation.
 
 import fs from 'node:fs';
@@ -150,6 +166,137 @@ const errors = [];
     console.log(`ensureSchema: ${schemaRan.length}/${wanted} schema statements executed, ALTER rejection absorbed`);
   } catch (e) {
     errors.push(`ensureSchema threw: ${(e && e.message) || e}`);
+  }
+}
+
+// ── 5 · the app's date helpers, executed outside UTC ─────────────────────────
+{
+  // Pulled out of index.html's inline <script> the same way check-inline-js.mjs
+  // extracts it, then RUN — not syntax-checked. The bug this exists for was a
+  // correct-in-UTC, wrong-in-Kyiv date rollover, invisible to any check that
+  // does not deliberately leave UTC.
+  const DAYS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+  const html = fs.readFileSync('index.html', 'utf8');
+  const blocks = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)];
+  if (blocks.length !== 1) {
+    errors.push(`index.html: expected one inline <script>, found ${blocks.length}.`);
+  } else {
+    const code = blocks[0][1];
+    const grab = (n) => {
+      const i = code.indexOf(`function ${n}(`);
+      if (i < 0) return null;
+      const j = code.indexOf('\nfunction ', i + 1);
+      return code.slice(i, j < 0 ? undefined : j);
+    };
+    const names = ['parseLocalDate', 'weekdayOf', 'nextRestockFromAnchor'];
+    const parts = names.map(grab);
+    if (parts.some((x) => x === null)) {
+      errors.push(`index.html: date helpers renamed or removed (${names.join(', ')}) — this check needs updating.`);
+    } else {
+      const api = {};
+      new Function('DAYS', 'api', `${parts.join('\n')}\napi.weekdayOf = weekdayOf; api.nextRestockFromAnchor = nextRestockFromAnchor;`)(DAYS, api);
+
+      // Node re-reads process.env.TZ on the next Date operation, so this is
+      // enough to leave UTC without spawning a second process.
+      const prevTZ = process.env.TZ;
+      process.env.TZ = 'Europe/Kyiv';
+      try {
+        // A weekday name must match what the calendar says, in any timezone.
+        for (const [iso, want] of [['2026-08-21', 'fri'], ['2026-08-23', 'sun'], ['2026-08-17', 'mon']]) {
+          const got = api.weekdayOf(iso);
+          if (got !== want) errors.push(`weekdayOf("${iso}") = "${got}", expected "${want}".`);
+        }
+        // An anchor exactly one cycle back must land on today, not yesterday.
+        const today = new Date(); today.setHours(0, 0, 0, 0);
+        const anchor = new Date(today); anchor.setDate(anchor.getDate() - 7);
+        const isoLocal = (d) => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+        const got = api.nextRestockFromAnchor(isoLocal(anchor), 7);
+        if (got !== isoLocal(today)) {
+          errors.push(`nextRestockFromAnchor() returned ${got}, expected ${isoLocal(today)} (TZ=Europe/Kyiv) — a local/UTC mismatch.`);
+        }
+      } finally {
+        if (prevTZ === undefined) delete process.env.TZ; else process.env.TZ = prevTZ;
+      }
+      console.log('date helpers: correct under TZ=Europe/Kyiv, not just UTC');
+    }
+  }
+}
+
+// ── 6 · a queued Instagram ad can be approved ────────────────────────────────
+{
+  // Drives the real route against the status createAdRow really writes. The two
+  // were inconsistent for the whole life of the feature, and nothing that reads
+  // either file in isolation can tell.
+  const TOKEN = 'c'.repeat(40);
+  let row, published;
+  const envFor = (status) => {
+    published = 0;
+    row = { id: 'ad_x', image_path: 'marketing/instagram/ads/ad_x.jpg',
+            caption_path: 'marketing/instagram/ads/ad_x.txt', token: TOKEN, status };
+    return { ADMIN_KEY: 'k', GH_PAT: 'x', DB: { prepare(sql) { return {
+      _a: [],
+      bind(...a) { this._a = a; return this; },
+      async run() {
+        if (/^\s*ALTER TABLE/.test(sql)) throw new Error('duplicate column');
+        if (/UPDATE instagram_ads/.test(sql)) { row.status = sql.match(/status = '(\w+)'/)[1]; row.token = ''; }
+        return { success: true };
+      },
+      async first() { return /FROM instagram_ads WHERE id/.test(sql) ? (row.id === this._a[0] ? row : null) : null; },
+      async all() { return { results: [] }; },
+    }; } } };
+  };
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async () => { published++; return new Response(null, { status: 204 }); };
+  try {
+    const mod = await import('../worker/worker.js');
+    const tap = async (env) => mod.default.fetch(
+      new Request(`https://x/ad/approve?id=ad_x&t=${TOKEN}`), env, { waitUntil() {} });
+
+    // The status a real queued ad actually carries.
+    const statusInCode = /captionPath, token, '(\w+)'/.exec(fs.readFileSync('worker/worker.js', 'utf8'));
+    const created = statusInCode ? statusInCode[1] : '(not found)';
+    const env = envFor(created);
+    const res = await tap(env);
+    if (published === 0) {
+      errors.push(`/ad/approve does not publish an ad createAdRow created (status '${created}') — HTTP ${res.status} "${(await res.text()).slice(0, 40)}". The queue has no exit.`);
+    }
+    // A second tap of a spent link must not publish again.
+    const before = published;
+    await tap(env);
+    if (published > before) errors.push('/ad/approve published twice for one ad — the spent link is not inert.');
+
+    // An already-decided ad must be refused.
+    const decided = envFor('published');
+    await tap(decided);
+    if (published > before) errors.push('/ad/approve acted on an already-published ad.');
+
+    console.log(`ad approval: a '${created}' ad publishes once, re-taps and decided ads refused`);
+  } catch (e) {
+    errors.push(`ad approval check could not run: ${(e && e.message) || e}`);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+}
+
+// ── 7 · the bot ranks by day-in-cycle, not elapsed days ──────────────────────
+{
+  // Static, because cheapText() reaches for module-level STORES and Telegram
+  // helpers a stub cannot supply cheaply. The invariant is narrow enough to
+  // state as a shape: the restockDate branch must reduce modulo the cycle.
+  // Sliced rather than matched with a regex — the branch spans comment lines,
+  // and a pattern loose enough to survive editing them is loose enough to match
+  // the wrong block.
+  const i = bot.indexOf('if (s.restockDate) {');
+  if (i < 0) {
+    errors.push("telegram-bot/worker.js: cheapText's restockDate branch not found — this check needs updating.");
+  } else {
+    const branch = bot.slice(i, i + 900);
+    const modulo = /%\s*cyc\b/.test(branch) || /%\s*cycle\b/.test(branch);
+    if (!modulo) {
+      errors.push('telegram-bot/worker.js: cheapText reports elapsed days since the restock anchor without reducing modulo the cycle, which inverts its own "longest since a restock" ranking.');
+    } else {
+      console.log('bot ranking: day-in-cycle, reduced modulo the cycle');
+    }
   }
 }
 

--- a/scripts/check-wiring.mjs
+++ b/scripts/check-wiring.mjs
@@ -143,15 +143,23 @@ const errors = [];
   };
   try {
     const worker_mod = await import('../worker/worker.js');
+    // /api/sub is bot-only and ADMIN_KEY-gated, so the probe has to
+    // authenticate — otherwise it 401s before ensureSchema is ever reached and
+    // this check reports "0 of 19 statements", blaming the schema for an
+    // authorization change. That is exactly what happened when the gate landed.
+    const ADMIN_KEY = 'check-wiring-probe-key';
     const res = await worker_mod.default.fetch(
       new Request('https://x/api/sub', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Admin-Key': ADMIN_KEY },
         body: JSON.stringify({ storeId: 's10', chatId: '1' }),
       }),
-      { DB },
+      { DB, ADMIN_KEY },
       { waitUntil() {} },
     );
+    if (res.status === 401) {
+      errors.push('ensureSchema probe was rejected before reaching the schema — /api/sub\'s gate changed and this check needs its credentials updated.');
+    }
     if (res.status >= 500) {
       errors.push(`ensureSchema left the Worker answering HTTP ${res.status} on a D1 route.`);
     }

--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -133,6 +133,18 @@ async function metricsCall(env, path, init) {
 // this apart from a refusal and knows retrying is worth it.
 const METRICS_DOWN = '⚠️ Сервіс тимчасово недоступний — спробуйте ще раз за хвилину.\n'
   + '⚠️ The service is temporarily unavailable — please try again in a minute.';
+// Ukrainian counts take three forms, and 11–14 behave like "many" despite
+// ending 1–4. Same helper tools/social/stories.mjs and promo.mjs already carry;
+// the bot had none, which is why its day counts were written around rather than
+// declined.
+function plural(n, one, few, many) {
+  const d = n % 10, h = n % 100;
+  if (h >= 11 && h <= 14) return many;
+  if (d === 1) return one;
+  if (d >= 2 && d <= 4) return few;
+  return many;
+}
+
 const DAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
 const DAY_NAMES = { mon: 'Monday', tue: 'Tuesday', wed: 'Wednesday', thu: 'Thursday', fri: 'Friday', sat: 'Saturday', sun: 'Sunday' };
 // Same Ukrainian labels as scripts/build-store-pages.mjs's DAYS list — kept in
@@ -339,20 +351,22 @@ function cheapText() {
   if (!scored.length) return cheapEmpty();
   const blocks = scored
     .map(({ s, days }) => {
-      const label = days === 0 ? '🆕 Restocked today — full selection' : `🔥 ${days} day${days > 1 ? 's' : ''} since restock — deeper discounts`;
+      const label = days === 0
+        ? '🆕 Завіз сьогодні · Restocked today'
+        : `🔥 ${days} ${plural(days, 'день', 'дні', 'днів')} від завозу · ${days} day${days > 1 ? 's' : ''} since restock`;
       return storeBlock(s, label);
     })
     .join('\n\n');
   return featuredBlock() + [
     '💸 <b>Найдовше без завозу · Longest since a restock</b>',
-    'By-weight prices drop each day after a restock, so the stores furthest into their weekly cycle have the deepest discounts today:',
+    'Скільки днів минуло від останнього завозу. Карта не називає цін — вона рахує дні · Days since each store last restocked. The map counts days, not prices:',
     '',
     blocks,
   ].join('\n');
 }
 
 function cheapEmpty() {
-  return `No by-weight stores are tracked yet. Open the full map: ${APP_URL}`;
+  return `Поки немає даних про завози. · No restock dates tracked yet. Open the full map: ${APP_URL}`;
 }
 
 // Stores with a fixed weekly restock day — any day, not just today. This is a
@@ -431,7 +445,7 @@ function submitText() {
 // as bare /feedback already does.
 // ─────────────────────────────────────────────────────────────────────────────
 const MENU_DAY = '📅 За днем тижня';
-const MENU_CHEAP = '💰 Найдешевше зараз';
+const MENU_CHEAP = '🕒 Найдовше без завозу';
 const MENU_RARE = '🐢 Рідко оновлюють';
 const MENU_ADD = '➕ Додати магазин';
 const MENU_FEEDBACK = '💬 Залишити відгук';

--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -106,6 +106,17 @@ function metricsFetch(env, path, init) {
 //
 // Returning an explicit ok flag forces the caller to decide what to say when
 // the call did not happen. A 204 with no body is a success with data: null.
+// Headers for the metrics Worker's bot-only routes (/api/sub, /api/rsub,
+// /api/unsub-all). They are ADMIN_KEY-gated there because they act on a chat id
+// taken from the body, and this Worker is their only caller. Returns the plain
+// content-type alone when no key is configured, so the failure is a clean 401
+// from the Worker rather than a confusing half-authenticated request.
+function adminJsonHeaders(env) {
+  const h = { 'Content-Type': 'application/json' };
+  if (env.ADMIN_KEY) h['X-Admin-Key'] = env.ADMIN_KEY;
+  return h;
+}
+
 async function metricsCall(env, path, init) {
   try {
     const res = await metricsFetch(env, path, init);
@@ -684,7 +695,7 @@ async function handleFlashSubStart(env, ctx) {
   if (!/^[a-z0-9]{1,12}$/i.test(storeId)) return false;
   const store = STORES.find((s) => s.id === storeId);
   const saved = await metricsCall(env, '/api/sub', {
-    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    method: 'POST', headers: adminJsonHeaders(env),
     body: JSON.stringify({ storeId, chatId }),
   });
   if (!saved.ok) {
@@ -774,7 +785,7 @@ async function handleRestockSubStart(env, ctx) {
   }
 
   const saved = await metricsCall(env, '/api/rsub', {
-    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    method: 'POST', headers: adminJsonHeaders(env),
     body: JSON.stringify({ storeId, chatId, name, next: pred.next, cycle: pred.cycle }),
   });
   if (!saved.ok) {
@@ -797,7 +808,7 @@ async function handleStopCommand(env, ctx) {
   const { chatId, text } = ctx;
   if (!/^\/stop\b/i.test(String(text || '').trim())) return false;
   const cleared = await metricsCall(env, '/api/unsub-all', {
-    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    method: 'POST', headers: adminJsonHeaders(env),
     body: JSON.stringify({ chatId }),
   });
   if (!cleared.ok) {

--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -308,8 +308,16 @@ function cheapText() {
         return { s, days: Math.round((Date.parse(today) - Date.parse(last)) / 86400000) };
       }
       if (s.restockDate) {
-        const days = Math.round((Date.parse(today) - Date.parse(s.restockDate)) / 86400000);
-        return days >= 0 ? { s, days } : null;
+        // Days INTO THE CURRENT CYCLE, not days since the anchor. Without the
+        // modulo this reported elapsed time since a fixed date, so a store that
+        // restocked today ranked as the longest without a restock: c72 and c84
+        // (cycle 7, anchor 2026-08-07) read "14 days" on 2026-08-21 and headed
+        // the list, while the app showed them at day 0 of 7. 19 of 25 dated
+        // stores were overstated. getDayInfo() in index.html does this right.
+        const raw = Math.round((Date.parse(today) - Date.parse(s.restockDate)) / 86400000);
+        if (raw < 0) return null;
+        const cyc = (s.cycle >= 1 && s.cycle <= 90) ? s.cycle : 7;
+        return { s, days: raw % cyc };
       }
       if (s.restockDay) return { s, days: (idx - DAYS.indexOf(s.restockDay) + 7) % 7 };
       return null;

--- a/tools/social/deals-image.mjs
+++ b/tools/social/deals-image.mjs
@@ -9,7 +9,7 @@
 //
 // The ranking mirrors telegram-bot/worker.js cheapText(): stores with a fixed
 // weekly restock day, ranked by how many days they are into their weekly cycle
-// (furthest in = deepest into the discount cycle today).
+// (furthest in = longest since that store last restocked).
 //
 // It carries NO prices, so nothing here may claim any. Per-kilogram rates differ
 // per store and move with the exchange rate, so a figure baked into a JPEG is
@@ -47,7 +47,8 @@ const dateEN = new Intl.DateTimeFormat('en-GB',
   { timeZone: 'Europe/Kyiv', weekday: 'long', day: 'numeric', month: 'long' }).format(new Date());
 
 const esc = (t) => String(t).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-// Heat: more days into the cycle → hotter (cheaper). 0 days = fresh (green).
+// Heat: more days since the last restock → hotter. 0 days = fresh (green).
+// Days, not prices: the map holds no per-kilogram cost and cannot claim one.
 const heat = (d) => d === 0 ? '#1b7a45' : ['#c98a00', '#d97706', '#e0590a', '#dc4a1e', '#dc2626', '#c81e1e'][Math.min(d, 6) - 1] || '#dc2626';
 // Paid sponsored slot (clearly labelled). Rotates daily if several are featured.
 const activeP = (s) => (s.promo && (!s.promo.until || new Date(s.promo.until + 'T23:59:59') >= new Date())) ? s.promo : null;
@@ -104,7 +105,7 @@ const page_html = `<!doctype html><html><head><meta charset="utf-8"><style>
     <h1>Longest since a restock
       <span class="ua">Найдовше без завозу</span></h1>
     <div class="list">${rows || "<div class='row'><div class='info'><div class='name'>Open the map for today's stores</div></div></div>"}</div>
-    <div class="foot"><span>Deepest into the discount cycle today · Найглибше в циклі знижок</span>
+    <div class="foot"><span>Найдовше без завозу · Longest since a restock</span>
       <span><b>www.lvivsecondhand.com</b></span></div>
   </div>
 </body></html>`;

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1576,6 +1576,16 @@ export default {
       return json({ ok: true, ...made }, 200, origin);
     }
     if (url.pathname === '/api/sub') {
+      // Bot-only: the Telegram Worker is the sole caller, over a service
+      // binding. Gated on ADMIN_KEY because these write and delete another
+      // person's subscriptions from a chat id supplied in the body, and
+      // Telegram chat ids are enumerable integers — ungated, /api/unsub-all
+      // let anyone unsubscribe anyone from everything, and its siblings let
+      // anyone subscribe an arbitrary chat. Same header gate as
+      // /api/ad/register; the browser never calls any of the three.
+      if (!env.ADMIN_KEY || !safeEqual(request.headers.get('X-Admin-Key') || '', env.ADMIN_KEY)) {
+        return json({ ok: false, reason: 'unauthorized' }, 401, origin);
+      }
       const storeId = body && body.storeId;
       const chatId = body && body.chatId;
       if (typeof storeId !== 'string' || !/^[a-z0-9]{1,12}$/i.test(storeId)
@@ -1591,6 +1601,16 @@ export default {
     // data and posts them here, because this Worker has the D1 binding and the
     // bot has the store list — neither has both.
     if (url.pathname === '/api/rsub') {
+      // Bot-only: the Telegram Worker is the sole caller, over a service
+      // binding. Gated on ADMIN_KEY because these write and delete another
+      // person's subscriptions from a chat id supplied in the body, and
+      // Telegram chat ids are enumerable integers — ungated, /api/unsub-all
+      // let anyone unsubscribe anyone from everything, and its siblings let
+      // anyone subscribe an arbitrary chat. Same header gate as
+      // /api/ad/register; the browser never calls any of the three.
+      if (!env.ADMIN_KEY || !safeEqual(request.headers.get('X-Admin-Key') || '', env.ADMIN_KEY)) {
+        return json({ ok: false, reason: 'unauthorized' }, 401, origin);
+      }
       const storeId = body && body.storeId;
       const chatId = body && body.chatId;
       if (typeof storeId !== 'string' || !/^[a-z0-9]{1,12}$/i.test(storeId)
@@ -1614,6 +1634,16 @@ export default {
       return new Response(null, { status: 204, headers: cors(origin) });
     }
     if (url.pathname === '/api/unsub-all') {
+      // Bot-only: the Telegram Worker is the sole caller, over a service
+      // binding. Gated on ADMIN_KEY because these write and delete another
+      // person's subscriptions from a chat id supplied in the body, and
+      // Telegram chat ids are enumerable integers — ungated, /api/unsub-all
+      // let anyone unsubscribe anyone from everything, and its siblings let
+      // anyone subscribe an arbitrary chat. Same header gate as
+      // /api/ad/register; the browser never calls any of the three.
+      if (!env.ADMIN_KEY || !safeEqual(request.headers.get('X-Admin-Key') || '', env.ADMIN_KEY)) {
+        return json({ ok: false, reason: 'unauthorized' }, 401, origin);
+      }
       const chatId = body && body.chatId;
       if (typeof chatId !== 'string' && typeof chatId !== 'number') {
         return new Response('bad request', { status: 400, headers: cors(origin) });

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -113,7 +113,7 @@ async function ensureSchema(env) {
   // rendered by a GitHub Action (Workers cannot rasterize) at a path derived
   // from the id, so no callback is needed to learn where it landed.
   await env.DB.prepare(
-    "CREATE TABLE IF NOT EXISTS instagram_ads (id TEXT PRIMARY KEY, store_id TEXT NOT NULL, ad_text TEXT NOT NULL, tier TEXT NOT NULL DEFAULT '', image_path TEXT NOT NULL, caption_path TEXT NOT NULL, token TEXT NOT NULL DEFAULT '', status TEXT NOT NULL DEFAULT 'rendering', created TEXT NOT NULL DEFAULT (datetime('now')), decided TEXT)"
+    "CREATE TABLE IF NOT EXISTS instagram_ads (id TEXT PRIMARY KEY, store_id TEXT NOT NULL, ad_text TEXT NOT NULL, tier TEXT NOT NULL DEFAULT '', image_path TEXT NOT NULL, caption_path TEXT NOT NULL, token TEXT NOT NULL DEFAULT '', status TEXT NOT NULL DEFAULT 'pending', created TEXT NOT NULL DEFAULT (datetime('now')), decided TEXT)"
   ).run();
   // Older rows predate the per-ad token. Same try/catch shape as the promos
   // ALTER above (SQLite has no ADD COLUMN IF NOT EXISTS), deliberately, rather
@@ -355,7 +355,7 @@ async function createAdRow(env, { storeId, text, tier }) {
   const captionPath = `marketing/instagram/ads/${id}.txt`;
   await env.DB.prepare(
     'INSERT INTO instagram_ads (id, store_id, ad_text, tier, image_path, caption_path, token, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
-  ).bind(id, storeId, text, tier || '', imagePath, captionPath, token, 'rendering').run();
+  ).bind(id, storeId, text, tier || '', imagePath, captionPath, token, 'pending').run();
   return { id, token, imagePath, captionPath };
 }
 
@@ -650,7 +650,7 @@ async function applyFlashDealEvent(env, ev, ctx) {
   }
 
   // A paid flash deal also queues an Instagram advertisement. Queued, not
-  // posted: it lands in instagram_ads as 'rendering' and reaches the feed only
+  // posted: it lands in instagram_ads as 'pending' and reaches the feed only
   // if the owner approves it, which is deliberately a separate decision from
   // approving the deal for the map — the same words can be fine on a store
   // page and wrong on a public feed.
@@ -1249,7 +1249,17 @@ export default {
         // Idempotent: tapping an old link twice, or after deciding, says so
         // rather than double-posting. Telegram link previews can and do fetch
         // these URLs, so a second GET must never be a second publish.
-        if (row.status !== 'pending') return new Response(`already ${row.status}`, { status: 200 });
+        //
+        // Tested for DECIDED, not for 'pending'. The previous form demanded
+        // 'pending' while createAdRow wrote 'rendering' and nothing ever
+        // transitioned between them, so every approve tap on every real ad
+        // returned 200 "already rendering" and published nothing — the whole
+        // paid-ad queue had no exit. Checking the decided states instead also
+        // means rows created before this fix stay approvable, with no data
+        // migration on a path that runs per request.
+        if (row.status === 'published' || row.status === 'rejected') {
+          return new Response(`already ${row.status}`, { status: 200 });
+        }
 
         // Single use: the token is cleared on decision, so a link that leaks
         // later — from a forward, a screenshot, a synced chat backup — cannot


### PR DESCRIPTION
Acts on the review at [`585dd6b8`](https://claude.ai/code/artifact/585dd6b8-bf77-4a71-b939-fd80ab089f37). Four commits, in the order the plan set: fixes, then the checks that would have caught them, then hardening, then copy. Every commit is green on its own.

The 17 unverified leads from the review are **not** touched — acting on an unreproduced finding is how you get a confident fix for a bug that was never there.

---

## 1 · The three criticals — `52c991f`

**The paid-ad queue had no exit.** `createAdRow` wrote status `'rendering'` while `/ad/approve` demanded `'pending'`, and nothing transitioned between them. Every approve tap on every real ad returned `200 "already rendering"` and published nothing — a store could pay, the ad could render, commit and reach Telegram, and the link did nothing.

`createAdRow` now writes `'pending'`, and the guard tests for a **decided** status rather than for `'pending'`. Testing decided-ness also keeps pre-fix rows approvable, so no data migration runs on a per-request path. The token burn already provided the idempotency the status check was nominally for.

**The bot inverted its own ranking.** `cheapText()` reported elapsed days since the anchor instead of days into the cycle. c72 and c84 (cycle 7, anchor 2026-08-07) read "14 days" on 2026-08-21 and headed the "longest since a restock" list while the app showed them at day 0 of 7. **19 of 25** dated stores were overstated.

**`weekdayOf()` was off by one for every date**, applying a Monday-first transform to a Sunday-first array — so an owner submission naming a restock weekday named the day before. Also fixes `nextRestockFromAnchor()`, which normalised to *local* midnight then serialised with `toISOString()` (UTC), returning yesterday for every user in Kyiv while being correct in CI.

## 2 · The harnesses, kept — `f0c86c6`

All three were found by throwaway scripts. `check-wiring.mjs` already exists for exactly this and already executes `ensureSchema` against a stub, so it gains three checks:

| | |
| --- | --- |
| **5** | The date helpers, pulled out of the inline `<script>` and **run under `TZ=Europe/Kyiv`** — a check that never leaves UTC cannot see that class of bug |
| **6** | Reads the status `createAdRow` really writes and drives the real `/ad/approve` with it, so it fails whenever the two disagree — the invariant, not a hardcoded value |
| **7** | The bot's `restockDate` branch must reduce modulo the cycle |

Each was verified by reintroducing its bug and confirming it fails. Check 6 needed **both** halves of its fix reverted before it fired — correct, since with the guard testing decided-ness a stale status alone is no longer fatal.

## 3 · Two holes closed — `8c6a943`

`/api/unsub-all` took an arbitrary `chatId` with no authentication and deleted that chat's rows from both subscription tables. Chat ids are enumerable integers; the only barrier was a per-IP rate limit. Confirmed against production, which answered `204` to a request carrying no credentials. `/api/sub` and `/api/rsub` are the same shape in reverse.

All three are bot-only — the browser's similar-looking fetches go to `/api/submit` — so all three now take the `X-Admin-Key` gate `/api/ad/register` uses.

`android-release.yml` pasted `version_name`/`version_code` into `sed` inside `run:`, in the one job holding the keystore and both signing passwords. Both now travel by `env` and are shape-checked first.

## 4 · The price sweep, finished — `f3e463c`

Five surviving claims in the bot and on the public deals post, including `💰 Найдешевше зараз` on the menu and *"Deepest into the discount cycle today"* on the Instagram image. Also adds the three-form Ukrainian plural helper the bot lacked.

---

## Verification

Everything below was **executed**, not read.

| | |
| --- | --- |
| Date helpers | `weekdayOf` correct for 4 dates, `nextRestockFromAnchor` correct — under **both** `TZ=UTC` and `TZ=Europe/Kyiv` |
| Ad approval | queued ad publishes once · spent link inert · legacy `'rendering'` row still approvable · decided ad refused |
| Bot ranking | re-checked against `stores.json`; the 19 overstated stores now report in-cycle |
| Subscription gate | all three routes: no key → `401` no write · wrong-but-right-length key → `401` no write · correct key → `204` write |
| Android inputs | accepts `7`/`1.0.0`, `12`/`2.1`; refuses an injected keystore read, `1.0/beta`, an appended `curl`, and an empty code |
| Plurals | 1 день · 2 дні · 5 днів · 11 днів · 21 день · 22 дні |
| Regression checks | each new check fails on its reintroduced bug, then restored |

Full gate green: `validate-stores`, `check-inline-js`, `check-wiring` (7/7), `node --check` on both Workers, `build-data`, and `store/ chain/ qr/ sitemap.xml` regenerate identically.

## One thing raised, not done

`index.html` has ten further price-flavoured matches — the meta description's *"коли найдешевше"*, the pin-colour legend's *"price cycle"*, and the help text explaining what by-the-kilogram pricing is. Those describe the domain and carry the product's positioning and SEO copy. Rewriting them is a decision about what the app claims to be, not a review fix, so it's your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_