### PR TITLE
Scope the /visit map link to its own list, not the agent's whole route

### DIFF
--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -1456,12 +1456,18 @@ async function promptStorePick(env, uid, chatId, session) {
     const onRoute = routeIds.includes(s.id) ? ` (🧭 маршрут, зупинка ${routeIds.indexOf(s.id) + 1} · route stop ${routeIds.indexOf(s.id) + 1})` : '';
     return `${i + 1}. <b>${esc(s.name)}</b>${onRoute} · ${fmtDist(d)}${s.address ? ' — ' + esc(s.address) : ''}`;
   });
-  // The line on a real map, from wherever they are in the round — no need to
-  // re-run /route to get their bearings.
-  const mapIds = (routeIds.length ? routeIds : near.map(({ s }) => s.id)).join(',');
+  // Always this list's own 8 stores, in this list's own order -- not the
+  // agent's whole day's route. A field report showed why: when a route was
+  // active, this used to link to the FULL route, whose pins are numbered by
+  // route-walking-order. That's a third, independent numbering next to this
+  // message's own 1-8 -- "pin 3 on the map" ended up meaning a completely
+  // different store than "item 3 in the list" (an early, already-visited
+  // stop vs. the nearby store she was trying to identify). Scoping the link
+  // to exactly what's listed here means pin N is always item N.
+  const mapIds = near.map(({ s }) => s.id).join(',');
   await say(env, chatId,
     '2️⃣ Який це магазин? Надішліть номер · Which store? Reply with the number:\n' + lines.join('\n') +
-    `\n\n🗺️ <a href="${APP_URL}?route=${mapIds}">${routeIds.length ? 'Маршрут на карті · Route on the map' : 'Ці магазини на карті · These stores on the map'}</a>` +
+    `\n\n🗺️ <a href="${APP_URL}?route=${mapIds}">Ці магазини на карті · These stores on the map</a>` +
     '\n\nНемає у списку — надішліть назву, або <code>new Назва</code>.\nNot listed — send a name, or <code>new Name</code>.',
     near.map((_, i) => [String(i + 1)]));
 }


### PR DESCRIPTION
Follow-up to #313, same root cause one click further away — reported right after the field agent hit the fixed version.

## What happened

Her message: "again it doesn't match, in the list it was written under number 3 - Shpitalna 7, and in the map under number 3 - Vinnychenko, which we have already visited."

The `/visit` nearby-store list's "🗺️ map" link, whenever she had an active `/route`, fell back to linking her **entire day's route** instead of just the 8 stores actually shown in the list — and the app numbers map pins by *route-walking-order*, not list order. So:
- **List item 3** = Birka! Lux — Шпитальна 7 (3rd-nearest store right now)
- **Map pin 3** = the 3rd stop in her *whole route* (an early stop she'd already visited)

Two more numbers, meaning two different things, sitting one tap apart. Same class of bug as #313 — this repo has ended up with three independent "number a store" schemes (list reply-index, route-stop badge, route-walking-order map pins) that can collide anywhere they appear side by side.

## The fix

The map link now always carries exactly the 8 ids from the list currently shown, in that list's own order — so a pin's number on the map always equals its list position, full stop. Dropped the "link to the whole route" fallback entirely for this specific link, since its actual purpose here is "let me see which building is store N," not general orientation.

`/route`'s own map link is untouched and doesn't need this — there, the numbered list *is* the route, so list position and map pin already agree by construction.

## Test plan

- [x] `node --check telegram-bot/worker.js`
- [x] `node scripts/check-wiring.mjs`, `node scripts/validate-stores.mjs`, `node scripts/check-inline-js.mjs`
- [x] Traced `?route=` handling in `index.html` (`checkRouteInURL`, `agentRouteIds`, pin ordering) to confirm pins are numbered by array order, which is what made the mismatch possible
- [ ] Manual check post-deploy: with an active `/route`, open `/visit`'s map link and confirm pin numbers match the list

Draft — for your review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_