### PR TITLE
Move c62's pin to Куліша 14

### DIFF
--- a/qr/index.html
+++ b/qr/index.html
@@ -81,7 +81,7 @@ li:last-child{border-bottom:0}
     <li><span class="dot" style="background:#5a70dd"></span><a href="https://www.lvivsecondhand.com/qr/c90/">Сток та секонд хенд — Величковського 30а</a><span class="dim"> — вул. Величковського, 30а</span></li>
     <li><span class="dot" style="background:#19a6ad"></span><a href="https://www.lvivsecondhand.com/qr/c89/">Сток та секонд хенд — Пасічна 96А</a><span class="dim"> — вул. Пасічна, 96А</span></li>
     <li><span class="dot" style="background:#e2761f"></span><a href="https://www.lvivsecondhand.com/qr/c91/">Сток та секонд хенд — Стрийська 61</a><span class="dim"> — вул. Стрийська, 61</span></li>
-    <li><span class="dot" style="background:#8fa62c"></span><a href="https://www.lvivsecondhand.com/qr/c62/">Супер Бомба секонд хенду</a><span class="dim"> — вул. Пантелеймона Куліша 14</span></li>
+    <li><span class="dot" style="background:#8fa62c"></span><a href="https://www.lvivsecondhand.com/qr/c62/">Супер Бомба секонд хенду</a><span class="dim"> — вул. Пантелеймона Куліша, 14</span></li>
     <li><span class="dot" style="background:#9a4fc9"></span><a href="https://www.lvivsecondhand.com/qr/c79/">Супер секонд-хенд</a><span class="dim"> — вул. Базарна, 8</span></li>
     <li><span class="dot" style="background:#5a70dd"></span><a href="https://www.lvivsecondhand.com/qr/c126/">Супер секонд-хенд</a><span class="dim"> — вул. Староміська, 1</span></li>
     <li><span class="dot" style="background:#19a6ad"></span><a href="https://www.lvivsecondhand.com/qr/c67/">Супер-Бомба</a><span class="dim"> — вул. Городоцька, 6</span></li>

--- a/store/c118/index.html
+++ b/store/c118/index.html
@@ -109,8 +109,8 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — 450 м, вул. Чорновола, 67</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/s4/">ObnovaNova</a><span class="dim"> — 670 м, просп. В. Чорновола, 16і</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c84/">Світ секонд-хенду — Цехова 1</a><span class="dim"> — 760 м, вул. Цехова, 1</span></li>
-      <li><a href="https://www.lvivsecondhand.com/store/c62/">Супер Бомба секонд хенду</a><span class="dim"> — 890 м, вул. Пантелеймона Куліша 14</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/h3/">HUMANA — Chornovola</a><span class="dim"> — 910 м, просп. В. Чорновола, 95</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c62/">Супер Бомба секонд хенду</a><span class="dim"> — 1.0 км, вул. Пантелеймона Куліша, 14</span></li>
   </ul>
 
   <footer>

--- a/store/c125/index.html
+++ b/store/c125/index.html
@@ -161,7 +161,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <li><a href="https://www.lvivsecondhand.com/store/c126/">Супер секонд-хенд</a><span class="dim"> — 190 м, вул. Староміська, 1</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c88/">ЄвроБренд — Городоцька 33</a><span class="dim"> — 220 м, вул. Городоцька, 33</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c116/">Second hand — Шолом-Алейхема 20</a><span class="dim"> — 240 м, вулиця Шолом-Алейхема, 20</span></li>
-      <li><a href="https://www.lvivsecondhand.com/store/c61/">Євро секонд хенд</a><span class="dim"> — 310 м, вул. Базарна, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c62/">Супер Бомба секонд хенду</a><span class="dim"> — 310 м, вул. Пантелеймона Куліша, 14</span></li>
   </ul>
 
   <footer>

