### PR TITLE
Add /apply — a field-agent onboarding pathway through Довідка

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ Every ad carries **`РЕКЛАМА · SPONSORED`** at the top of the image. The 
 | `/cheap` | Which stores have gone longest since a restock |
 | `/submit` | Submit your own store (for shop owners) |
 | `/materials` | Printable flyers, posters and QR stickers |
+| `/apply` | Apply to become a field agent |
 | `/feedback` | Send the maintainer a note about the bot or the map |
 | `/leaderboard` | Top 10 community contributors by points |
 | `/stop` | Unsubscribe from everything — restock alerts *and* flash-deal alerts |
@@ -709,6 +710,7 @@ PWA (прогресивний веб-додаток) для пошуку та в
 | `/cheap` | Хто найдовше без завозу |
 | `/submit` | Додати свій магазин (для власників) |
 | `/materials` | Матеріали для друку: флаєри, постери, QR-наліпки |
+| `/apply` | Податися в польові агенти |
 | `/feedback` | Надіслати власнику відгук про бота чи карту |
 | `/leaderboard` | Топ-10 учасників спільноти за балами |
 | `/stop` | Відписатися від усіх сповіщень про спалах-знижки |

--- a/jobs/index.html
+++ b/jobs/index.html
@@ -165,9 +165,9 @@ code{background:var(--chip);border:1px solid var(--line);border-radius:6px;paddi
     <div class="rule"></div>
     <div class="start">
       <ul class="ticks">
-        <li>Відкрийте <code>@Secondhandlvivbot</code> у Telegram і надішліть будь-яке повідомлення (наприклад, <code>/start</code>) — оскільки ви ще не зареєстровані, бот покаже ваш Telegram ID. Перешліть цей ID мені.</li>
+        <li>Відкрийте <code>@Secondhandlvivbot</code> у Telegram і надішліть <code>/apply</code> — коротко напишіть, чому цікавить роль, вашу доступність (дні/години) і чи є телефон з GPS.</li>
         <li>Переконайтеся, що у вас встановлено Telegram.</li>
-        <li>Я додам вас до списку агентів, надішлю першу зону і разом пройдемо перший <code>/visit</code>. Тоді ж командою <code>/card</code> ви вкажете картку для виплат.</li>
+        <li>Я розгляну заявку, додам вас до списку агентів, надішлю першу зону і разом пройдемо перший <code>/visit</code>. Тоді ж командою <code>/card</code> ви вкажете картку для виплат.</li>
       </ul>
     </div>
     <p class="note">Фотографуйте вітрини та товар — <b>не людей</b> — і тримайте кожен контакт власника конфіденційним.</p>

--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -242,7 +242,7 @@ function helpText() {
     '/rare — stores that restock every 14+ days · рідко оновлювані магазини',
     '/cheap — longest since a restock · найдовше без завозу',
     '/submit — add your store (for owners) · додати свій магазин',
-    '/apply — apply to be a field agent · податися в польові агенти',
+    '/job — vacancy: field agent · вакансії: польовий агент',
     '/feedback — tell the maintainer something · залишити відгук',
     '/materials — print-ready flyers, stickers, poster · рекламні матеріали для друку',
     '/help — this message · ця довідка',
@@ -1313,6 +1313,7 @@ const PUBLIC_CMDS = [
   { command: 'cheap', description: '🛍 Хто найдовше без завозу' },
   { command: 'submit', description: '🏪 Додати свій магазин (власникам)' },
   { command: 'materials', description: '🏪 Матеріали для друку: флаєри, наліпки' },
+  { command: 'job', description: '🧭 Вакансія польового агента · Field agent vacancy' },
   { command: 'apply', description: '🧭 Податися в польові агенти · Apply to be a field agent' },
   { command: 'feedback', description: '💬 Залишити відгук власнику' },
   { command: 'leaderboard', description: '🏆 Топ учасників за балами' },
@@ -1834,11 +1835,13 @@ function jobText() {
   return [
     '📋 <b>Опис вакансії · Job brief</b>',
     'Повний опис ролі, як це працює та схема оплати (UA/EN):',
-    'Full role, workflow and pay scheme:',
+    'Full role, workflow and pay scheme.',
     '',
     `👉 <a href="${JOB_BRIEF_URL}">Відкрити опис вакансії · Open the job brief</a>`,
     '',
-    'Питання? Пишіть власнику напряму. · Questions? Message the owner directly.',
+    'Готові податися? Натисніть /apply. · Ready to apply? Tap /apply.',
+    '',
+    'Питання? Скористайтесь /feedback. · Questions? Use /feedback.',
   ].join('\n');
 }
 
@@ -2439,8 +2442,10 @@ async function handleVisit(env, c, msg, ctx) {
     await cmdCard(env, userId, chatId, arg);
     return true;
   }
+  // #316: public, not gated on isAgent/isOwner — this is the job brief a
+  // prospective applicant reads before they have any access at all
+  // (Довідка → Вакансії), not just a reference for existing agents.
   if (command === 'job' || command === 'brief') {
-    if (!(isAgent || isOwner)) { await say(env, chatId, notAgentMsg(userId)); return true; }
     await cmdJob(env, chatId);
     return true;
   }

--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -242,6 +242,7 @@ function helpText() {
     '/rare — stores that restock every 14+ days · рідко оновлювані магазини',
     '/cheap — longest since a restock · найдовше без завозу',
     '/submit — add your store (for owners) · додати свій магазин',
+    '/apply — apply to be a field agent · податися в польові агенти',
     '/feedback — tell the maintainer something · залишити відгук',
     '/materials — print-ready flyers, stickers, poster · рекламні матеріали для друку',
     '/help — this message · ця довідка',
@@ -983,6 +984,74 @@ async function handleFeedbackFlow(env, ctx) {
   return await submitFeedback(env, ctx, raw);
 }
 
+// Application to become a field agent, reachable from Довідка/help (/apply).
+// Same shape as the feedback flow above — a short-lived KV wait flag
+// captures the next free-text message — but pushes straight to the owner
+// via Telegram rather than through /api/submit, since a hire isn't a
+// map-data change and has no business in a GitHub issue. Approving still
+// means adding the id to AGENT_IDS and redeploying, same as today; this
+// only replaces the manual "copy my id out of a message" step (notAgentMsg)
+// with an application the owner can act on directly.
+const APPLY_WAIT_TTL = 300; // 5 min
+const applyWaitKey = (uid) => `applywait:${uid}`;
+
+async function submitAgentApplication(env, c, ctx, whyText) {
+  const { chatId, from } = ctx;
+  const text = String(whyText || '').trim().slice(0, 2000);
+  if (!text) return false;
+  const name = [from.first_name, from.last_name].filter(Boolean).join(' ') || String(chatId);
+  const handle = from.username ? `@${from.username}` : '—';
+  if (c.ownerId) {
+    await tg(env, 'sendMessage', {
+      chat_id: c.ownerId, parse_mode: 'HTML',
+      text: `🧭 <b>Заявка в польові агенти · Field agent application</b>\n` +
+        `${esc(name)} (${esc(handle)})\n` +
+        `ID: <code>${chatId}</code>\n\n` +
+        `${esc(text)}\n\n` +
+        `Додайте id до AGENT_IDS у telegram-bot/wrangler.toml і розгорніть, щоб надати доступ. · ` +
+        `Add the id to AGENT_IDS in telegram-bot/wrangler.toml and redeploy to grant access.`,
+    });
+  }
+  await tg(env, 'sendMessage', {
+    chat_id: chatId,
+    text: '🧭 Дякуємо! Заявку надіслано власнику. · Thanks — your application was sent to the owner.',
+  });
+  return true;
+}
+
+async function handleAgentApplyFlow(env, c, ctx) {
+  if (!env.BOT_TOKEN || !env.VISITS) return false;
+  const { userId, chatId, text } = ctx;
+  const raw = String(text || '').trim();
+  const command = raw ? (/^\/([a-z]+)(?:@\w+)?/i.exec(raw) || [])[1]?.toLowerCase() : null;
+  if (command === 'apply') {
+    const isOwner = Boolean(c.ownerId) && String(userId) === c.ownerId;
+    const isAgent = c.agentIds.includes(String(userId));
+    if (isOwner || isAgent) {
+      await tg(env, 'sendMessage', { chat_id: chatId, text: '🧭 У вас вже є доступ. · You already have access.' });
+      return true;
+    }
+    await env.VISITS.put(applyWaitKey(userId), '1', { expirationTtl: APPLY_WAIT_TTL });
+    await tg(env, 'sendMessage', {
+      chat_id: chatId, parse_mode: 'HTML',
+      text: `🧭 <b>Заявка в польові агенти · Field agent application</b>\n` +
+        `Спершу прочитайте опис ролі: <a href="${JOB_BRIEF_URL}">Опис вакансії · Job brief</a>\n\n` +
+        `Напишіть одним повідомленням: чому цікавить, доступність (дні/години), чи є телефон з GPS. · ` +
+        `Send one message: why you're interested, your availability (days/hours), and whether you have a GPS-capable phone.`,
+    });
+    return true;
+  }
+  // Not a command — might be the pending application text the prompt above
+  // asked for. Bail on anything command-shaped so this can never swallow an
+  // unrelated command as an application.
+  if (!raw || raw.startsWith('/')) return false;
+  let waiting = null;
+  try { waiting = await env.VISITS.get(applyWaitKey(userId)); } catch (e) {}
+  if (!waiting) return false;
+  await env.VISITS.delete(applyWaitKey(userId));
+  return await submitAgentApplication(env, c, ctx, raw);
+}
+
 // `/start bounty_{token}` — the deep-link entry point. Returns true if it
 // consumed the update (whether or not the token was valid).
 async function handleBountyStart(env, c, ctx) {
@@ -1244,6 +1313,7 @@ const PUBLIC_CMDS = [
   { command: 'cheap', description: '🛍 Хто найдовше без завозу' },
   { command: 'submit', description: '🏪 Додати свій магазин (власникам)' },
   { command: 'materials', description: '🏪 Матеріали для друку: флаєри, наліпки' },
+  { command: 'apply', description: '🧭 Податися в польові агенти · Apply to be a field agent' },
   { command: 'feedback', description: '💬 Залишити відгук власнику' },
   { command: 'leaderboard', description: '🏆 Топ учасників за балами' },
   { command: 'stop', description: '🔕 Вимкнути всі сповіщення' },
@@ -1754,7 +1824,8 @@ async function ownerExport(env, chatId) {
 
 function notAgentMsg(uid) {
   return `🔒 Ви не в списку польових агентів. · You're not a registered field agent.\n` +
-    `Надішліть власнику цей ID, щоб отримати доступ · Send this ID to the owner to get access:\n<code>${uid}</code>`;
+    `Надішліть заявку командою /apply · Apply with /apply\n` +
+    `(або надішліть власнику цей ID напряму · or send the owner this ID directly: <code>${uid}</code>)`;
 }
 
 // Job brief for a prospective/onboarding agent to read and review.
@@ -2784,6 +2855,14 @@ export default {
     // pending feedback text.
     try {
       if (await handleFeedbackFlow(env, mctx)) return ok();
+    } catch (e) {}
+
+    // Field-agent application (/apply), reachable from Довідка/help. Same
+    // tier as feedback above — open to anyone, not gated on already being an
+    // agent — and checked after it for the same reason: an in-progress
+    // /visit's free text should never be mistaken for a pending application.
+    try {
+      if (await handleAgentApplyFlow(env, c, mctx)) return ok();
     } catch (e) {}
 
     // Public, stateless commands (answered in the webhook response — no token).


### PR DESCRIPTION
Field-agent onboarding pathway, reachable through Довідка/help — per your scope choice: **in-bot application, you approve manually**.

## What it does

`/apply` (mentioned in `/help`'s Довідка text) starts a short flow:
1. If the sender is already an agent or owner, tells them so and stops.
2. Otherwise, points them at the job brief and asks for **one message** covering why they're interested, their availability, and whether they have a GPS-capable phone.
3. That message gets forwarded straight to you in Telegram, with the applicant's name, `@handle`, and Telegram id in a copy-friendly `<code>` block, plus a reminder of the exact step to grant access.

**What doesn't change:** approving still means adding the id to `AGENT_IDS` in `telegram-bot/wrangler.toml` and redeploying, same as today. This only replaces the manual "have them forward me their ID" step with an actual application you can act on directly — no new architecture, no redeploy-free access grant (that was the "instant approval" option you didn't pick).

Implementation mirrors the existing `/feedback` flow almost exactly (a short-lived KV wait-flag captures the next free-text message) — but pushes to you via Telegram directly rather than through `/api/submit`, since a hire isn't a map-data change and has no business becoming a GitHub issue.

**Also touched**, since they were the natural other places this needed to land:
- `notAgentMsg()` — the message someone gets when they try an agent-only command without access — now leads with `/apply` instead of "forward me your ID."
- `jobs/index.html`'s "Як почати" section and both README command tables updated to describe `/apply` instead of the old manual flow.

## Test plan

- [x] `node --check telegram-bot/worker.js`
- [x] `node scripts/check-wiring.mjs` — 24 commands listed, all resolved (up from 23)
- [x] `node scripts/validate-stores.mjs`, `node scripts/check-inline-js.mjs`
- [ ] Manual check post-deploy: `/apply` as a non-agent, confirm the owner push arrives correctly and the id renders as copyable

Draft — for your review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_