### PR TITLE
Sort the default store list by cycle urgency instead of insertion order

### DIFF
--- a/index.html
+++ b/index.html
@@ -1630,6 +1630,15 @@ function isOpenNow(s) {
 // another map, that map copied our dataset. Keep the filter centralized here.
 function allStores() { return [...STORES, ...getCustomStores()].filter(s => !s.watermark); }
 
+// How close a store is to the end of its restock cycle — the same day/cycle
+// ratio that already drives its fresh/mid/old badge, reused here as a sort
+// key instead of just a label. Unranked (no cycle data) sorts last: nothing
+// to prioritize it for, not a claim that it's freshest.
+function cycleUrgency(s) {
+  const cs = calculateStoreCycleState(getStoreData(s));
+  return cs ? cs.day / cs.cycle : -1;
+}
+
 function filtered() {
   const hidden = new Set(getHiddenStores());
   // A planned route replaces the filters entirely — the agent asked for these
@@ -1657,6 +1666,14 @@ function filtered() {
   });
   if (currentFilter === 'nearby' && filterUserPos) {
     list = list.map(s => [s, distMeters(filterUserPos, s)]).sort((a,b) => a[1]-b[1]).map(x => x[0]);
+  } else {
+    // #323: the list used to keep stores.json's own insertion order, which
+    // happened to cluster HUMANA branches near the top and read as
+    // favoritism. Sort by cycle urgency instead — closest to a restock
+    // first, the one thing most worth leading with for someone browsing
+    // without a specific chain in mind. "nearby" keeps its own distance
+    // sort above, a different deliberate choice the user already made.
+    list = list.map(s => [s, cycleUrgency(s)]).sort((a,b) => b[1]-a[1]).map(x => x[0]);
   }
   // Sponsored stores float to the top of whatever view is showing (stable — the
   // rest keep their order). Clearly badged as advertising in the card.


### PR DESCRIPTION
Closes #323.

## What

The main store list kept `stores.json`'s own arbitrary insertion order for
its default view — nothing in the code actually gave HUMANA priority, it
just happened to sit early in the file, which read as favoritism.

`filtered()` now sorts the default (non-"nearby") view by the same
`day/cycle` ratio that already drives each card's fresh/mid/old badge
(`calculateStoreCycleState`/`getPhase`) — soonest-to-restock first. Stores
with no known cycle sort last, not first, since there's nothing to
prioritize them for. `nearby` keeps its own distance sort — a different,
deliberate choice the user made by tapping that filter.

## Verification

Ran the app in a real browser (Playwright against a local static server),
not just the syntax gate:

- No console/page errors.
- Confirmed via `filtered()` directly and the rendered DOM: the top of the
  default list is now a genuine mix of chains, all at "🔴 Late cycle" /
  high day-in-cycle ratio — no HUMANA clustering.

## Test plan

- [x] `node scripts/check-inline-js.mjs`
- [x] `node scripts/validate-stores.mjs`
- [x] `node scripts/check-wiring.mjs`
- [x] Manually verified in a headless browser — see above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8At7YzuKfvMxjHVXf8nfN)_