--- a/store/c126/index.html
+++ b/store/c126/index.html
@@ -151,8 +151,8 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <li><a href="https://www.lvivsecondhand.com/store/c125/">Birka! Lux — Шпитальна 7</a><span class="dim"> — 190 м, вул. Шпитальна, 7</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c127/">Взуття з Європи</a><span class="dim"> — 220 м, вул. Шпитальна, 8</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — 230 м, вулиця Котлярська, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c62/">Супер Бомба секонд хенду</a><span class="dim"> — 300 м, вул. Пантелеймона Куліша, 14</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c88/">ЄвроБренд — Городоцька 33</a><span class="dim"> — 390 м, вул. Городоцька, 33</span></li>
-      <li><a href="https://www.lvivsecondhand.com/store/c62/">Супер Бомба секонд хенду</a><span class="dim"> — 410 м, вул. Пантелеймона Куліша 14</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c116/">Second hand — Шолом-Алейхема 20</a><span class="dim"> — 420 м, вулиця Шолом-Алейхема, 20</span></li>
   </ul>
 

--- a/store/c27/index.html
+++ b/store/c27/index.html
@@ -166,9 +166,9 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <li><a href="https://www.lvivsecondhand.com/store/c127/">Взуття з Європи</a><span class="dim"> — 90 м, вул. Шпитальна, 8</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c125/">Birka! Lux — Шпитальна 7</a><span class="dim"> — 110 м, вул. Шпитальна, 7</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c116/">Second hand — Шолом-Алейхема 20</a><span class="dim"> — 200 м, вулиця Шолом-Алейхема, 20</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c62/">Супер Бомба секонд хенду</a><span class="dim"> — 220 м, вул. Пантелеймона Куліша, 14</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c126/">Супер секонд-хенд</a><span class="dim"> — 230 м, вул. Староміська, 1</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c61/">Євро секонд хенд</a><span class="dim"> — 260 м, вул. Базарна, 1</span></li>
-      <li><a href="https://www.lvivsecondhand.com/store/c79/">Супер секонд-хенд</a><span class="dim"> — 260 м, вул. Базарна, 8</span></li>
   </ul>
 
   <footer>

--- a/store/c62/index.html
+++ b/store/c62/index.html
@@ -4,13 +4,13 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="theme-color" content="#17693a">
-<title>Супер Бомба секонд хенду — вул. Пантелеймона Куліша 14 · Секонд-хенд Львів</title>
-<meta name="description" content="Супер Бомба секонд хенду — секонд-хенд у Львові, за адресою вул. Пантелеймона Куліша 14, поштучно (ціна за річ). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<title>Супер Бомба секонд хенду — вул. Пантелеймона Куліша, 14 · Секонд-хенд Львів</title>
+<meta name="description" content="Супер Бомба секонд хенду — секонд-хенд у Львові, за адресою вул. Пантелеймона Куліша, 14, поштучно (ціна за річ). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <link rel="canonical" href="https://www.lvivsecondhand.com/store/c62/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Lviv Second Hand">
-<meta property="og:title" content="Супер Бомба секонд хенду — вул. Пантелеймона Куліша 14 · Секонд-хенд Львів">
-<meta property="og:description" content="Супер Бомба секонд хенду — секонд-хенд у Львові, за адресою вул. Пантелеймона Куліша 14, поштучно (ціна за річ). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
+<meta property="og:title" content="Супер Бомба секонд хенду — вул. Пантелеймона Куліша, 14 · Секонд-хенд Львів">
+<meta property="og:description" content="Супер Бомба секонд хенду — секонд-хенд у Львові, за адресою вул. Пантелеймона Куліша, 14, поштучно (ціна за річ). Години роботи, ціни та цикл знижок на карті секонд-хендів Львова.">
 <meta property="og:url" content="https://www.lvivsecondhand.com/store/c62/">
 <meta property="og:image" content="https://www.lvivsecondhand.com/og-image.png">
 <meta property="og:locale" content="uk_UA">
