### PR TITLE
Fix update-map.yml, which #283 shipped broken, and make CI parse workflow files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,13 @@ jobs:
       - name: Check the map-patch pipeline
         run: node scripts/check-map-patch.mjs
 
+      # A workflow with a YAML error does not fail loudly: GitHub names the run
+      # after the file path instead of the declared name, and the workflow simply
+      # never fires on its real trigger. update-map.yml shipped broken exactly
+      # that way and nothing said so.
+      - name: Check workflow files parse
+        run: node scripts/check-workflows.mjs
+
       # The per-store pages and sitemap are generated from stores.json but
       # committed (GitHub Pages serves the repo root, so the files ARE the
       # deploy). Regenerate and fail if the committed output differs — that

--- a/.github/workflows/update-map.yml
+++ b/.github/workflows/update-map.yml
@@ -103,50 +103,19 @@ jobs:
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
-          REPORT: ${{ runner.temp }}/patch-report.json
+          PATCH_REPORT_FILE: ${{ runner.temp }}/patch-report.json
+          ISSUE_BODY_FILE: ${{ runner.temp }}/issue.md
         run: |
-          [ -f "$REPORT" ] || { echo "No report written — nothing to raise."; exit 0; }
-          COUNT=$(node -e "const r=require('$REPORT');console.log((r.needsReview||[]).length)")
+          if [ ! -f "$PATCH_REPORT_FILE" ]; then
+            echo "No report written — nothing to raise."
+            exit 0
+          fi
+          COUNT=$(node scripts/render-patch-issue.mjs)
           if [ "$COUNT" = "0" ]; then
             echo "Nothing declined — no issue needed."
             exit 0
           fi
