### PR TITLE
Clarify /route's closing line for every stop, not just the first

### DIFF
--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -2580,7 +2580,8 @@ async function handleVisit(env, c, msg, ctx) {
       lines.join('\n') +
       `\n\n🗺️ <a href="${routeUrl}">Показати на карті · See it on the map</a>` +
       `\n🧭 <a href="${mapsUrl}">Навігація в Google Maps · Turn-by-turn in Google Maps</a>\n\n` +
-      'Далі — /visit біля першого магазину. · Then /visit at the first store.');
+      'Далі — рухайтесь до першого магазину і на місці надішліть /visit. Прибувши до наступної точки, знову оберіть /visit. · ' +
+      'Now go to your first store and send /visit once there. When you arrive at your next location, select /visit again.');
     return true;
   }
 


### PR DESCRIPTION
## What

`/route`'s closing line read "Далі — /visit біля першого магазину. · Then
/visit at the first store." — worded like a one-time instruction, even
though the same step (arrive, send `/visit`) applies at every stop on the
route, not just the first.

Reworded to spell that out: go to the first store and send `/visit` on
arrival, then do the same at the next location, and so on.

## Test plan

- [x] `node --check telegram-bot/worker.js`
- [x] `node scripts/check-wiring.mjs`
- [x] `node scripts/validate-stores.mjs`
- [x] `node scripts/check-inline-js.mjs`


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_