### PR TITLE
Correct c27's opening hours from the photographed sign

### DIFF
--- a/store/c27/index.html
+++ b/store/c27/index.html
@@ -39,38 +39,44 @@
     {
       "@type": "OpeningHoursSpecification",
       "dayOfWeek": "https://schema.org/Monday",
-      "opens": "10:00",
+      "opens": "09:00",
       "closes": "19:00"
     },
     {
       "@type": "OpeningHoursSpecification",
       "dayOfWeek": "https://schema.org/Tuesday",
-      "opens": "10:00",
+      "opens": "09:00",
       "closes": "19:00"
     },
     {
       "@type": "OpeningHoursSpecification",
       "dayOfWeek": "https://schema.org/Wednesday",
-      "opens": "10:00",
-      "closes": "19:00"
+      "opens": "09:00",
+      "closes": "12:30"
     },
     {
       "@type": "OpeningHoursSpecification",
       "dayOfWeek": "https://schema.org/Thursday",
-      "opens": "10:00",
+      "opens": "09:00",
       "closes": "19:00"
     },
     {
       "@type": "OpeningHoursSpecification",
       "dayOfWeek": "https://schema.org/Friday",
-      "opens": "10:00",
+      "opens": "09:00",
       "closes": "19:00"
     },
     {
       "@type": "OpeningHoursSpecification",
       "dayOfWeek": "https://schema.org/Saturday",
+      "opens": "09:00",
+      "closes": "18:00"
+    },
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": "https://schema.org/Sunday",
       "opens": "10:00",
-      "closes": "19:00"
+      "closes": "17:00"
     }
   ],
   "isPartOf": {
@@ -129,18 +135,18 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
   <h2>Години роботи</h2>
   <table>
     <tbody>
-      <tr><th scope="row">Понеділок</th><td>10:00–19:00</td></tr>
-      <tr><th scope="row">Вівторок</th><td>10:00–19:00</td></tr>
-      <tr><th scope="row">Середа</th><td>10:00–19:00</td></tr>
-      <tr><th scope="row">Четвер</th><td>10:00–19:00</td></tr>
-      <tr><th scope="row">П’ятниця</th><td>10:00–19:00</td></tr>
-      <tr><th scope="row">Субота</th><td>10:00–19:00</td></tr>
-      <tr><th scope="row">Неділя</th><td>Зачинено</td></tr>
+      <tr><th scope="row">Понеділок</th><td>09:00–19:00</td></tr>
+      <tr><th scope="row">Вівторок</th><td>09:00–19:00</td></tr>
+      <tr><th scope="row">Середа</th><td>09:00–12:30</td></tr>
+      <tr><th scope="row">Четвер</th><td>09:00–19:00</td></tr>
+      <tr><th scope="row">П’ятниця</th><td>09:00–19:00</td></tr>
+      <tr><th scope="row">Субота</th><td>09:00–18:00</td></tr>
+      <tr><th scope="row">Неділя</th><td>10:00–17:00</td></tr>
     </tbody>
   </table>
 
   <h2>Примітки</h2>
-  <p class="note">By weight. Restocked Thursdays.</p>
+  <p class="note">By weight. Restocked Thursdays. Hours photographed on the door 2026-08-21 (issue #270): opens 09:00 daily, Wed closes 12:30, Sat 18:00, Sun 10:00–17:00.</p>
 
   <h2>Інші магазини мережі Євро Тренд Секонд хенд</h2>
   <ul class="links">

--- a/stores.json
+++ b/stores.json
@@ -962,19 +962,19 @@
     "type": "other",
     "pricing": "kg",
     "hours": {
-      "mon": "10:00–19:00",
-      "tue": "10:00–19:00",
-      "wed": "10:00–19:00",
-      "thu": "10:00–19:00",
-      "fri": "10:00–19:00",
-      "sat": "10:00–19:00",
-      "sun": "closed"
+      "mon": "09:00–19:00",
+      "tue": "09:00–19:00",
+      "wed": "09:00–12:30",
+      "thu": "09:00–19:00",
+      "fri": "09:00–19:00",
+      "sat": "09:00–18:00",
+      "sun": "10:00–17:00"
     },
     "cycle": 7,
     "restockDay": "thu",
     "lat": 49.845323,
     "lng": 24.023052,
-    "note": "By weight. Restocked Thursdays."
+    "note": "By weight. Restocked Thursdays. Hours photographed on the door 2026-08-21 (issue #270): opens 09:00 daily, Wed closes 12:30, Sat 18:00, Sun 10:00–17:00."
   },
   {
     "id": "c28",


### PR DESCRIPTION
Closes #270.

You reported c27's hours were wrong and photographed the sign on the door. All **seven** days were wrong, and two of them were sending people to a closed shop:

| day | map said | sign says |
| --- | --- | --- |
| Пн | 10:00–19:00 | 09:00–19:00 |
| Вт | 10:00–19:00 | 09:00–19:00 |
| **Ср** | 10:00–19:00 | **09:00–12:30** |
| Чт | 10:00–19:00 | 09:00–19:00 |
| Пт | 10:00–19:00 | 09:00–19:00 |
| Сб | 10:00–19:00 | 09:00–18:00 |
| **Нд** | **closed** | **10:00–17:00** |

The map turned people away on Sundays for a shop that opens 10:00–17:00, and sent them on a Wednesday afternoon to a door that shuts at 12:30.

The sign lists days starting Thursday, but every row is labelled, so there's no ambiguity about the mapping.

## Why this isn't taken from #272

The #272 contribution batch also lists c27 — and restates these hours **byte-identical to the wrong ones already on the map**. Applying that batch would have silently reverted this fix. Worth knowing before #272 is actioned.

## Notes

- Provenance is recorded in the store's `note`. "Someone photographed the door" is stronger evidence than most rows on this map have, and it should survive the next bulk edit rather than being overwritten by a lower-confidence source.
- `restockDay` stays `thu` — the sign says nothing about deliveries.
- Times use the en dash and zero-padded hours, matching every other row.

## Verification

- `validate-stores.mjs` — 132 stores, no duplicate ids
- `build-data.mjs`, `build-store-pages.mjs`, `build-qr-posters.mjs` regenerated; `store/c27/index.html` now shows Неділя 10:00–17:00 and Середа 09:00–12:30, with zero `closed` markers
- `check-inline-js.mjs`, `check-wiring.mjs` (7/7) green
- Diff touches only `stores.json` and c27's generated page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_