@@ -25,15 +25,15 @@
   "url": "https://www.lvivsecondhand.com/store/c62/",
   "address": {
     "@type": "PostalAddress",
-    "streetAddress": "вул. Пантелеймона Куліша 14",
+    "streetAddress": "вул. Пантелеймона Куліша, 14",
     "addressLocality": "Львів",
     "addressRegion": "Львівська область",
     "addressCountry": "UA"
   },
   "geo": {
     "@type": "GeoCoordinates",
-    "latitude": 49.848122,
-    "longitude": 24.02414
+    "latitude": 49.8471165,
+    "longitude": 24.0244292
   },
   "openingHoursSpecification": [
     {
@@ -116,15 +116,15 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
   <nav class="crumb"><a href="https://www.lvivsecondhand.com/">Секонд-хенди Львова</a> › <a href="https://www.lvivsecondhand.com/store/">Усі магазини</a> › Супер Бомба секонд хенду</nav>
 
   <h1>Супер Бомба секонд хенду</h1>
-  <p class="sub">Секонд-хенд у Львові · вул. Пантелеймона Куліша 14</p>
+  <p class="sub">Секонд-хенд у Львові · вул. Пантелеймона Куліша, 14</p>
 
   <a class="cta" href="https://www.lvivsecondhand.com/?store=c62">Відкрити на карті</a>
-  <a class="cta alt" href="https://www.google.com/maps/dir/?api=1&amp;destination=49.848122,24.02414" rel="noopener">Прокласти маршрут</a>
+  <a class="cta alt" href="https://www.google.com/maps/dir/?api=1&amp;destination=49.8471165,24.0244292" rel="noopener">Прокласти маршрут</a>
 
   <h2>Інформація</h2>
   <table>
     <tbody>
-      <tr><th scope="row">Адреса</th><td>вул. Пантелеймона Куліша 14 <span class="dim">· 14 Panteleymona Kulisha St</span></td></tr>
+      <tr><th scope="row">Адреса</th><td>вул. Пантелеймона Куліша, 14 <span class="dim">· 14 Panteleymona Kulisha St</span></td></tr>
       <tr><th scope="row">Тип цін</th><td>Поштучно (ціна за річ)</td></tr>
       <tr><th scope="row">Цикл знижок</th><td>7 дн.</td></tr>
     </tbody>
@@ -144,16 +144,16 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
   </table>
 
   <h2>Примітки</h2>
-  <p class="note">From locator.lviv.ua listing. New stock arrives every day; the shop only does a full seasonal wardrobe change rather than following a fixed restock cycle.</p>
+  <p class="note">Адресу підтверджено власником мапи: буд. 14. Позначку зміщено на 114 м за геокодом будинку (OpenStreetMap) — за тією ж адресою значиться магазин одягу. · Address confirmed by the maintainer as no. 14. Pin moved 114 m to the building-level geocode (OpenStreetMap), which also lists a clothing shop at that number.</p>
 
   <h2>Секонд-хенди поруч</h2>
   <ul class="links">
-      <li><a href="https://www.lvivsecondhand.com/store/c84/">Світ секонд-хенду — Цехова 1</a><span class="dim"> — 120 м, вул. Цехова, 1</span></li>
-      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — 320 м, вулиця Котлярська, 6</span></li>
-      <li><a href="https://www.lvivsecondhand.com/store/s4/">ObnovaNova</a><span class="dim"> — 390 м, просп. В. Чорновола, 16і</span></li>
-      <li><a href="https://www.lvivsecondhand.com/store/c126/">Супер секонд-хенд</a><span class="dim"> — 410 м, вул. Староміська, 1</span></li>
-      <li><a href="https://www.lvivsecondhand.com/store/c127/">Взуття з Європи</a><span class="dim"> — 410 м, вул. Шпитальна, 8</span></li>
-      <li><a href="https://www.lvivsecondhand.com/store/c125/">Birka! Lux — Шпитальна 7</a><span class="dim"> — 420 м, вул. Шпитальна, 7</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — 220 м, вулиця Котлярська, 6</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c84/">Світ секонд-хенду — Цехова 1</a><span class="dim"> — 240 м, вул. Цехова, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c126/">Супер секонд-хенд</a><span class="dim"> — 300 м, вул. Староміська, 1</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c127/">Взуття з Європи</a><span class="dim"> — 310 м, вул. Шпитальна, 8</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c125/">Birka! Lux — Шпитальна 7</a><span class="dim"> — 310 м, вул. Шпитальна, 7</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c116/">Second hand — Шолом-Алейхема 20</a><span class="dim"> — 380 м, вулиця Шолом-Алейхема, 20</span></li>
   </ul>
 
   <footer>

--- a/store/c76/index.html
+++ b/store/c76/index.html
@@ -167,7 +167,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
       <li><a href="https://www.lvivsecondhand.com/store/c37/">EconomClass — Chornovola 67</a><span class="dim"> — 560 м, вул. Чорновола, 67</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/s4/">ObnovaNova</a><span class="dim"> — 580 м, просп. В. Чорновола, 16і</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c84/">Світ секонд-хенду — Цехова 1</a><span class="dim"> — 650 м, вул. Цехова, 1</span></li>
-      <li><a href="https://www.lvivsecondhand.com/store/c62/">Супер Бомба секонд хенду</a><span class="dim"> — 780 м, вул. Пантелеймона Куліша 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c62/">Супер Бомба секонд хенду</a><span class="dim"> — 890 м, вул. Пантелеймона Куліша, 14</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/h3/">HUMANA — Chornovola</a><span class="dim"> — 1.0 км, просп. В. Чорновола, 95</span></li>
   </ul>
 

--- a/store/c84/index.html
+++ b/store/c84/index.html
@@ -163,7 +163,7 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
 
   <h2>Секонд-хенди поруч</h2>
   <ul class="links">
-      <li><a href="https://www.lvivsecondhand.com/store/c62/">Супер Бомба секонд хенду</a><span class="dim"> — 120 м, вул. Пантелеймона Куліша 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c62/">Супер Бомба секонд хенду</a><span class="dim"> — 240 м, вул. Пантелеймона Куліша, 14</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/s4/">ObnovaNova</a><span class="dim"> — 340 м, просп. В. Чорновола, 16і</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c27/">Євро Тренд Секонд хенд — Котлярська 6</a><span class="dim"> — 440 м, вулиця Котлярська, 6</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c79/">Супер секонд-хенд</a><span class="dim"> — 500 м, вул. Базарна, 8</span></li>

--- a/store/index.html
+++ b/store/index.html
@@ -892,7 +892,7 @@ footer{margin-top:30px;padding-top:16px;border-top:1px solid var(--line);font-si
       <li><a href="https://www.lvivsecondhand.com/store/c90/">Сток та секонд хенд — Величковського 30а</a><span class="dim"> — вул. Величковського, 30а</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c89/">Сток та секонд хенд — Пасічна 96А</a><span class="dim"> — вул. Пасічна, 96А</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c91/">Сток та секонд хенд — Стрийська 61</a><span class="dim"> — вул. Стрийська, 61</span></li>
-      <li><a href="https://www.lvivsecondhand.com/store/c62/">Супер Бомба секонд хенду</a><span class="dim"> — вул. Пантелеймона Куліша 14</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c62/">Супер Бомба секонд хенду</a><span class="dim"> — вул. Пантелеймона Куліша, 14</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c79/">Супер секонд-хенд</a><span class="dim"> — вул. Базарна, 8</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c126/">Супер секонд-хенд</a><span class="dim"> — вул. Староміська, 1</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c67/">Супер-Бомба</a><span class="dim"> — вул. Городоцька, 6</span></li>

--- a/store/s4/index.html
+++ b/store/s4/index.html
@@ -150,8 +150,8 @@ footer{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-si
   <h2>Секонд-хенди поруч</h2>
   <ul class="links">
       <li><a href="https://www.lvivsecondhand.com/store/c84/">Світ секонд-хенду — Цехова 1</a><span class="dim"> — 340 м, вул. Цехова, 1</span></li>
-      <li><a href="https://www.lvivsecondhand.com/store/c62/">Супер Бомба секонд хенду</a><span class="dim"> — 390 м, вул. Пантелеймона Куліша 14</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c79/">Супер секонд-хенд</a><span class="dim"> — 470 м, вул. Базарна, 8</span></li>
+      <li><a href="https://www.lvivsecondhand.com/store/c62/">Супер Бомба секонд хенду</a><span class="dim"> — 480 м, вул. Пантелеймона Куліша, 14</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c61/">Євро секонд хенд</a><span class="dim"> — 510 м, вул. Базарна, 1</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c116/">Second hand — Шолом-Алейхема 20</a><span class="dim"> — 560 м, вулиця Шолом-Алейхема, 20</span></li>
       <li><a href="https://www.lvivsecondhand.com/store/c76/">Світ секонд-хенду — Чорновола 45</a><span class="dim"> — 580 м, просп. В&#39;ячеслава Чорновола, 45</span></li>

--- a/stores.json
+++ b/stores.json
@@ -1768,7 +1768,7 @@
     "id": "c62",
     "name": "Супер Бомба секонд хенду",
     "brand": "Independent",
-    "address": "вул. Пантелеймона Куліша 14",
+    "address": "вул. Пантелеймона Куліша, 14",
     "addressEn": "14 Panteleymona Kulisha St",
     "phone": "",
     "type": "other",
@@ -1783,9 +1783,9 @@
       "sun": "10:00–19:00"
     },
     "cycle": 7,
-    "lat": 49.848122,
-    "lng": 24.02414,
-    "note": "From locator.lviv.ua listing. New stock arrives every day; the shop only does a full seasonal wardrobe change rather than following a fixed restock cycle.",
+    "lat": 49.8471165,
+    "lng": 24.0244292,
+    "note": "Адресу підтверджено власником мапи: буд. 14. Позначку зміщено на 114 м за геокодом будинку (OpenStreetMap) — за тією ж адресою значиться магазин одягу. · Address confirmed by the maintainer as no. 14. Pin moved 114 m to the building-level geocode (OpenStreetMap), which also lists a clothing shop at that number.",
     "dailyDrop": true
   },
   {


### PR DESCRIPTION
The address was corrected to no. 14 through the app, but the marker stayed put — at the time nothing in the chain could move a pin. #290 changed that, so this catches the marker up with the address it already carries.

## The move

| | |
|---|---|
| from | `49.848122, 24.02414` |
| to | **`49.8471165, 24.0244292`** |
| distance | **114 m** |

Source: the OpenStreetMap **building-level** geocode for вул. Пантелеймона Куліша, 14 — a house-number match, not a street-level fallback.

**Corroborated:** OSM also lists a clothing-shop POI (`Одяг для жінок`) at that same number, which is what a secondhand at this address should look like to a geocoder.

**No collision:** nearest other store to the new position is `c27` at 223 m, then `c84` at 238 m. Well outside the 60 m duplicate radius.

Address normalised to `вул. Пантелеймона Куліша, 14` — comma before the house number, matching every other record.

## Note

This is a geocode, not a surveyed doorway. It's accurate to the building rather than the shopfront. Now that the app has a 📍 button, standing outside and tapping it would pin the actual entrance — worth doing next time you pass, the same way `c37` and `c21` were fixed.

Green: `validate-stores` (130 stores), `check-inline-js`, `check-wiring` 7/7, store pages / QR posters / chain pages / sitemap regenerated in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_