### PR TITLE
Fix the /visit store-picker's colliding route-stop and list-index numbers

### DIFF
--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -1447,7 +1447,13 @@ async function promptStorePick(env, uid, chatId, session) {
   session.step = 'store';
   await putSession(env, uid, session);
   const lines = near.map(({ s, d }, i) => {
-    const onRoute = routeIds.includes(s.id) ? ` 🧭${routeIds.indexOf(s.id) + 1}` : '';
+    // Route-stop number is unrelated to this list's own reply-index below, and
+    // a bare digit right after the name reads exactly like an alternative
+    // pick number -- a field report showed exactly that: a store's route-stop
+    // number visually matched a *different* store's list position, and the
+    // agent replied with the route number, picking the wrong store. Spelling
+    // it out removes the ambiguity.
+    const onRoute = routeIds.includes(s.id) ? ` (🧭 маршрут, зупинка ${routeIds.indexOf(s.id) + 1} · route stop ${routeIds.indexOf(s.id) + 1})` : '';
     return `${i + 1}. <b>${esc(s.name)}</b>${onRoute} · ${fmtDist(d)}${s.address ? ' — ' + esc(s.address) : ''}`;
   });
   // The line on a real map, from wherever they are in the round — no need to


### PR DESCRIPTION
Root cause of the field report: "We chose number 8 from the list. The address was Shpitalna 7, I went to the map and it said Horodotska 33."

## What actually happened

Traced against the two screenshots and `stores.json` directly. `c88` (ЄвроБренд — Городоцька 33) and `c125` (Birka! Lux — Шпитальна 7) are two genuinely separate stores ~220m apart — not a duplicate-id or data-corruption bug.

The real issue is in `promptStorePick()`'s nearby-store list. Every line carries **two independent numbers**:
- the reply-index at the start (`5.`, `8.`, …) — what she's actually supposed to type back
- a route-stop badge (`🧭N`) for any store that's *also* on her currently active `/route` — completely unrelated numbering

In her case, ЄвроБренд was list position **5** but happened to be route-stop **🧭8**; Birka Lux was list position **8**. A bare digit stuck right after a store's name reads exactly like an alternative way to pick it — she read "🧭8" next to ЄвроБренд and replied "8", and the bot (correctly, by its own rules) resolved that as list position 8: Birka Lux.

## The fix

Spells the route-stop badge out — `(🧭 маршрут, зупинка 8 · route stop 8)` instead of a bare `🧭8` — so it can no longer be misread as a second reply-index. Nothing about the actual picking logic changed; this is purely about removing the visual collision.

**Worth checking on your end:** if she went on to complete that `/visit` while actually standing at ЄвроБренд's storefront, the submission would be recorded against Birka Lux's id (`c125`) instead — worth a look at whether that visit's "✅ Publish" got tapped, since it would have written the wrong store's data.

## Test plan

- [x] `node --check telegram-bot/worker.js`
- [x] `node scripts/check-wiring.mjs`, `node scripts/validate-stores.mjs`
- [x] Confirmed both stores are real, separate, correctly-coordinated entries in `stores.json` — this is a display bug, not a data bug

Draft — for your review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_