### PR TITLE
Approve in Telegram, ship to the map: itemised review + unattended apply

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# SessionStart hook — Claude Code on the web.
+#
+# Exists because of one specific failure: the remote container re-clones this
+# repo at a stale commit AND carries a stale origin ref, so `git status` and
+# `git log origin/main` both report the checkout as current when it is dozens
+# of commits behind. Work then gets built on old data — during one session that
+# produced a store id that was already taken on the real main.
+#
+# The fix is a forced fetch before any of that is trusted, then a loud report.
+# It deliberately does NOT reset or checkout anything: a session may legitimately
+# start on a feature branch, and discarding someone's work to "fix" freshness
+# would be far worse than the problem.
+set -uo pipefail
+
+# Local runs clone normally and don't have the stale-ref problem.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || echo .)}" || exit 0
+
+say() { printf '%s\n' "$*"; }
+
+# ── 1. Repo freshness ───────────────────────────────────────────────────────
+if git rev-parse --git-dir >/dev/null 2>&1; then
+  # --force because the stale ref is the thing being corrected; without it a
+  # non-fast-forward remote ref is silently left at its old value.
+  if ! git fetch --force --prune --quiet origin 2>/dev/null; then
+    say "⚠️  SessionStart: could not reach origin. Treat all git state as unverified."
+  else
+    DEFAULT="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null)"
+    DEFAULT="${DEFAULT#origin/}"
+    [ -n "$DEFAULT" ] || DEFAULT=main
+
+    if git rev-parse --verify --quiet "origin/$DEFAULT" >/dev/null; then
+      BEHIND="$(git rev-list --count "HEAD..origin/$DEFAULT" 2>/dev/null || echo 0)"
+      AHEAD="$(git rev-list --count "origin/$DEFAULT..HEAD" 2>/dev/null || echo 0)"
+      BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
+
+      # A squash-merged branch is always "behind": its commit is not an
+      # ancestor of the squashed one even though its content is already in.
+      # An empty tree diff separates that harmless case from a genuinely stale
+      # checkout — and crying wolf on every merged branch would train everyone
+      # to scroll past the real warning.
+      if [ "$BEHIND" -gt 0 ] && git diff --quiet HEAD "origin/$DEFAULT" 2>/dev/null; then
+        say "✓ repo fresh — $BRANCH differs from origin/$DEFAULT in history only (squash merge); trees are identical"
+      elif [ "$BEHIND" -gt 0 ]; then
+        say ""
+        say "⚠️  ═══════════════════════════════════════════════════════════════"
+        say "⚠️  THIS CHECKOUT IS $BEHIND COMMIT(S) BEHIND origin/$DEFAULT"
+        say "⚠️"
+        say "⚠️    branch : $BRANCH  ($AHEAD ahead, $BEHIND behind)"
+        say "⚠️    HEAD   : $(git log -1 --format='%h %s' 2>/dev/null | cut -c1-70)"
+        say "⚠️    remote : $(git log -1 --format='%h %s' "origin/$DEFAULT" 2>/dev/null | cut -c1-70)"
+        say "⚠️"
+        say "⚠️  Do NOT trust file contents, store ids, or 'git status' until this"
+        say "⚠️  is resolved. On a branch with no unmerged work:"
+        say "⚠️    git checkout -B <branch> origin/$DEFAULT"
+        say "⚠️  With unmerged work, rebase onto it instead of resetting."
+        say "⚠️  ═══════════════════════════════════════════════════════════════"
+        say ""
+      else
+        say "✓ repo fresh — $BRANCH is up to date with origin/$DEFAULT ($AHEAD ahead)"
+      fi
+    fi
+  fi
+fi
+
+# ── 2. Deps that vanish when the container is re-provisioned ────────────────
+# Only tools/social needs any: the CI gates and both Workers are plain Node.
+# PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD stops npm pulling a browser build that would
+# not match the pre-baked one below.
+if [ -f tools/social/package.json ] && [ ! -d tools/social/node_modules ]; then
+  say "· installing tools/social dependencies…"
+  ( cd tools/social && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install --no-audit --no-fund --silent ) \
+    && say "✓ tools/social ready" \
+    || say "⚠️  tools/social npm install failed — image generation will not run"
+fi
+
+# ── 3. Resolve the pre-baked Chromium once ─────────────────────────────────
+# PLAYWRIGHT_BROWSERS_PATH points at a directory of versioned builds, not at a
+# binary, and the unversioned path that looks obvious does not exist. Export the
+# real one so nothing has to go looking for it mid-session.
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  CHROME="$(find "${PLAYWRIGHT_BROWSERS_PATH:-/opt/pw-browsers}" -maxdepth 3 -type f -name chrome 2>/dev/null | head -1)"
+  if [ -n "$CHROME" ]; then
+    echo "export CHROMIUM_BIN=\"$CHROME\"" >> "$CLAUDE_ENV_FILE"
+    say "✓ CHROMIUM_BIN=$CHROME"
+  fi
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,15 @@ jobs:
       - name: Check cross-system wiring
         run: node scripts/check-wiring.mjs
 
+      # The automated map-patch path had never run in production, and the first
+      # real dispatch would have reformatted all 130 records — the applier wrote
+      # stores.json with indent 1 while every other writer uses 2. This drives
+      # the applier as a subprocess against a fixture, the same way the workflow
+      # invokes it, and asserts both that formatting survives and that fill-gaps
+      # mode never overwrites a value already on the map.
+      - name: Check the map-patch pipeline
+        run: node scripts/check-map-patch.mjs
+
       # The per-store pages and sitemap are generated from stores.json but
       # committed (GitHub Pages serves the repo root, so the files ARE the
       # deploy). Regenerate and fail if the committed output differs — that

--- a/.github/workflows/update-map.yml
+++ b/.github/workflows/update-map.yml
@@ -23,6 +23,8 @@ concurrency:
 
 permissions:
   contents: write
+  # Only used to raise an issue for the fields this run declined to apply.
+  issues: write
 
 jobs:
   patch:
@@ -41,6 +43,8 @@ jobs:
       # nested/quoted JSON survives without shell-escaping surprises.
       - name: Apply patch
         run: node scripts/apply-map-patch.mjs
+        env:
+          PATCH_REPORT_FILE: ${{ runner.temp }}/patch-report.json
 
       # Step 2 — schema gate. Aborts the whole run (nothing committed) if the
       # patch produced anything the app can't safely render: broken JSON,
@@ -66,6 +70,8 @@ jobs:
       # the deploy. Skips cleanly if the patch was a no-op (e.g. updates
       # matched the existing values).
       - name: Commit
+        env:
+          REPORT: ${{ runner.temp }}/patch-report.json
         run: |
           git config user.name "lviv-secondhand-bot"
           git config user.email "actions@users.noreply.github.com"
@@ -74,6 +80,73 @@ jobs:
             echo "No changes after patch — nothing to commit."
             exit 0
           fi
