### PR TITLE
Approved contributions apply every field, not only the empty ones

### DIFF
--- a/scripts/apply-map-patch.mjs
+++ b/scripts/apply-map-patch.mjs
@@ -9,15 +9,22 @@
 // JSON in `updates` can't be mangled by shell interpolation.
 //
 // Two modes:
-//   (default)    overwrite — the patch wins. Used by flows where a human has
-//                already confirmed the value: the bot's store survey, and
-//                /restock/approve.
+//   (default)    overwrite — the patch wins. Used wherever a human has already
+//                confirmed the change: the bot's store survey,
+//                /restock/approve, and contributions approved in Telegram.
+//                A correction only ever *disagrees* with what's recorded —
+//                that is what makes it a correction — so a mode that refused
+//                to overwrite could never ship one.
 //   'fill-gaps'  only writes where the map currently holds nothing, plus a
-//                strictly-newer restock_date. Used for contributions approved
-//                in bulk, where "the map has no phone number and someone sent
-//                one" is safe to apply unattended but "someone disagrees with
-//                a value we already hold" is a judgment call. Anything skipped
-//                is reported so it can be raised for a human instead.
+//                strictly-newer restock_date, reporting whatever it declined.
+//                Kept for any future flow that wants to merge a source it
+//                does not fully trust; nothing uses it by default.
+//
+// Whether an unknown store id is fatal depends on the payload shape, not the
+// mode: a batch reports it and carries on, since a contribution can name a
+// store the map does not hold and failing the whole batch would discard the
+// patches that were fine. A single { store_id, updates } still throws — those
+// callers pass an id they just read out of stores.json.
 import { readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
@@ -166,7 +173,8 @@ function main() {
   // { patches: [{ store_id, updates }] } — lets one approved contribution
   // touching a dozen stores be one workflow run, one commit and one report,
   // instead of a dozen runs queued behind each other each opening its own issue.
-  const batch = Array.isArray(payload.patches) ? payload.patches
+  const isBatch = Array.isArray(payload.patches);
+  const batch = isBatch ? payload.patches
     : payload.store_id ? [{ store_id: payload.store_id, updates: payload.updates }]
     : [];
   const hasAddsOrRemoves = Array.isArray(payload.adds) || Array.isArray(payload.removes);
@@ -189,12 +197,7 @@ function main() {
 
     const idx = stores.findIndex((s) => s && s.id === storeId);
     if (idx === -1) {
-      // In fill-gaps mode an unknown id is a fact to report, not a crash: a
-      // contribution can legitimately mention a store the map doesn't hold yet,
-      // and failing the whole batch would discard the patches that were fine.
-      // The overwrite callers pass ids they just read out of stores.json, so
-      // there it still means something is genuinely wrong.
-      if (mode === 'fill-gaps') {
+      if (isBatch) {
         results.push({ store_id: storeId, applied: {}, skipped: [], missing: true });
         console.log(`Store "${storeId}" is not on the map — reported, not applied.`);
         continue;
@@ -208,15 +211,25 @@ function main() {
       console.log(`Patched store "${storeId}" (fill-gaps): applied ${JSON.stringify(r.applied)}`);
       if (r.skipped.length) console.log(`  declined ${r.skipped.length} field(s): ${JSON.stringify(r.skipped)}`);
     } else {
-      deepMerge(stores[idx], updates);
-      results.push({ store_id: storeId, applied: updates, skipped: [] });
-      console.log(`Patched store "${storeId}":`, JSON.stringify(updates));
+      // Proposing false for a flag the store doesn't set leaves the state
+      // identical either way, so it is dropped rather than written — otherwise
+      // an older cached client that still sends every field would slowly add
+      // "dailyDrop": false across the dataset. Not a judgment about the value;
+      // there is simply nothing to change.
+      const clean = {};
+      for (const [k, v] of Object.entries(updates)) {
+        if (v === false && isGap(stores[idx][k])) continue;
+        clean[k] = v;
+      }
+      deepMerge(stores[idx], clean);
+      results.push({ store_id: storeId, applied: clean, skipped: [] });
+      console.log(`Patched store "${storeId}":`, JSON.stringify(clean));
     }
   }
   // Additions and removals, which a field patch cannot express. Both are only
   // honoured in fill-gaps mode — the overwrite callers patch one known store.
   const added = [], removedIds = [], rejectedAdds = [];
-  if (mode === 'fill-gaps') {
+  {
     for (const proposed of (Array.isArray(payload.adds) ? payload.adds.slice(0, 50) : [])) {
       const r = addStore(stores, proposed);
       if (r.rejected) {

--- a/scripts/check-map-patch.mjs
+++ b/scripts/check-map-patch.mjs
@@ -145,11 +145,13 @@ const pretty = JSON.stringify(FIXTURE, null, 2) + '\n';
   check('batch still writes indent 2', r.raw === JSON.stringify(out, null, 2) + '\n');
 }
 {
-  // Overwrite callers pass ids they just read out of stores.json, so there an
-  // unknown id still has to be loud.
-  const r = run({ patches: [{ store_id: 'ghost', updates: { phone: 'x' } }] }, pretty);
-  check('overwrite mode still aborts on an unknown store',
+  // A single-store payload still aborts on an unknown id: those callers pass an
+  // id they just read out of stores.json, so it means something is wrong.
+  const r = run({ store_id: 'ghost', updates: { phone: 'x' } }, pretty);
+  check('a single-store patch still aborts on an unknown store',
     !!r.error && /No store with id/.test(String(r.error.stderr || r.error)));
+  const r2 = run({ patches: [{ store_id: 'ghost', updates: { phone: 'x' } }] }, pretty);
+  check('but a batch reports it and carries on', !r2.error && r2.report.stores[0].missing === true);
 }
 
 // ── 7. A flag proposed as false where the store has none is a no-op ────────
@@ -215,7 +217,34 @@ const pretty = JSON.stringify(FIXTURE, null, 2) + '\n';
 }
 {
   const r = run({ store_id: 'a1', removes: ['a2'], updates: { phone: 'x' } }, pretty);
-  check('overwrite mode ignores adds/removes entirely', JSON.parse(r.raw).length === 2);
+  check('removals work in default mode too, not only fill-gaps', JSON.parse(r.raw).length === 1);
+}
+
+// ── 10. Default mode is what contributions use: every field is updatable ───
+{
+  const r = run({ patches: [{ store_id: 'a1', updates: {
+    name: 'Renamed', address: 'вул. Нова, 5', hours: { mon: '08:00–20:00' },
+  } }] }, pretty);
+  const s0 = JSON.parse(r.raw)[0];
+  check('an approved rename lands', s0.name === 'Renamed', s0.name);
+  check('an approved address change lands over an existing one', s0.address === 'вул. Нова, 5', s0.address);
+  check('an approved hours change lands over a recorded day', s0.hours.mon === '08:00–20:00', s0.hours.mon);
+  check('untouched days survive the merge', s0.hours.sun === 'closed');
+  check('nothing is held back for review', r.report.needsReview.length === 0, JSON.stringify(r.report.needsReview));
+}
+{
+  // The one thing still withheld: a new pin on top of an existing store.
+  const one = JSON.stringify([{ id: 'c9', name: 'Existing', lat: 49.8397, lng: 24.0297, cycle: 7 }], null, 2) + '\n';
+  const r = run({ adds: [{ name: 'Dup', lat: 49.83972, lng: 24.02972 }] }, one);
+  check('a duplicate addition is still refused in default mode', JSON.parse(r.raw).length === 1);
+  check('and reported', r.report.rejectedAdds.length === 1);
+}
+{
+  // Noise suppression, not a value judgment: the resulting state is identical.
+  const r = run({ patches: [{ store_id: 'a2', updates: { dailyDrop: false, phone: '+38 (1) 1' } }] }, pretty);
+  const s1 = JSON.parse(r.raw)[1];
+  check('a false flag on a store that lacks it is not written', !('dailyDrop' in s1));
+  check('while the real field in the same patch still lands', s1.phone === '+38 (1) 1');
 }
 
 console.log('');

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -320,11 +320,10 @@ const AUTO_PATCH_FIELDS = [
   'dailyDrop', 'restockDay', 'restock_date', 'note', 'hours',
 ];
 
-// Turns an approved contribution's corrections into one fill-gaps batch. The
-// workflow decides what actually lands: anything that would contradict a value
-// already on the map is declined there and raised as its own issue. So this
-// only has to be conservative about *which fields* may be offered, not about
-// whether each one is right.
+// Turns an approved contribution's corrections into one batch. Conservative
+// about *which fields* may be carried, not about whether each value is right —
+// that judgment was made when the moderator read the itemised list and tapped
+// approve.
 function contributionPatches(payload) {
   const list = Array.isArray(payload && payload.overrideList) ? payload.overrideList.slice(0, 200) : [];
   const patches = [];
@@ -341,8 +340,9 @@ function contributionPatches(payload) {
 }
 
 // Stores proposed for addition, trimmed to the fields stores.json holds. The
-// applier still refuses anything landing within 60 m of an existing pin, so
-// this only has to filter fields, not judge the store.
+// applier still refuses anything landing within 60 m of an existing pin — a
+// duplicate store is corrupt data rather than a correction, and it is the one
+// failure this map keeps hitting — so this only filters fields.
 function contributionAdds(payload) {
   const list = Array.isArray(payload && payload.custom) ? payload.custom.slice(0, 50) : [];
   return list.map((c) => {
@@ -361,7 +361,7 @@ function contributionRemoves(payload) {
   return list.map((r) => r && r.id).filter((id) => typeof id === 'string' && /^[a-z0-9]{1,12}$/i.test(id));
 }
 
-async function dispatchFillGaps(env, body) {
+async function dispatchContribution(env, body) {
   if (!env.GH_PAT) throw new Error('GH_PAT not configured');
   const res = await fetch('https://api.github.com/repos/anonymouspartner/lviv-secondhand/dispatches', {
     method: 'POST',
@@ -372,7 +372,7 @@ async function dispatchFillGaps(env, body) {
       'X-GitHub-Api-Version': '2022-11-28',
       'User-Agent': 'lviv-secondhand-worker',
     },
-    body: JSON.stringify({ event_type: 'update_map_data', client_payload: { mode: 'fill-gaps', ...body } }),
+    body: JSON.stringify({ event_type: 'update_map_data', client_payload: body }),
   });
   if (res.status !== 204) throw new Error(`dispatch failed: ${res.status}`);
 }
@@ -1427,7 +1427,12 @@ export default {
           removes = contributionRemoves(payload);
           if (patches.length || adds.length || removes.length) {
             try {
-              await dispatchFillGaps(env, { patches, adds, removes });
+              // Default (overwrite) mode: the moderator has just read an
+              // itemised list of every change and approved it. A correction
+              // only ever disagrees with what's on the map — that is what makes
+              // it a correction — so refusing to overwrite would mean the one
+              // thing this pipeline could never ship is a fix.
+              await dispatchContribution(env, { patches, adds, removes });
             } catch (e) {
               return new Response('map-patch dispatch failed — check GH_PAT and the update-map workflow logs', { status: 502 });
             }
@@ -1456,7 +1461,7 @@ export default {
         if (adds.length) bits.push(`${adds.length} new store(s)`);
         if (removes.length) bits.push(`${removes.length} removal(s)`);
         const applied = bits.length
-          ? `🤖 Sent to the map pipeline: ${bits.join(', ')}.\nIt ships in a couple of minutes. Anything that disagrees with data already on the map — or an addition landing on top of an existing pin — is declined there and raised as its own issue.\n\n`
+          ? `🤖 Sent to the map pipeline: ${bits.join(', ')}.\nIt ships in a couple of minutes. An addition landing on top of an existing pin is held back and raised as its own issue; everything else applies as submitted.\n\n`
           : '';
         return new Response(issueUrl
           ? `✅ Approved.\n\n${applied}Issue created:\n${issueUrl}`


### PR DESCRIPTION
Contributions were dispatched in `fill-gaps` mode, which writes only where the map holds nothing. That made **a correction the one thing the pipeline could never ship** — an edit to a name, address or a recorded opening time disagrees with what's on record *by definition*, which is what makes it a correction.

## The concrete case

Editing `c62`'s name, address and hours in the app, then approving:

| field | on the map | before this change |
|---|---|---|
| hours | all `?` | ✅ applied |
| phone | empty | ✅ applied |
| **name** | `Бомба` | ❌ declined → issue |
| **address** | `вул. Пантелеймона Куліша` | ❌ declined → issue |

The half that mattered was the half that never landed.

## After

```
c62 after the approval:
   name    : Бомба — секонд хенд
   address : вул. Пантелеймона Куліша, 12
   addrEn  : 12 Panteleymona Kulisha St
   hours   : mon 09:00–19:00  sat 09:00–18:00  sun closed
   pricing : item (untouched)
   lat/lng : 49.848122,24.02414 (untouched)

held back for review: 0
```

Fields not in the patch are untouched — it's still a merge, not a replace.

## Why this is safe enough

The moderator has just read an **itemised list**: every removal by name, every addition with its address, every edit with its field list. That is the review. A second one, field by field in GitHub, was the thing being asked for less of.

## Two behaviours moved off the mode

Neither was ever about trust:

**Unknown store ids** now soft-fail on *payload shape*. A batch reports the miss and applies the rest — a contribution can legitimately name a store the map doesn't hold. A single `{ store_id, updates }` still throws, because those callers pass an id they read out of `stores.json` a moment earlier.

**Adds and removes** are honoured in both modes. They're explicit instructions, not a merge strategy.

## The one thing still withheld

An addition landing **within 60 m of an existing pin**. A duplicate store is corrupt data rather than a correction, and it's the failure this map keeps hitting — `c12`, `c13` and two re-submitted stores were all found that way. It's raised as an issue, not dropped.

Also suppressed: a proposed `false` for a flag the store doesn't set. The resulting state is identical either way, so writing it would only let an older cached client slowly add `"dailyDrop": false` across the dataset. Not a judgment about the value — there's nothing to change.

`fill-gaps` is kept and still fully tested, for any future flow that merges a source it doesn't fully trust. Nothing uses it by default now.

## Tests

`check-map-patch.mjs` covers the new semantics — an approved rename, address change and hours change all land, sibling days survive the merge, nothing is held back, the duplicate refusal still fires, and a batch reports a missing id while a single patch still throws.

Green: `validate-stores` (130 stores), `check-inline-js`, `check-wiring` 7/7, `check-map-patch`, `check-workflows` 14/14, `node --check` on both Workers and `sw.js`, plus a real YAML parse of all fourteen workflows.

## Worth being plain about

I argued for `fill-gaps` on the grounds that it would have stopped #278's seventeen bad fields — including a revert of `c21`'s door-sign hours. That protection is now gone: whatever is approved, applies.

What replaces it is the itemised Telegram message. It's a real review rather than a rubber stamp, but it is the only one left, and #278 is a live example of a bundle that looked routine and wasn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_