-          node -e "
-            const r = require('$REPORT');
-            const L = [];
-            L.push('An automated map patch applied what it safely could and declined the rest.');
-            L.push('');
-            L.push('Declined values are **not** errors — they are places where a contribution');
-            L.push('disagrees with something already on the map, which is a judgment call.');
-            L.push('');
-            for (const s of r.needsReview) {
-              if (s.missing) {
-                L.push('### `' + s.store_id + '` — not on the map');
-                L.push('');
-                L.push('A patch referenced this id but no such store exists. It needs adding by hand,');
-                L.push('or the contribution is pointing at the wrong store.');
-                L.push('');
-                continue;
-              }
-              L.push('### `' + s.store_id + '`');
-              L.push('');
-              L.push('| field | on the map | proposed | why declined |');
-              L.push('|---|---|---|---|');
-              for (const k of s.skipped) {
-                L.push('| `' + k.field + '` | ' + JSON.stringify(k.have) + ' | ' + JSON.stringify(k.proposed) + ' | ' + k.why + ' |');
-              }
-              L.push('');
-            }
-            const applied = (r.stores || []).filter(x => Object.keys(x.applied || {}).length);
-            if (applied.length) {
-              L.push('---');
-              L.push('');
-              L.push('Applied without review: ' + applied.map(x => '`' + x.store_id + '` (' + Object.keys(x.applied).join(', ') + ')').join(', '));
-            }
-            require('fs').writeFileSync(process.env.RUNNER_TEMP + '/issue.md', L.join('
-'));
-          "
           gh issue create \
-            --title "Map patch declined ${COUNT} change(s) that need a decision" \
-            --body-file "${RUNNER_TEMP}/issue.md" \
+            --title "Map patch raised $COUNT change(s) for a decision" \
+            --body-file "$ISSUE_BODY_FILE" \
             --label map-contribution

--- a/scripts/check-workflows.mjs
+++ b/scripts/check-workflows.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Parses every workflow file. Exists because a workflow with a YAML error does
+// not fail loudly — GitHub creates a run whose *name is the file path* instead
+// of the declared name, and the workflow simply never fires on its real
+// trigger. update-map.yml sat broken that way: an escaped newline inside an
+// inline `node -e` block ended the quoted scalar early, and nothing said so
+// until someone looked at the Actions list and noticed the name was wrong.
+//
+// No YAML dependency: this repo has none and adding one for a syntax check
+// would be heavier than the check. The parser below handles the subset these
+// workflows use, and its job is to catch unbalanced quoting and broken
+// indentation, not to validate the Actions schema.
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const dir = resolve(here, '..', '.github', 'workflows');
+
+let failures = 0;
+const files = readdirSync(dir).filter((f) => f.endsWith('.yml') || f.endsWith('.yaml')).sort();
+
+for (const f of files) {
+  const text = readFileSync(join(dir, f), 'utf8');
+  const problems = [];
+
+  // A workflow must declare a name; GitHub falls back to the path when it
+  // can't parse the file, which is the symptom this check exists to catch.
+  if (!/^name:\s*\S/m.test(text)) problems.push('no top-level "name:"');
+  if (!/^on:\s*$|^on:\s*\S|^"on":/m.test(text)) problems.push('no "on:" trigger block');
+  if (!/^jobs:\s*$/m.test(text)) problems.push('no "jobs:" block');
+
+  // Unbalanced double quotes on a line are how the update-map.yml break
+  // manifested: a quoted scalar opened and never closed, swallowing the rest
+  // of the file. Ignore lines inside block scalars, where quoting is shell's
+  // problem rather than YAML's — those are detected by indentation.
+  const lines = text.split('\n');
+  let blockIndent = null;
+  lines.forEach((line, i) => {
+    if (blockIndent !== null) {
+      const indent = line.match(/^(\s*)/)[1].length;
+      if (line.trim() === '') return;
+      if (indent > blockIndent) return;      // still inside the block scalar
+      blockIndent = null;                    // block ended, fall through
+    }
+    if (/:\s*[|>][-+]?\s*$/.test(line)) { blockIndent = line.match(/^(\s*)/)[1].length; return; }
+    const withoutComment = line.replace(/#.*$/, '');
+    const quotes = (withoutComment.match(/"/g) || []).length;
+    if (quotes % 2 === 1) problems.push(`line ${i + 1}: odd number of double quotes — unclosed string?`);
+    if (/\t/.test(line)) problems.push(`line ${i + 1}: tab character (YAML forbids tabs for indentation)`);
+  });
+
+  if (problems.length) {
+    failures++;
+    console.error(`  FAIL ${f}`);
+    for (const p of problems.slice(0, 5)) console.error(`         ${p}`);
+  } else {
+    console.log(`  ok   ${f}`);
+  }
+}
+
+console.log('');
+if (failures) { console.error(`${failures} workflow file(s) look broken.`); process.exit(1); }
+console.log(`Workflows OK — ${files.length} files parsed.`);

--- a/scripts/render-patch-issue.mjs
+++ b/scripts/render-patch-issue.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Renders the "needs a decision" issue body for update-map.yml from the
+// applier's report. Lives here rather than inline in the workflow because that
+// meant a JS program nested inside YAML inside shell — three levels of quoting,
+// and an escaped newline in the middle of it silently broke the whole file.
+//
+// Reads PATCH_REPORT_FILE, writes ISSUE_BODY_FILE, and prints the number of
+// items needing review so the workflow can skip the issue when there are none.
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const reportPath = process.env.PATCH_REPORT_FILE;
+const outPath = process.env.ISSUE_BODY_FILE;
+if (!reportPath || !outPath) throw new Error('PATCH_REPORT_FILE and ISSUE_BODY_FILE must both be set.');
+
+const r = JSON.parse(readFileSync(reportPath, 'utf8'));
+const needsReview = r.needsReview || [];
+const rejectedAdds = r.rejectedAdds || [];
+
+const L = [];
+L.push('An automated map patch applied what it safely could and raised the rest.');
+L.push('');
+L.push('These are **not** errors. They are places where a contribution disagrees with');
+L.push('something already on the map, or proposes a store that looks like one already');
+L.push('there — both of which are judgment calls rather than data entry.');
+L.push('');
+
+for (const s of needsReview) {
+  if (s.missing) {
+    L.push('### `' + s.store_id + '` — not on the map');
+    L.push('');
+    L.push('A patch referenced this id but no such store exists. Either it needs adding');
+    L.push('by hand, or the contribution is pointing at the wrong store.');
+    L.push('');
+    continue;
+  }
+  L.push('### `' + s.store_id + '`');
+  L.push('');
+  L.push('| field | on the map | proposed | why declined |');
+  L.push('|---|---|---|---|');
+  for (const k of s.skipped || []) {
+    L.push('| `' + k.field + '` | ' + JSON.stringify(k.have) + ' | ' + JSON.stringify(k.proposed) + ' | ' + k.why + ' |');
+  }
+  L.push('');
+}
+
+if (rejectedAdds.length) {
+  L.push('### Additions not made');
+  L.push('');
+  L.push('| store | why |');
+  L.push('|---|---|');
+  for (const a of rejectedAdds) L.push('| ' + a.name + ' | ' + a.why + ' |');
+  L.push('');
+}
+
+const applied = (r.stores || []).filter((x) => Object.keys(x.applied || {}).length);
+const added = r.added || [];
+const removed = r.removed || [];
+if (applied.length || added.length || removed.length) {
+  L.push('---');
+  L.push('');
+  L.push('Applied in the same run, without review:');
+  L.push('');
+  for (const x of applied) L.push('- `' + x.store_id + '` — ' + Object.keys(x.applied).join(', '));
+  for (const x of added) L.push('- **added** `' + x.id + '` — ' + x.name);
+  for (const x of removed) L.push('- **removed** `' + x.id + '` — ' + x.name);
+  L.push('');
+}
+
+writeFileSync(outPath, L.join('\n') + '\n');
+console.log(String(needsReview.length + rejectedAdds.length));


### PR DESCRIPTION
**#283 shipped `update-map.yml` broken.** I merged it without validating the YAML, and it was dead on arrival — taking the whole unattended-apply path with it.

## What broke

The "raise anything that needs a decision" step nested a JS program inside YAML inside shell. An escaped newline in the middle was written as a **literal** newline, which ended the quoted scalar early and made the file unparseable.

```
line 148: odd number of double quotes — unclosed string?
```

## Why nobody noticed

A broken workflow doesn't announce itself. GitHub creates a run named after the **file path** instead of the declared name, and the workflow never fires on its real trigger:

```
CI                          7a40d71  completed   success
Deploy metrics Worker       7a40d71  completed   success
.github/workflows/update-m  7a40d71  completed   failure    ← the only sign
```

That's it. One oddly-named failed run in a list. Every gate in CI passed, because CI never parsed the workflow files.

## Fix 1 — stop nesting a program in YAML

The issue body now comes from `scripts/render-patch-issue.mjs`. Three levels of quoting *was* the defect; a real file has one. It also reports additions refused as duplicates, which the inline version never did.

Rendered against a realistic report:

```markdown
### `c21`
| field | on the map | proposed | why declined |
|---|---|---|---|
| `hours.sun` | "10:00–13:00" | "closed" | would overwrite a recorded value |

### Additions not made
| store | why |
|---|---|
| Дубль | 12 m from c76 (Світ секонд-хенду — Чорновола 45) — possible duplicate |

---
Applied in the same run, without review:
- `c118` — restock_date
- **added** `c129` — Новий секонд
- **removed** `c120` — ЕЛІТ
```

## Fix 2 — CI now parses the workflows

`scripts/check-workflows.mjs` asserts the things whose absence means GitHub couldn't read the file — a top-level `name:`, an `on:` block, a `jobs:` block — and flags unbalanced quoting outside block scalars, which is precisely how this broke.

No YAML dependency: this repo has none, and adding one to syntax-check fourteen files would weigh more than the check.

**Verified against the file that actually shipped** — not a synthetic case:

```
FAIL update-map.yml
       line 148: odd number of double quotes — unclosed string?
1 workflow file(s) look broken.        (exit 1)
```

Also confirmed the fixed file parses under a real YAML parser as well as the guard, and that the other thirteen workflows were unaffected.

## Verification

`validate-stores` (130 stores), `check-inline-js`, `check-wiring` 7/7, `check-map-patch` 45/45, `check-workflows` 14/14, `node --check` on both Workers and `sw.js`. No data changed.

## Note

The Worker half of #283 deployed fine — `Deploy metrics Worker` was green on `7a40d71`, so the approval flow is live and dispatching. It was the receiving end that was dead. Nothing was lost: a dispatch to a broken workflow simply doesn't run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_