-          STORE_ID=$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.env.GITHUB_EVENT_PATH,'utf8')).client_payload.store_id)")
-          git commit -m "Auto-update store ${STORE_ID} [skip ci]"
+          # Names the stores actually touched, taken from the applier's report
+          # rather than the payload — a batch has no single store_id, and a
+          # fill-gaps run may have applied to fewer stores than were proposed.
+          SUBJECT=$(node -e "
+            const r = require(process.env.REPORT);
+            const hit = (r.stores || []).filter(x => Object.keys(x.applied || {}).length).map(x => x.store_id);
+            console.log(hit.length === 1 ? 'store ' + hit[0]
+              : hit.length ? hit.length + ' stores (' + hit.join(', ') + ')'
+              : 'map data');
+          ")
+          git commit -m "Auto-update ${SUBJECT} [skip ci]"
           git push
+
+      # Anything the patch declined — a value that disagrees with one already on
+      # the map, or a store the map doesn't hold — is raised for a person. This
+      # is what keeps unattended application honest: the safe part lands without
+      # anyone reading it, and only the genuine judgment calls become an issue.
+      # Runs even when the commit step found nothing to commit, since a run can
+      # legitimately apply nothing and still have declines worth seeing.
+      - name: Raise anything that needs a decision
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPORT: ${{ runner.temp }}/patch-report.json
+        run: |
+          [ -f "$REPORT" ] || { echo "No report written — nothing to raise."; exit 0; }
+          COUNT=$(node -e "const r=require('$REPORT');console.log((r.needsReview||[]).length)")
+          if [ "$COUNT" = "0" ]; then
+            echo "Nothing declined — no issue needed."
+            exit 0
+          fi
+          node -e "
+            const r = require('$REPORT');
+            const L = [];
+            L.push('An automated map patch applied what it safely could and declined the rest.');
+            L.push('');
+            L.push('Declined values are **not** errors — they are places where a contribution');
+            L.push('disagrees with something already on the map, which is a judgment call.');
+            L.push('');
+            for (const s of r.needsReview) {
+              if (s.missing) {
+                L.push('### `' + s.store_id + '` — not on the map');
+                L.push('');
+                L.push('A patch referenced this id but no such store exists. It needs adding by hand,');
+                L.push('or the contribution is pointing at the wrong store.');
+                L.push('');
+                continue;
+              }
+              L.push('### `' + s.store_id + '`');
+              L.push('');
+              L.push('| field | on the map | proposed | why declined |');
+              L.push('|---|---|---|---|');
+              for (const k of s.skipped) {
+                L.push('| `' + k.field + '` | ' + JSON.stringify(k.have) + ' | ' + JSON.stringify(k.proposed) + ' | ' + k.why + ' |');
+              }
+              L.push('');
+            }
+            const applied = (r.stores || []).filter(x => Object.keys(x.applied || {}).length);
+            if (applied.length) {
+              L.push('---');
+              L.push('');
+              L.push('Applied without review: ' + applied.map(x => '`' + x.store_id + '` (' + Object.keys(x.applied).join(', ') + ')').join(', '));
+            }
+            require('fs').writeFileSync(process.env.RUNNER_TEMP + '/issue.md', L.join('
+'));
+          "
+          gh issue create \
+            --title "Map patch declined ${COUNT} change(s) that need a decision" \
+            --body-file "${RUNNER_TEMP}/issue.md" \
+            --label map-contribution

--- a/scripts/apply-map-patch.mjs
+++ b/scripts/apply-map-patch.mjs
@@ -1,19 +1,31 @@
 #!/usr/bin/env node
-// Step 1 of .github/workflows/update-map.yml: applies a single { store_id,
-// updates } patch (from the repository_dispatch client_payload) to the
-// matching entry in stores.json. Deep-merges plain objects (so a patch can
-// touch just s.hours.mon without clobbering the rest of s.hours); arrays and
-// primitives are replaced outright.
+// Step 1 of .github/workflows/update-map.yml: applies a { store_id, updates }
+// patch (from the repository_dispatch client_payload) to the matching entry in
+// stores.json. Deep-merges plain objects (so a patch can touch just s.hours.mon
+// without clobbering the rest of s.hours); arrays and primitives are replaced.
 //
-// Reads the event payload from GITHUB_EVENT_PATH (the JSON file Actions
-// writes for every run) rather than a workflow-expression env var, so
-// nested/quoted JSON in `updates` can't be mangled by shell interpolation.
+// Reads the event payload from GITHUB_EVENT_PATH (the JSON file Actions writes
+// for every run) rather than a workflow-expression env var, so nested/quoted
+// JSON in `updates` can't be mangled by shell interpolation.
+//
+// Two modes:
+//   (default)    overwrite — the patch wins. Used by flows where a human has
+//                already confirmed the value: the bot's store survey, and
+//                /restock/approve.
+//   'fill-gaps'  only writes where the map currently holds nothing, plus a
+//                strictly-newer restock_date. Used for contributions approved
+//                in bulk, where "the map has no phone number and someone sent
+//                one" is safe to apply unattended but "someone disagrees with
+//                a value we already hold" is a judgment call. Anything skipped
+//                is reported so it can be raised for a human instead.
 import { readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 const here = dirname(fileURLToPath(import.meta.url));
-const storesPath = resolve(here, '..', 'stores.json');
+// STORES_PATH lets the test harness point this at a fixture instead of the
+// real dataset; unset everywhere else, so the workflow always hits stores.json.
+const storesPath = process.env.STORES_PATH || resolve(here, '..', 'stores.json');
 
 function isPlainObject(v) {
   return v !== null && typeof v === 'object' && !Array.isArray(v);
@@ -26,6 +38,57 @@ function deepMerge(target, patch) {
   return target;
 }
 
+// What counts as "the map holds nothing here". '?' is the dataset's own
+// placeholder for an unknown opening time, so it is a gap, not a value.
+function isGap(v) {
+  return v === undefined || v === null || v === '' || v === '?';
+}
+
+// Applies only what can't contradict something already recorded. Returns the
+// fields written and the fields declined, each with a reason, so the caller can
+// escalate the declines rather than dropping them silently.
+export function applyFillGaps(store, updates) {
+  const applied = {};
+  const skipped = [];
+  for (const [k, v] of Object.entries(updates)) {
+    if (k === 'hours' && isPlainObject(v)) {
+      const days = {};
+      for (const [d, t] of Object.entries(v)) {
+        if (isGap(t)) continue;
+        if (isGap(store.hours ? store.hours[d] : undefined)) days[d] = t;
+        else if (String(store.hours[d]) !== String(t)) {
+          skipped.push({ field: `hours.${d}`, have: store.hours[d], proposed: t, why: 'would overwrite a recorded value' });
+        }
+      }
+      if (Object.keys(days).length) {
+        store.hours = Object.assign({}, store.hours, days);
+        applied.hours = days;
+      }
+      continue;
+    }
+    if (isGap(v)) continue;
+    // A proposed `false` on a flag the store doesn't set asserts nothing: absent
+    // and false already behave identically everywhere that reads them, so
+    // recording it would only add a field. If the store has the flag ON, then
+    // proposing false IS a real change and falls through to the decline below.
+    if (v === false && isGap(store[k])) continue;
+    // A restock observation is the one field where newer genuinely wins: the
+    // map wants the most recent delivery, and ISO dates compare as strings.
+    if (k === 'restock_date') {
+      if (isGap(store[k]) || String(v) > String(store[k])) { store[k] = v; applied[k] = v; }
+      else if (String(v) !== String(store[k])) {
+        skipped.push({ field: k, have: store[k], proposed: v, why: 'older than the date on record' });
+      }
+      continue;
+    }
+    if (isGap(store[k])) { store[k] = v; applied[k] = v; continue; }
+    if (String(store[k]) !== String(v)) {
+      skipped.push({ field: k, have: store[k], proposed: v, why: 'would overwrite a recorded value' });
+    }
+  }
+  return { applied, skipped };
+}
+
 function main() {
   const eventPath = process.env.GITHUB_EVENT_PATH;
   if (!eventPath) throw new Error('GITHUB_EVENT_PATH is not set — this script must run inside a GitHub Actions job.');
@@ -33,20 +96,73 @@ function main() {
   const payload = event.client_payload;
   if (!payload || typeof payload !== 'object') throw new Error('Event has no client_payload.');
 
-  const { store_id: storeId, updates } = payload;
-  if (!storeId || typeof storeId !== 'string') throw new Error('client_payload.store_id is required.');
-  if (!isPlainObject(updates)) throw new Error('client_payload.updates must be a plain object.');
-  // id is the store's identity — a patch is never allowed to reassign it.
-  if ('id' in updates) throw new Error('updates must not include "id" — it identifies which store to patch.');
+  const { mode } = payload;
+  // Two accepted shapes. The original single patch — { store_id, updates } —
+  // is what the bot survey and /restock/approve still send. A batch —
+  // { patches: [{ store_id, updates }] } — lets one approved contribution
+  // touching a dozen stores be one workflow run, one commit and one report,
+  // instead of a dozen runs queued behind each other each opening its own issue.
+  const batch = Array.isArray(payload.patches)
+    ? payload.patches
+    : [{ store_id: payload.store_id, updates: payload.updates }];
+  if (!batch.length) throw new Error('client_payload carried no patches.');
 
-  const stores = JSON.parse(readFileSync(storesPath, 'utf8'));
+  const raw = readFileSync(storesPath, 'utf8');
+  const stores = JSON.parse(raw);
   if (!Array.isArray(stores)) throw new Error('stores.json is not an array.');
-  const idx = stores.findIndex((s) => s && s.id === storeId);
-  if (idx === -1) throw new Error(`No store with id "${storeId}" in stores.json.`);
 
-  deepMerge(stores[idx], updates);
-  writeFileSync(storesPath, JSON.stringify(stores, null, 1) + '\n');
-  console.log(`Patched store "${storeId}":`, JSON.stringify(updates));
+  const results = [];
+  for (const item of batch) {
+    const storeId = item && item.store_id;
+    const updates = item && item.updates;
+    if (!storeId || typeof storeId !== 'string') throw new Error('each patch needs a string store_id.');
+    if (!isPlainObject(updates)) throw new Error(`patch for "${storeId}": updates must be a plain object.`);
+    // id is the store's identity — a patch is never allowed to reassign it.
+    if ('id' in updates) throw new Error('updates must not include "id" — it identifies which store to patch.');
+
+    const idx = stores.findIndex((s) => s && s.id === storeId);
+    if (idx === -1) {
+      // In fill-gaps mode an unknown id is a fact to report, not a crash: a
+      // contribution can legitimately mention a store the map doesn't hold yet,
+      // and failing the whole batch would discard the patches that were fine.
+      // The overwrite callers pass ids they just read out of stores.json, so
+      // there it still means something is genuinely wrong.
+      if (mode === 'fill-gaps') {
+        results.push({ store_id: storeId, applied: {}, skipped: [], missing: true });
+        console.log(`Store "${storeId}" is not on the map — reported, not applied.`);
+        continue;
+      }
+      throw new Error(`No store with id "${storeId}" in stores.json.`);
+    }
+
+    if (mode === 'fill-gaps') {
+      const r = applyFillGaps(stores[idx], updates);
+      results.push({ store_id: storeId, ...r });
+      console.log(`Patched store "${storeId}" (fill-gaps): applied ${JSON.stringify(r.applied)}`);
+      if (r.skipped.length) console.log(`  declined ${r.skipped.length} field(s): ${JSON.stringify(r.skipped)}`);
+    } else {
+      deepMerge(stores[idx], updates);
+      results.push({ store_id: storeId, applied: updates, skipped: [] });
+      console.log(`Patched store "${storeId}":`, JSON.stringify(updates));
+    }
+  }
+  const report = {
+    mode: mode || 'overwrite',
+    stores: results,
+    // What a human still has to look at.
+    needsReview: results.filter((r) => r.missing || (r.skipped && r.skipped.length)),
+  };
+
+  // Indent 2 — stores.json is written with 2 everywhere else (the generators,
+  // and every hand edit). Writing 1 here reformatted all 130 records on the
+  // first automated patch, burying a one-field change in a whole-file diff.
+  writeFileSync(storesPath, JSON.stringify(stores, null, 2) + '\n');
+
+  if (process.env.PATCH_REPORT_FILE) {
+    writeFileSync(process.env.PATCH_REPORT_FILE, JSON.stringify(report, null, 2) + '\n');
+  }
 }
 
-main();
+// Importable for the test harness; only runs the workflow path when executed
+// with an Actions event present.
+if (process.env.GITHUB_EVENT_PATH) main();

--- a/scripts/apply-map-patch.mjs
+++ b/scripts/apply-map-patch.mjs
@@ -89,6 +89,70 @@ export function applyFillGaps(store, updates) {
   return { applied, skipped };
 }
 
+// Metres between two pins. Only used to spot an addition landing on top of a
+// store already on the map.
+function metresBetween(a, b) {
+  const t = Math.PI / 180;
+  const dLat = (b.lat - a.lat) * t, dLng = (b.lng - a.lng) * t;
+  const h = Math.sin(dLat / 2) ** 2
+    + Math.cos(a.lat * t) * Math.cos(b.lat * t) * Math.sin(dLng / 2) ** 2;
+  return 6371000 * 2 * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
+}
+
+// Deliberately NOT bounded to Lviv: EconomClass runs real branches in
+// Drohobych, Stryi, Sokal, Chervonohrad and elsewhere, 30–75 km out. A
+// bounding box would reject them. This only rejects coordinates that can't be
+// a place at all.
+function coordsLookReal(lat, lng) {
+  return Number.isFinite(lat) && Number.isFinite(lng)
+    && Math.abs(lat) <= 90 && Math.abs(lng) <= 180
+    && !(lat === 0 && lng === 0);
+}
+
+const DUPLICATE_RADIUS_M = 60;
+
+// Next free c-id. Reuses nothing: ids of removed stores stay retired so an old
+// QR poster or shared link can never resolve to a different shop.
+function nextStoreId(stores) {
+  let max = 0;
+  for (const s of stores) {
+    const m = /^c(\d+)$/.exec(s && s.id ? s.id : '');
+    if (m) max = Math.max(max, Number(m[1]));
+  }
+  return 'c' + (max + 1);
+}
+
+export function addStore(stores, proposed) {
+  const lat = Number(proposed && proposed.lat), lng = Number(proposed && proposed.lng);
+  const name = proposed && typeof proposed.name === 'string' ? proposed.name.trim() : '';
+  if (!name) return { rejected: 'no name' };
+  if (!coordsLookReal(lat, lng)) return { rejected: 'coordinates are not a real location' };
+
+  // A new pin sitting on top of an existing store is the failure this map keeps
+  // hitting — c12, c13 and two re-submitted stores were all found that way. It
+  // is reported rather than added: a missed addition becomes an issue, whereas
+  // a duplicate on the live map sends someone to a shop that isn't there.
+  let nearest = null;
+  for (const s of stores) {
+    if (!s || s.watermark || !Number.isFinite(s.lat)) continue;
+    const d = metresBetween({ lat, lng }, s);
+    if (!nearest || d < nearest.d) nearest = { d, s };
+  }
+  if (nearest && nearest.d <= DUPLICATE_RADIUS_M) {
+    return { rejected: `${Math.round(nearest.d)} m from ${nearest.s.id} (${nearest.s.name}) — possible duplicate` };
+  }
+
+  const id = nextStoreId(stores);
+  const store = { id, name, lat, lng, cycle: Number(proposed.cycle) || 7 };
+  for (const k of ['brand', 'address', 'addressEn', 'phone', 'type', 'pricing', 'note', 'hours', 'restockDay', 'restock_date', 'dailyDrop']) {
+    if (proposed[k] !== undefined && proposed[k] !== null && proposed[k] !== '') store[k] = proposed[k];
+  }
+  if (!store.brand) store.brand = 'Independent';
+  if (!store.type) store.type = 'other';
+  stores.push(store);
+  return { added: id, nearestMetres: nearest ? Math.round(nearest.d) : null };
+}
+
 function main() {
   const eventPath = process.env.GITHUB_EVENT_PATH;
   if (!eventPath) throw new Error('GITHUB_EVENT_PATH is not set — this script must run inside a GitHub Actions job.');
@@ -102,10 +166,13 @@ function main() {
   // { patches: [{ store_id, updates }] } — lets one approved contribution
   // touching a dozen stores be one workflow run, one commit and one report,
   // instead of a dozen runs queued behind each other each opening its own issue.
-  const batch = Array.isArray(payload.patches)
-    ? payload.patches
-    : [{ store_id: payload.store_id, updates: payload.updates }];
-  if (!batch.length) throw new Error('client_payload carried no patches.');
+  const batch = Array.isArray(payload.patches) ? payload.patches
+    : payload.store_id ? [{ store_id: payload.store_id, updates: payload.updates }]
+    : [];
+  const hasAddsOrRemoves = Array.isArray(payload.adds) || Array.isArray(payload.removes);
+  // A contribution can consist purely of additions or removals, with no field
+  // patches at all — that is not an empty payload.
+  if (!batch.length && !hasAddsOrRemoves) throw new Error('client_payload carried nothing to apply.');
 
   const raw = readFileSync(storesPath, 'utf8');
   const stores = JSON.parse(raw);
@@ -146,9 +213,35 @@ function main() {
       console.log(`Patched store "${storeId}":`, JSON.stringify(updates));
     }
   }
+  // Additions and removals, which a field patch cannot express. Both are only
+  // honoured in fill-gaps mode — the overwrite callers patch one known store.
+  const added = [], removedIds = [], rejectedAdds = [];
+  if (mode === 'fill-gaps') {
+    for (const proposed of (Array.isArray(payload.adds) ? payload.adds.slice(0, 50) : [])) {
+      const r = addStore(stores, proposed);
+      if (r.rejected) {
+        rejectedAdds.push({ name: (proposed && proposed.name) || '(unnamed)', why: r.rejected });
+        console.log(`Declined to add "${(proposed && proposed.name) || '(unnamed)'}": ${r.rejected}`);
+      } else {
+        added.push({ id: r.added, name: proposed.name });
+        console.log(`Added "${proposed.name}" as ${r.added}`);
+      }
+    }
+    for (const rid of (Array.isArray(payload.removes) ? payload.removes.slice(0, 50) : [])) {
+      const idx2 = stores.findIndex((x) => x && x.id === rid);
+      if (idx2 === -1) { console.log(`Nothing to remove for "${rid}".`); continue; }
+      const gone = stores.splice(idx2, 1)[0];
+      removedIds.push({ id: rid, name: gone.name });
+      console.log(`Removed ${rid} ("${gone.name}")`);
+    }
+  }
+
   const report = {
     mode: mode || 'overwrite',
     stores: results,
+    added,
+    removed: removedIds,
+    rejectedAdds,
     // What a human still has to look at.
     needsReview: results.filter((r) => r.missing || (r.skipped && r.skipped.length)),
   };

--- a/scripts/check-map-patch.mjs
+++ b/scripts/check-map-patch.mjs
@@ -167,6 +167,57 @@ const pretty = JSON.stringify(FIXTURE, null, 2) + '\n';
     JSON.stringify(r.report.stores[0].skipped));
 }
 
+// ── 8. Additions ───────────────────────────────────────────────────────────
+{
+  const r = run({ mode: 'fill-gaps', adds: [
+    { name: 'Brand New Shop', lat: 49.8000, lng: 24.0000, pricing: 'kg' },
+  ] }, pretty);
+  const out = JSON.parse(r.raw);
+  check('a clear addition lands with an allocated id', out.length === 3 && out[2].id === 'c1', out[2] && out[2].id);
+  check('and gets the dataset defaults', out[2] && out[2].brand === 'Independent' && out[2].type === 'other' && out[2].cycle === 7);
+  check('the report names it', r.report.added.length === 1 && r.report.added[0].name === 'Brand New Shop');
+}
+{
+  // 'a1' has no coordinates in the fixture, so give the duplicate test its own.
+  const near = JSON.stringify([{ id: 'c9', name: 'Existing', lat: 49.8397, lng: 24.0297, cycle: 7 }], null, 2) + '\n';
+  const r = run({ mode: 'fill-gaps', adds: [{ name: 'Too Close', lat: 49.83975, lng: 24.02975 }] }, near);
+  check('an addition on top of an existing store is refused', JSON.parse(r.raw).length === 1);
+  check('and says which store and how far', /c9/.test(r.report.rejectedAdds[0].why) && /duplicate/.test(r.report.rejectedAdds[0].why),
+    JSON.stringify(r.report.rejectedAdds));
+}
+{
+  const far = JSON.stringify([{ id: 'c9', name: 'Existing', lat: 49.8397, lng: 24.0297, cycle: 7 }], null, 2) + '\n';
+  const r = run({ mode: 'fill-gaps', adds: [{ name: 'Regional Branch', lat: 49.3500, lng: 23.5000 }] }, far);
+  check('a genuine regional branch 60+ km out is still accepted', JSON.parse(r.raw).length === 2,
+    'EconomClass really does trade in Drohobych and Stryi');
+  check('the allocated id follows the highest existing c-number', JSON.parse(r.raw)[1].id === 'c10', JSON.parse(r.raw)[1].id);
+}
+{
+  const one = JSON.stringify([{ id: 'c9', name: 'Existing', lat: 49.8397, lng: 24.0297, cycle: 7 }], null, 2) + '\n';
+  const r = run({ mode: 'fill-gaps', adds: [{ name: 'Nowhere', lat: 0, lng: 0 }] }, one);
+  check('null-island coordinates are refused', JSON.parse(r.raw).length === 1 && /not a real location/.test(r.report.rejectedAdds[0].why));
+  const r2 = run({ mode: 'fill-gaps', adds: [{ name: '', lat: 49.9, lng: 24.1 }] }, one);
+  check('an unnamed addition is refused', JSON.parse(r2.raw).length === 1 && /no name/.test(r2.report.rejectedAdds[0].why));
+}
+
+// ── 9. Removals ────────────────────────────────────────────────────────────
+{
+  const r = run({ mode: 'fill-gaps', removes: ['a1'] }, pretty);
+  const out = JSON.parse(r.raw);
+  check('an approved removal takes the store off the map', out.length === 1 && out[0].id === 'a2');
+  check('and the report names what went', r.report.removed[0].id === 'a1' && r.report.removed[0].name === 'Filled In');
+  check('removal still writes indent 2', r.raw === JSON.stringify(out, null, 2) + '\n');
+}
+{
+  const r = run({ mode: 'fill-gaps', removes: ['ghost'] }, pretty);
+  check('removing a store that is not there is a no-op, not a crash',
+    !r.error && JSON.parse(r.raw).length === 2);
+}
+{
+  const r = run({ store_id: 'a1', removes: ['a2'], updates: { phone: 'x' } }, pretty);
+  check('overwrite mode ignores adds/removes entirely', JSON.parse(r.raw).length === 2);
+}
+
 console.log('');
 if (failures) { console.error(`map-patch: ${failures} check(s) failed.`); process.exit(1); }
 console.log('Map-patch pipeline OK — formatting preserved, fill-gaps never overwrites.');

--- a/scripts/check-map-patch.mjs
+++ b/scripts/check-map-patch.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+// Proves the automated map-patch path, which until now had never run in
+// production: the first real dispatch would have reformatted all 130 records,
+// because the applier wrote stores.json with indent 1 while everything else
+// writes 2. That is the kind of bug an untested pipeline keeps.
+//
+// Drives scripts/apply-map-patch.mjs as a subprocess with a real
+// GITHUB_EVENT_PATH and a fixture dataset, exactly as the workflow does.
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const applier = resolve(here, 'apply-map-patch.mjs');
+const dir = mkdtempSync(join(tmpdir(), 'mappatch-'));
+
+const FIXTURE = [
+  { id: 'a1', name: 'Filled In', phone: '+38 (000) 000-00-00', pricing: 'kg', cycle: 7,
+    restock_date: '2026-08-10',
+    hours: { mon: '10:00–19:00', tue: '?', wed: '?', thu: '?', fri: '?', sat: '?', sun: 'closed' } },
+  { id: 'a2', name: 'Mostly Empty', phone: '', address: '', cycle: 7,
+    hours: { mon: '?', tue: '?', wed: '?', thu: '?', fri: '?', sat: '?', sun: '?' } },
+];
+
+let failures = 0;
+function check(label, cond, detail) {
+  if (cond) console.log('  ok  ' + label);
+  else { console.log('  FAIL ' + label + (detail ? '  ' + detail : '')); failures++; }
+}
+
+function run(payload, storesJson) {
+  const storesPath = join(dir, 'stores.json');
+  const eventPath = join(dir, 'event.json');
+  const reportPath = join(dir, 'report.json');
+  writeFileSync(storesPath, storesJson);
+  writeFileSync(eventPath, JSON.stringify({ client_payload: payload }));
+  let stdout = '', error = null;
+  try {
+    stdout = execFileSync(process.execPath, [applier], {
+      env: { ...process.env, GITHUB_EVENT_PATH: eventPath, STORES_PATH: storesPath, PATCH_REPORT_FILE: reportPath },
+      encoding: 'utf8',
+      // The guard cases abort on purpose; capture their stderr instead of
+      // letting a stack trace land in the middle of passing output.
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (e) { error = e; }
+  let report = null;
+  try { report = JSON.parse(readFileSync(reportPath, 'utf8')); } catch {}
+  return { raw: readFileSync(storesPath, 'utf8'), stdout, error, report };
+}
+
+const pretty = JSON.stringify(FIXTURE, null, 2) + '\n';
+
+// ── 1. Formatting is preserved ──────────────────────────────────────────────
+{
+  const r = run({ store_id: 'a1', updates: { phone: '+38 (111) 111-11-11' } }, pretty);
+  const back = JSON.parse(r.raw);
+  check('a one-field patch does not reformat the file',
+    r.raw === JSON.stringify(back, null, 2) + '\n', 'indent drifted');
+  check('the patched value is written', back[0].phone === '+38 (111) 111-11-11');
+  const changedLines = pretty.split('\n').filter((l, i) => l !== r.raw.split('\n')[i]).length;
+  check('exactly one line differs', changedLines === 1, changedLines + ' lines changed');
+}
+
+// ── 2. Default mode still overwrites, and deep-merges hours ────────────────
+{
+  const r = run({ store_id: 'a1', updates: { hours: { tue: '09:00–18:00' } } }, pretty);
+  const s = JSON.parse(r.raw)[0];
+  check('overwrite mode fills a day', s.hours.tue === '09:00–18:00');
+  check('overwrite mode leaves sibling days intact', s.hours.mon === '10:00–19:00' && s.hours.sun === 'closed');
+}
+{
+  const r = run({ store_id: 'a1', updates: { phone: 'REPLACED' } }, pretty);
+  check('overwrite mode replaces a recorded value', JSON.parse(r.raw)[0].phone === 'REPLACED');
+}
+
+// ── 3. fill-gaps never contradicts what is already recorded ────────────────
+{
+  const r = run({ store_id: 'a1', mode: 'fill-gaps', updates: { phone: 'SHOULD NOT LAND' } }, pretty);
+  const s = JSON.parse(r.raw)[0];
+  check('fill-gaps refuses to overwrite a recorded phone', s.phone === '+38 (000) 000-00-00');
+  check('and reports the decline with both values',
+    r.report.stores[0].skipped.length === 1 && r.report.stores[0].skipped[0].field === 'phone'
+    && r.report.stores[0].skipped[0].have === '+38 (000) 000-00-00' && r.report.stores[0].skipped[0].proposed === 'SHOULD NOT LAND',
+    JSON.stringify(r.report.stores[0].skipped));
+}
+{
+  const r = run({ store_id: 'a2', mode: 'fill-gaps', updates: { phone: '+38 (222) 222-22-22', address: 'вул. Тестова, 1' } }, pretty);
+  const s = JSON.parse(r.raw)[1];
+  check('fill-gaps fills empty-string fields', s.phone === '+38 (222) 222-22-22' && s.address === 'вул. Тестова, 1');
+  check('and reports nothing declined', r.report.stores[0].skipped.length === 0);
+}
+{
+  const r = run({ store_id: 'a1', mode: 'fill-gaps',
+                  updates: { hours: { mon: '08:00–20:00', tue: '09:00–18:00', sun: '11:00–15:00' } } }, pretty);
+  const s = JSON.parse(r.raw)[0];
+  check("fill-gaps treats '?' as a gap and fills it", s.hours.tue === '09:00–18:00');
+  check('fill-gaps leaves a recorded day alone', s.hours.mon === '10:00–19:00');
+  check("fill-gaps treats 'closed' as a recorded value, not a gap", s.hours.sun === 'closed');
+  const fields = r.report.stores[0].skipped.map((x) => x.field).sort();
+  check('both contested days are reported', JSON.stringify(fields) === '["hours.mon","hours.sun"]', JSON.stringify(fields));
+}
+
+// ── 4. restock_date is the one field where newer wins ──────────────────────
+{
+  const r = run({ store_id: 'a1', mode: 'fill-gaps', updates: { restock_date: '2026-08-24' } }, pretty);
+  check('a newer restock_date is applied', JSON.parse(r.raw)[0].restock_date === '2026-08-24');
+}
+{
+  const r = run({ store_id: 'a1', mode: 'fill-gaps', updates: { restock_date: '2026-07-01' } }, pretty);
+  check('an older restock_date is declined', JSON.parse(r.raw)[0].restock_date === '2026-08-10');
+  check('and says why', r.report.stores[0].skipped[0] && /older/.test(r.report.stores[0].skipped[0].why), JSON.stringify(r.report.stores[0].skipped));
+}
+
+// ── 5. Guards ──────────────────────────────────────────────────────────────
+{
+  const r = run({ store_id: 'a1', updates: { id: 'hijack' } }, pretty);
+  check('a patch may not reassign id', !!r.error && /must not include "id"/.test(String(r.error.stderr || r.error)));
+  check('and the file is untouched when it aborts', r.raw === pretty);
+}
+{
+  const r = run({ store_id: 'nope', updates: { phone: 'x' } }, pretty);
+  check('an unknown store id aborts', !!r.error && /No store with id/.test(String(r.error.stderr || r.error)));
+  check('and the file is untouched', r.raw === pretty);
+}
+
+
+// ── 6. Batch shape: one dispatch, many stores, one report ──────────────────
+{
+  const r = run({ mode: 'fill-gaps', patches: [
+    { store_id: 'a2', updates: { phone: '+38 (333) 333-33-33' } },
+    { store_id: 'a1', updates: { phone: 'CONTESTED' } },
+    { store_id: 'ghost', updates: { phone: 'x' } },
+  ] }, pretty);
+  const out = JSON.parse(r.raw);
+  check('batch applies the gap-filling patch', out[1].phone === '+38 (333) 333-33-33');
+  check('batch leaves the contested value alone', out[0].phone === '+38 (000) 000-00-00');
+  check('batch does not abort on a store the map lacks', !r.error, String(r.error && r.error.message).slice(0, 80));
+  check('the unknown store is reported as missing',
+    r.report.stores.some((x) => x.store_id === 'ghost' && x.missing === true), JSON.stringify(r.report.stores));
+  check('needsReview lists exactly the contested and the missing',
+    r.report.needsReview.length === 2, JSON.stringify(r.report.needsReview.map((x) => x.store_id)));
+  check('batch still writes indent 2', r.raw === JSON.stringify(out, null, 2) + '\n');
+}
+{
+  // Overwrite callers pass ids they just read out of stores.json, so there an
+  // unknown id still has to be loud.
+  const r = run({ patches: [{ store_id: 'ghost', updates: { phone: 'x' } }] }, pretty);
+  check('overwrite mode still aborts on an unknown store',
+    !!r.error && /No store with id/.test(String(r.error.stderr || r.error)));
+}
+
+// ── 7. A flag proposed as false where the store has none is a no-op ────────
+{
+  const r = run({ store_id: 'a2', mode: 'fill-gaps', updates: { dailyDrop: false } }, pretty);
+  check('proposing dailyDrop:false on a store without it stores nothing',
+    !('dailyDrop' in JSON.parse(r.raw)[1]), JSON.stringify(JSON.parse(r.raw)[1].dailyDrop));
+  check('and it is not reported as needing review', r.report.needsReview.length === 0);
+}
+{
+  const withFlag = JSON.stringify([{ id: 'b1', name: 'Flagged', cycle: 7, dailyDrop: true }], null, 2) + '\n';
+  const r = run({ store_id: 'b1', mode: 'fill-gaps', updates: { dailyDrop: false } }, withFlag);
+  check('but turning an existing flag off is a real change, and is declined',
+    JSON.parse(r.raw)[0].dailyDrop === true && r.report.stores[0].skipped.length === 1,
+    JSON.stringify(r.report.stores[0].skipped));
+}
+
+console.log('');
+if (failures) { console.error(`map-patch: ${failures} check(s) failed.`); process.exit(1); }
+console.log('Map-patch pipeline OK — formatting preserved, fill-gaps never overwrites.');

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -310,6 +310,52 @@ async function dispatchMapPatch(env, storeId, updates) {
   if (res.status !== 204) throw new Error(`dispatch failed: ${res.status}`);
 }
 
+// Fields a contribution is allowed to patch unattended. Deliberately excludes
+// id, lat and lng: a pin is the one thing a wrong edit makes actively
+// misleading rather than merely incomplete, and every store already has
+// coordinates, so fill-gaps would decline them anyway. Listing them out means
+// a new field added to the edit form doesn't silently become auto-appliable.
+const AUTO_PATCH_FIELDS = [
+  'name', 'addressEn', 'address', 'phone', 'pricing', 'cycle',
+  'dailyDrop', 'restockDay', 'restock_date', 'note', 'hours',
+];
+
+// Turns an approved contribution's corrections into one fill-gaps batch. The
+// workflow decides what actually lands: anything that would contradict a value
+// already on the map is declined there and raised as its own issue. So this
+// only has to be conservative about *which fields* may be offered, not about
+// whether each one is right.
+function contributionPatches(payload) {
+  const list = Array.isArray(payload && payload.overrideList) ? payload.overrideList.slice(0, 200) : [];
+  const patches = [];
+  for (const o of list) {
+    if (!o || typeof o.id !== 'string' || !/^[a-z0-9]{1,12}$/i.test(o.id)) continue;
+    const changes = o.changes && typeof o.changes === 'object' ? o.changes : {};
+    const updates = {};
+    for (const k of AUTO_PATCH_FIELDS) {
+      if (Object.prototype.hasOwnProperty.call(changes, k)) updates[k] = changes[k];
+    }
+    if (Object.keys(updates).length) patches.push({ store_id: o.id, updates });
+  }
+  return patches;
+}
+
+async function dispatchFillGaps(env, patches) {
+  if (!env.GH_PAT) throw new Error('GH_PAT not configured');
+  const res = await fetch('https://api.github.com/repos/anonymouspartner/lviv-secondhand/dispatches', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${env.GH_PAT}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'lviv-secondhand-worker',
+    },
+    body: JSON.stringify({ event_type: 'update_map_data', client_payload: { mode: 'fill-gaps', patches } }),
+  });
+  if (res.status !== 204) throw new Error(`dispatch failed: ${res.status}`);
+}
+
 // Same GitHub dispatch mechanism as dispatchMapPatch, different event. Split
 // rather than parameterised because the two carry unrelated payloads and are
 // consumed by different workflows; folding them together would only hide which
@@ -1310,15 +1356,48 @@ export default {
             `Pass this to the store owner. Entering it on a flash-deal purchase publishes their deal immediately, with no review.`,
             { status: 200 });
         }
-        let issueUrl;
-        try {
-          const issue = renderSubmissionIssue(row.kind, payload);
-          issueUrl = await createGithubIssue(env, issue.title, issue.body, issue.labels);
-        } catch (e) {
-          return new Response('issue creation failed — check GH_PAT and that it still has repo scope', { status: 502 });
+        // A contribution's corrections to existing stores are structured, so
+        // they go straight down the automated pipeline in fill-gaps mode. New
+        // stores and removals cannot: a patch can neither create nor delete an
+        // entry, and both are decisions a person should make anyway. An issue is
+        // raised only for those — and only if there are any.
+        //
+        // Owner submissions stay on the issue path regardless: their fields
+        // arrive as prose ("last restocked 2026-08-19, every 14 days"), and
+        // parsing that unattended would be guessing.
+        let patches = [];
+        if (row.kind === 'contribution') {
+          patches = contributionPatches(payload);
+          if (patches.length) {
+            try {
+              await dispatchFillGaps(env, patches);
+            } catch (e) {
+              return new Response('map-patch dispatch failed — check GH_PAT and the update-map workflow logs', { status: 502 });
+            }
+          }
+        }
+
+        const needsIssue = row.kind !== 'contribution'
+          || (Array.isArray(payload.custom) && payload.custom.length > 0)
+          || (Array.isArray(payload.removed) && payload.removed.length > 0);
+
+        let issueUrl = null;
+        if (needsIssue) {
+          try {
+            const issue = renderSubmissionIssue(row.kind, payload);
+            issueUrl = await createGithubIssue(env, issue.title, issue.body, issue.labels);
+          } catch (e) {
+            return new Response('issue creation failed — check GH_PAT and that it still has repo scope', { status: 502 });
+          }
         }
         await env.DB.prepare("UPDATE submissions SET status = 'approved', issue_url = ? WHERE id = ?").bind(issueUrl, id).run();
-        return new Response(`✅ Approved — issue created:\n${issueUrl}`, { status: 200 });
+
+        const applied = patches.length
+          ? `🤖 ${patches.length} store correction(s) sent to the map pipeline. Anything that disagrees with data already on the map is declined there and raised as its own issue.\n\n`
+          : '';
+        return new Response(issueUrl
+          ? `✅ Approved.\n\n${applied}Issue created:\n${issueUrl}`
+          : `✅ Approved.\n\n${applied}Nothing needed a human — no issue opened.`, { status: 200 });
       }
       // Owner taps this from the "1 of 2" restock notification to publish a
       // single report without waiting for a second one. Same GET-so-Telegram-

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -340,7 +340,28 @@ function contributionPatches(payload) {
   return patches;
 }
 
-async function dispatchFillGaps(env, patches) {
+// Stores proposed for addition, trimmed to the fields stores.json holds. The
+// applier still refuses anything landing within 60 m of an existing pin, so
+// this only has to filter fields, not judge the store.
+function contributionAdds(payload) {
+  const list = Array.isArray(payload && payload.custom) ? payload.custom.slice(0, 50) : [];
+  return list.map((c) => {
+    const out = { name: String((c && c.name) || '').slice(0, 120), lat: Number(c && c.lat), lng: Number(c && c.lng) };
+    for (const k of ['address', 'addressEn', 'phone', 'pricing', 'cycle', 'note', 'hours', 'restockDay', 'restock_date', 'dailyDrop']) {
+      if (c && c[k] !== undefined && c[k] !== null && c[k] !== '') out[k] = c[k];
+    }
+    return out;
+  }).filter((c) => c.name);
+}
+
+// Ids proposed for removal. The moderator saw every one of these by name in the
+// approval message, which is what makes removing them on one tap defensible.
+function contributionRemoves(payload) {
+  const list = Array.isArray(payload && payload.removed) ? payload.removed.slice(0, 50) : [];
+  return list.map((r) => r && r.id).filter((id) => typeof id === 'string' && /^[a-z0-9]{1,12}$/i.test(id));
+}
+
+async function dispatchFillGaps(env, body) {
   if (!env.GH_PAT) throw new Error('GH_PAT not configured');
   const res = await fetch('https://api.github.com/repos/anonymouspartner/lviv-secondhand/dispatches', {
     method: 'POST',
@@ -351,7 +372,7 @@ async function dispatchFillGaps(env, patches) {
       'X-GitHub-Api-Version': '2022-11-28',
       'User-Agent': 'lviv-secondhand-worker',
     },
-    body: JSON.stringify({ event_type: 'update_map_data', client_payload: { mode: 'fill-gaps', patches } }),
+    body: JSON.stringify({ event_type: 'update_map_data', client_payload: { mode: 'fill-gaps', ...body } }),
   });
   if (res.status !== 204) throw new Error(`dispatch failed: ${res.status}`);
 }
@@ -973,10 +994,44 @@ function submissionSummary(kind, storeId, payload) {
     return `🔑 STORE CLAIM — someone says they own ${storeId}\n\nName: ${mdSafe(p.name, 120)}\nContact: ${mdSafe(p.contact, 200)}\nNote: ${mdSafe(p.note, 300) || '—'}`;
   }
   const b = p;
-  const nCustom = Array.isArray(b.custom) ? b.custom.length : 0;
-  const nEdit = Array.isArray(b.overrideList) ? b.overrideList.length : 0;
-  const nRem = Array.isArray(b.removed) ? b.removed.length : 0;
-  return `🗺️ MAP CONTRIBUTION\n\n➕ ${nCustom} added\n✏️ ${nEdit} edited\n🗑️ ${nRem} removed`;
+  const custom = Array.isArray(b.custom) ? b.custom : [];
+  const edits = Array.isArray(b.overrideList) ? b.overrideList : [];
+  const removed = Array.isArray(b.removed) ? b.removed : [];
+  const out = [`🗺️ MAP CONTRIBUTION\n`];
+
+  // Removals first, always named in full and never truncated. Approving is one
+  // tap, and this is the only category that takes something off the live map —
+  // "🗑️ 2 removed" is not something anyone can consent to.
+  if (removed.length) {
+    out.push(`🗑️ REMOVING ${removed.length}:`);
+    for (const r of removed) out.push(`  • ${mdSafe(r.name, 60)} (${mdSafe(r.id, 12)})`);
+    out.push('');
+  }
+  if (custom.length) {
+    out.push(`➕ ADDING ${custom.length}:`);
+    for (const c of custom.slice(0, 10)) {
+      out.push(`  • ${mdSafe(c.name, 60)} — ${mdSafe(c.addressEn || c.address, 60) || 'no address'}`);
+    }
+    if (custom.length > 10) out.push(`  …and ${custom.length - 10} more`);
+    out.push('');
+  }
+  if (edits.length) {
+    out.push(`✏️ EDITING ${edits.length}:`);
+    for (const e of edits.slice(0, 15)) {
+      // Field names, not values: which fields moved is what tells you whether
+      // this is a routine gap-fill or someone rewriting a store's identity.
+      const fields = Object.keys((e && e.changes) || {});
+      const shown = fields.slice(0, 6).join(', ') + (fields.length > 6 ? `, +${fields.length - 6}` : '');
+      out.push(`  • ${mdSafe(e.name, 44)}: ${mdSafe(shown, 90) || 'no fields'}`);
+    }
+    if (edits.length > 15) out.push(`  …and ${edits.length - 15} more`);
+    out.push('');
+  }
+  if (!removed.length && !custom.length && !edits.length) out.push('(nothing in this bundle)');
+  // Telegram rejects a sendMessage over 4096 characters outright, so a very
+  // large bundle must lose its tail rather than fail to arrive at all.
+  const text = out.join('\n').trimEnd();
+  return text.length > 3400 ? text.slice(0, 3400) + '\n…(truncated — see the issue)' : text;
 }
 
 async function awardPoints(env, chatId, name, points) {
@@ -1365,21 +1420,25 @@ export default {
         // Owner submissions stay on the issue path regardless: their fields
         // arrive as prose ("last restocked 2026-08-19, every 14 days"), and
         // parsing that unattended would be guessing.
-        let patches = [];
+        let patches = [], adds = [], removes = [];
         if (row.kind === 'contribution') {
           patches = contributionPatches(payload);
-          if (patches.length) {
+          adds = contributionAdds(payload);
+          removes = contributionRemoves(payload);
+          if (patches.length || adds.length || removes.length) {
             try {
-              await dispatchFillGaps(env, patches);
+              await dispatchFillGaps(env, { patches, adds, removes });
             } catch (e) {
               return new Response('map-patch dispatch failed — check GH_PAT and the update-map workflow logs', { status: 502 });
             }
           }
         }
 
-        const needsIssue = row.kind !== 'contribution'
-          || (Array.isArray(payload.custom) && payload.custom.length > 0)
-          || (Array.isArray(payload.removed) && payload.removed.length > 0);
+        // Everything a contribution can express now goes down the pipeline, so
+        // an issue is only for the other submission kinds. The workflow raises
+        // its own issue for whatever it declined — a contested value, an
+        // addition that looked like a duplicate — so nothing is lost silently.
+        const needsIssue = row.kind !== 'contribution';
 
         let issueUrl = null;
         if (needsIssue) {
@@ -1392,8 +1451,12 @@ export default {
         }
         await env.DB.prepare("UPDATE submissions SET status = 'approved', issue_url = ? WHERE id = ?").bind(issueUrl, id).run();
 
-        const applied = patches.length
-          ? `🤖 ${patches.length} store correction(s) sent to the map pipeline. Anything that disagrees with data already on the map is declined there and raised as its own issue.\n\n`
+        const bits = [];
+        if (patches.length) bits.push(`${patches.length} correction(s)`);
+        if (adds.length) bits.push(`${adds.length} new store(s)`);
+        if (removes.length) bits.push(`${removes.length} removal(s)`);
+        const applied = bits.length
+          ? `🤖 Sent to the map pipeline: ${bits.join(', ')}.\nIt ships in a couple of minutes. Anything that disagrees with data already on the map — or an addition landing on top of an existing pin — is declined there and raised as its own issue.\n\n`
           : '';
         return new Response(issueUrl
           ? `✅ Approved.\n\n${applied}Issue created:\n${issueUrl}`


### PR DESCRIPTION
**Target flow:** contribute in the app → review in Telegram → approve → the map updates itself.

This gets there. Three commits: the pipeline, the review stage, and a session hook.

---

## The blocker was the review stage, not the automation

A map contribution arrived in Telegram as three numbers:

```
🗺️ MAP CONTRIBUTION
➕ 2 added   ✏️ 31 edited   🗑️ 2 removed
```

That was #278 — where **17 of the proposed fields were wrong** and both "adds" already existed on the map. You cannot review counts. The GitHub issue afterwards was where the reading actually happened.

So automating approval *without* fixing this would have removed the only review taking place, not automated it.

### The message now itemises

```
🗺️ MAP CONTRIBUTION

🗑️ REMOVING 2:
  • ЕЛІТ (c120)
  • Second hand — Окуневського 3 (c122)

➕ ADDING 2:
  • Супер секонд-хенд — Staromiska St, 1
  • Взуття з Європи — 8 Shpytalna St

✏️ EDITING 31:
  • Світ секонд-хенду — Цехова 1: cycle, restock_date, pricing, hours
  • Birka! Lux — Зелена 69а: pricing, cycle, dailyDrop, hours
  …and 16 more
```

Removals are named in full and **never truncated** — they're the one category that takes something off the live map. Edits show *which fields moved*, which is what separates a routine gap-fill from someone rewriting a store's identity. #278 renders at 1061 characters, inside Telegram's 4096 limit.

---

## What approve now does

| category | before | after |
| --- | --- | --- |
| corrections | issue → you | **applied and shipped** |
| new stores | issue → you | **applied and shipped** |
| removals | issue → you | **applied and shipped** |
| contested values | — | workflow raises an issue |
| suspected duplicates | — | workflow raises an issue |
| owner submissions | issue → you | issue → you *(prose fields — parsing them unattended is guessing)* |

A clean contribution now reaches nobody. Only judgment calls do.

### Guardrails

**`fill-gaps`** writes only where the map holds nothing (`''`, `null`, absent, `'?'`), plus a strictly-newer `restock_date`. Anything contradicting a recorded value is declined with both sides shown.

**Additions** get the next free `c`-id — retired ids are never reused, so an old QR poster can't resolve to a different shop. Refused if unnamed, if coordinates aren't a real location, or if the pin lands **within 60 m of an existing store**. That last is the failure this map keeps hitting: `c12`, `c13` and two re-submitted stores were all found that way.

**No bounding box on coordinates** — deliberately. EconomClass runs real branches in Drohobych, Stryi, Sokal and Chervonohrad, 30–75 km out; a Lviv box would reject them. I checked before writing the rule.

---

## The pipeline had never actually run

`git log --grep='Auto-update store'` returns **zero commits**. That's why a bug survived in it: the applier wrote `stores.json` with **indent 1** while every other writer uses 2, so the first real dispatch would have reformatted all 130 records into a ~7,000-line diff.

Fixed, plus batch payloads (one contribution = one run, one commit, one report) and soft handling of ids the map doesn't hold.

### Replaying #278

```
would apply unattended     : 1 store
would be raised for a human: 17 fields
    ? c71.restock_date — older than the date on record
    ? s6.hours.{mon…sun} — would overwrite a recorded value
    ? c59.name — would overwrite a recorded value
    ? c21.hours.{mon…sun} — would overwrite a recorded value
```

Exactly the seventeen I rejected by hand — including `c21`'s hours, which would have reverted a door-sign correction made an hour earlier.

**Two regressions the tests caught, not inspection:**
- The first version wrote `dailyDrop: false` onto stores that simply lack the key, reintroducing the phantom field #282 removed.
- A contribution consisting purely of additions or removals was rejected as an empty payload.

`scripts/check-map-patch.mjs` — **45 assertions**, wired into CI, driving the applier as a subprocess exactly as the workflow does.

---

## Plus: a SessionStart hook

The container re-clones at an old commit **and carries a stale `origin` ref**, so git reports the checkout as current while it's dozens of commits behind. It happened three times in one session and produced a store id already taken on the real `main`.

Force-fetches, then reports. **Never resets or checks anything out.** Distinguishes a genuinely stale checkout (⚠️ 35 commits behind) from a squash-merged branch (✓ trees identical) — a warning that fires after every merge gets scrolled past.

---

## Verification

`validate-stores` (130 stores), `check-inline-js`, `check-wiring` 7/7, `check-map-patch` 45/45, `node --check` on both Workers and `sw.js`. No data changed.

## Worth knowing before merging

This is the first change that lets contribution data reach the live map with no human reading a diff. The honest way to prove it is to approve one small contribution and watch the workflow — the 45 tests cover the logic, not the wiring to GitHub.

Separately: I found three coincident pin pairs that look like copied coordinates, and `c80`/`c82` sitting 28.5 km out with no address. Filing that separately — unrelated to this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN