### PR TITLE
Mirror automatic posts to a Telegram channel, run store-of-the-week weekly, and document the wider plan

### DIFF
--- a/.github/workflows/deals-image.yml
+++ b/.github/workflows/deals-image.yml
@@ -82,3 +82,15 @@ jobs:
     with:
       image: marketing/deals-this-week.jpg
       caption: ${{ needs.deals.outputs.caption }}
+
+  # Same image, same caption, second surface. A separate job rather than a step
+  # inside `post` so Instagram being broken (an expired token, most likely)
+  # cannot stop the channel from getting the week's ranking, and vice versa.
+  mirror:
+    needs: deals
+    if: needs.deals.outputs.changed == 'true'
+    uses: ./.github/workflows/telegram-channel-post.yml
+    secrets: inherit
+    with:
+      image: marketing/deals-this-week.jpg
+      caption: ${{ needs.deals.outputs.caption }}

--- a/.github/workflows/instagram-feature.yml
+++ b/.github/workflows/instagram-feature.yml
@@ -1,33 +1,46 @@
-name: Feature a store on Instagram (not an ad)
+name: Feature a store (not an ad)
 
-# Renders a store card from stores.json and, optionally, posts it.
+# Renders a store card from stores.json and posts it — to Instagram and, when a
+# channel is configured, to Telegram.
 #
 # This is the UNPAID counterpart to instagram-ad.yml. Nobody bought this
 # placement, so the card and the caption both say so outright — "Не реклама" —
 # rather than staying silent. Once some store posts are paid, an unlabelled one
 # is ambiguous rather than neutral, and the ambiguity flatters us.
 #
-# WHY THERE IS NO APPROVAL QUEUE HERE
-# instagram-ad.yml needs one because a payment triggers it: a machine decides to
-# make a post, so a human has to decide whether it goes out. This workflow is
-# already a human decision — you typed a store id into it. Adding a Worker row,
-# a token and an approve endpoint would add a security surface to guard a
-# decision that was never automatic.
+# TWO WAYS IN, AND THEY DIFFER ON PURPOSE
 #
-# So `publish` is false by default: the first run renders, commits and sends the
-# card to Telegram so you can look at it. Run it again with publish ticked to
-# post the same committed file. Two deliberate acts, no new endpoints.
+#   Weekly schedule — pick-feature.mjs chooses the store and the run publishes
+#   on its own. This is the "store of the week" slot: unattended, or it does not
+#   happen.
 #
-# There is NO text input. Every word comes from stores.json, so this workflow
-# cannot be used to put a sentence in a shop's mouth.
+#   By hand — you type a store id. `publish` is false by default, so the first
+#   run renders, commits and sends the card to Telegram for you to look at; run
+#   it again with publish ticked to post that same committed file.
+#
+# WHY AUTO-PUBLISHING IS SAFE HERE AND NOT IN instagram-ad.yml
+# The ad pipeline needs a human gate because a payment triggers it and the ad
+# carries text the buyer wrote. This workflow has NO text input: every word on
+# the card is either fixed chrome or a field of stores.json, so no scheduled run
+# can put a sentence in a shop's mouth. What a schedule does add is a machine
+# choosing WHICH shop, and that is what pick-feature.mjs's rules are for — it
+# refuses stores that are currently paying for placement (whose card would say
+# "not an ad" to a reader who cannot tell), and stores whose card would be
+# mostly blanks. The owner still gets the card on Telegram as it goes out.
+#
+# To stop the weekly slot, comment out the `schedule:` block below. Nothing else
+# depends on it.
 
 on:
+  schedule:
+    - cron: "0 10 * * 4" # Thursdays 10:00 UTC (~13:00 Europe/Kyiv)
   workflow_dispatch:
     inputs:
       store_id:
-        description: "Store id from stores.json, e.g. s10"
-        required: true
+        description: "Store id from stores.json, e.g. s10. Leave empty to let the picker choose."
+        required: false
         type: string
+        default: ""
       publish:
         description: "Post it. Leave unticked to only render and preview on Telegram."
         required: false
@@ -47,6 +60,8 @@ jobs:
       image: ${{ steps.render.outputs.image }}
       caption: ${{ steps.render.outputs.caption }}
       caption_path: ${{ steps.render.outputs.caption_path }}
+      store: ${{ steps.pick.outputs.store }}
+      publish: ${{ steps.pick.outputs.publish }}
     steps:
       - uses: actions/checkout@v7
 
@@ -54,7 +69,57 @@ jobs:
         with:
           node-version: 22
 
+      # Before the npm install, because the picker deliberately has no
+      # dependencies — a week with no eligible store should cost seconds, not a
+      # Chromium download.
+      - name: Choose the store
+        id: pick
+        env:
+          # Via env, never interpolated into the script body. A dispatch input
+          # substituted as ${{ }} inside `run:` is pasted into the shell before
+          # bash sees it, so a value containing a quote or a semicolon executes.
+          # Only collaborators can dispatch this, but instagram-ad.yml takes the
+          # same care with its inputs and the reason is the same.
+          GIVEN: ${{ inputs.store_id }}
+          EVENT: ${{ github.event_name }}
+          WANT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          if [ -n "$GIVEN" ]; then
+            STORE="$GIVEN"
+            echo "Store given by hand: $STORE"
+          else
+            # Prints the id on stdout and its reasoning on stderr; prints
+            # nothing when no store qualifies.
+            STORE=$(cd tools/social && node pick-feature.mjs)
+          fi
+
+          if [ -z "$STORE" ]; then
+            echo "::notice::No store qualifies for a feature this week — skipping. A weak card is worse than no post."
+            echo "store=" >> "$GITHUB_OUTPUT"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Shape check before the id is ever used to build a path. stores.json
+          # ids are short alphanumerics; anything else cannot match a store, so
+          # rejecting it here costs nothing and keeps '..' and '/' out of $IMG.
+          case "$STORE" in
+            ''|*[!a-zA-Z0-9_]*)
+              echo "::error::store id '$STORE' is not a plain alphanumeric id."
+              exit 1 ;;
+          esac
+
+          # A scheduled run has no inputs at all, so `publish` is empty there —
+          # and an unattended slot that renders without posting is not a slot.
+          if [ "$EVENT" = "schedule" ] || [ "$WANT_PUBLISH" = "true" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "store=$STORE" >> "$GITHUB_OUTPUT"
+
       - name: Install deps + Chromium
+        if: steps.pick.outputs.store != ''
         working-directory: tools/social
         run: |
           npm install
@@ -62,22 +127,10 @@ jobs:
 
       - name: Render the card and its caption
         id: render
+        if: steps.pick.outputs.store != ''
         env:
-          # Via env, never interpolated into the script body. A dispatch input
-          # substituted as ${{ }} inside `run:` is pasted into the shell before
-          # bash sees it, so a value containing a quote or a semicolon executes.
-          # Only collaborators can dispatch this, but instagram-ad.yml takes the
-          # same care with its inputs and the reason is the same.
-          FEATURE_STORE_ID: ${{ inputs.store_id }}
+          FEATURE_STORE_ID: ${{ steps.pick.outputs.store }}
         run: |
-          # Shape check before the id is ever used to build a path. stores.json
-          # ids are short alphanumerics; anything else cannot match a store, so
-          # rejecting it here costs nothing and keeps '..' and '/' out of $IMG.
-          case "$FEATURE_STORE_ID" in
-            ''|*[!a-zA-Z0-9_]*)
-              echo "::error::store id '$FEATURE_STORE_ID' is not a plain alphanumeric id."
-              exit 1 ;;
-          esac
           IMG="marketing/instagram/features/${FEATURE_STORE_ID}.jpg"
           CAP="marketing/instagram/features/${FEATURE_STORE_ID}.txt"
           # The generator rejects any id not in stores.json, so a typo fails
@@ -95,18 +148,44 @@ jobs:
             echo 'FEATURE_CAPTION_EOF'
           } >> "$GITHUB_OUTPUT"
 
-      # Committed because Meta fetches image_url over HTTP at publish time, and
-      # GitHub Pages serves the repo root — so committing IS how the image gets
-      # a public URL. Same mechanism the ad and deals pipelines rely on.
+      # Only a run that actually posts advances the rotation — a preview must
+      # not consume a store's turn. The trade-off is the other way round: if the
+      # publish below fails after this commit lands, the store is recorded as
+      # featured without having been posted. Re-run by hand with its id to fix
+      # that; leaving it unrecorded would instead re-post it every week forever.
+      - name: Record it in the rotation history
+        if: steps.pick.outputs.store != '' && steps.pick.outputs.publish == 'true'
+        env:
+          STORE: ${{ steps.pick.outputs.store }}
+        run: |
+          HIST=marketing/instagram/features/history.json
+          [ -f "$HIST" ] || echo '{}' > "$HIST"
+          TMP=$(mktemp)
+          jq --arg id "$STORE" --arg d "$(date -u +%F)" '.[$id] = $d' "$HIST" > "$TMP"
+          mv "$TMP" "$HIST"
+
+      # Committed because Meta and Telegram both fetch the image over HTTP at
+      # publish time, and GitHub Pages serves the repo root — so committing IS
+      # how the image gets a public URL. Same mechanism the ad and deals
+      # pipelines rely on.
       - name: Commit the card
+        if: steps.pick.outputs.store != ''
         env:
           IMG: ${{ steps.render.outputs.image }}
           CAP: ${{ steps.render.outputs.caption_path }}
-          STORE: ${{ inputs.store_id }}
+          STORE: ${{ steps.pick.outputs.store }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add "$IMG" "$CAP"
+          # Only present once a publishing run has recorded one; `git add` on a
+          # missing path is a fatal pathspec error, which would fail every
+          # preview run. Written as an `if` rather than `[ -f … ] && git add`
+          # because steps run under `bash -e`, where a false test at the head of
+          # an && list is itself a non-zero status that ends the step.
+          if [ -f marketing/instagram/features/history.json ]; then
+            git add marketing/instagram/features/history.json
+          fi
           if git diff --cached --quiet; then
             echo "Card is unchanged since the last run — nothing to commit."
           else
@@ -115,6 +194,7 @@ jobs:
           fi
 
       - name: Wait for Pages to serve it
+        if: steps.pick.outputs.store != ''
         env:
           IMG: ${{ steps.render.outputs.image }}
         run: |
@@ -128,6 +208,7 @@ jobs:
           exit 1
 
       - name: Send the preview to Telegram
+        if: steps.pick.outputs.store != ''
         env:
           # Same fallback chain the rest of the repo uses; BOT_TOKEN did not
           # exist when this repo's token was first stored.
@@ -135,7 +216,7 @@ jobs:
           OWNER_ID: ${{ secrets.OWNER_ID }}
           IMG: ${{ steps.render.outputs.image }}
           CAPTION_BODY: ${{ steps.render.outputs.caption }}
-          WILL_PUBLISH: ${{ inputs.publish }}
+          WILL_PUBLISH: ${{ steps.pick.outputs.publish }}
         run: |
           # OWNER_ID is a chat id, not a credential — it is already committed as
           # a plain var in worker/wrangler.toml, so read it from there rather
@@ -144,6 +225,12 @@ jobs:
             OWNER_ID=$(sed -n 's/^OWNER_ID *= *"\([0-9-]*\)".*/\1/p' worker/wrangler.toml | head -1)
           fi
           if [ -z "$BOT_TOKEN" ] || [ -z "$OWNER_ID" ]; then
+            if [ "$WILL_PUBLISH" = "true" ]; then
+              # The post is going out either way; losing the heads-up is not a
+              # reason to fail the run and leave a half-done pipeline behind.
+              echo "::warning::No Telegram bot token or OWNER_ID — publishing without sending you the heads-up."
+              exit 0
+            fi
             echo "::error::No Telegram bot token or OWNER_ID, so the preview cannot be sent — and the preview is the point of a publish:false run."
             exit 1
           fi
@@ -158,14 +245,35 @@ jobs:
             -d "$(jq -nc --arg c "$OWNER_ID" --arg p "$SITE/$IMG" --arg cap "$MSG" \
                   '{chat_id:$c, photo:$p, caption:$cap}')" || echo '{}')
           if [ "$(echo "$RESP" | jq -r '.ok // false')" != "true" ]; then
-            echo "::error::Telegram rejected the preview: $(echo "$RESP" | jq -c '{error_code, description}' 2>/dev/null || echo "$RESP")"
+            DETAIL=$(echo "$RESP" | jq -c '{error_code, description}' 2>/dev/null || echo "$RESP")
+            # Same reasoning as the missing-token branch above: on a publishing
+            # run the heads-up is a courtesy and the post is the job, so a
+            # Telegram hiccup must not leave the pipeline half-done. On a
+            # preview-only run the heads-up IS the job, so it stays fatal.
+            if [ "$WILL_PUBLISH" = "true" ]; then
+              echo "::warning::Telegram rejected the heads-up ($DETAIL) — publishing anyway."
+              exit 0
+            fi
+            echo "::error::Telegram rejected the preview: $DETAIL"
             exit 1
           fi
 
   publish:
     needs: render
-    if: ${{ inputs.publish }}
+    if: needs.render.outputs.publish == 'true'
     uses: ./.github/workflows/instagram-post.yml
+    secrets: inherit
+    with:
+      image: ${{ needs.render.outputs.image }}
+      caption: ${{ needs.render.outputs.caption }}
+
+  # The store card is the post that benefits most from the channel: its caption
+  # ends in a /?store=… deep link, which is dead text on Instagram and a working
+  # link here. Separate job so one surface failing cannot take the other down.
+  mirror:
+    needs: render
+    if: needs.render.outputs.publish == 'true'
+    uses: ./.github/workflows/telegram-channel-post.yml
     secrets: inherit
     with:
       image: ${{ needs.render.outputs.image }}

--- a/.github/workflows/telegram-channel-post.yml
+++ b/.github/workflows/telegram-channel-post.yml
@@ -1,0 +1,263 @@
+name: Post to the Telegram channel
+
+# Publishes one image + caption to the public Telegram channel. It is the mirror
+# of instagram-post.yml and takes deliberately IDENTICAL inputs (image, caption,
+# dry_run), so any pipeline that already posts to Instagram can post here by
+# adding one more `uses:` job rather than by growing a second caption format.
+#
+# WHY A CHANNEL AT ALL, GIVEN THE BOT EXISTS
+# The bot reaches people who already found us. A channel is the forwardable,
+# public surface: someone forwarding "Bomba has gone 6 days" into a friends'
+# chat is the distribution. It also fixes the one structural problem with the
+# Instagram feed — a channel post's link is CLICKABLE, so the caption's
+# https://www.lvivsecondhand.com/?store=… actually goes somewhere.
+#
+# WHY THIS IS CHEAP
+# Telegram has no equivalent of Meta's container/publish dance, no 60-day token
+# expiry, and no JPEG-only rule. It is one sendPhoto call with a URL, using the
+# BOT_TOKEN this repo already holds. Everything below that is not that one call
+# is a pre-flight, because a channel post that fails silently at 07:00 on a
+# Monday is worse than one that never ran.
+#
+# SAFE UNTIL CONFIGURED
+# Exits green and posts nothing until TG_CHANNEL is set, exactly like the
+# Instagram poster — an unconfigured repo accumulates no failed runs. Setup is
+# three steps and lives in docs/TELEGRAM_CHANNEL.md.
+#
+# NO parse_mode, ON PURPOSE
+# Captions can carry store-supplied fragments elsewhere in this repo, and the
+# same rule the Worker's Telegram notifications follow applies here: no
+# parse_mode means no text can be made to render as markup, and no post can be
+# broken by an unbalanced asterisk in a shop's name. Bare URLs still auto-link
+# in Telegram, so nothing is lost.
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: "Repo-relative image path under marketing/. Empty posts text only."
+        type: string
+        required: false
+        default: ""
+      caption:
+        type: string
+        required: true
+      dry_run:
+        type: boolean
+        required: false
+        default: false
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "Image path in this repo (committed and served). Empty posts text only."
+        required: false
+        type: string
+        default: marketing/deals-this-week.jpg
+      caption:
+        description: "Caption. Links are clickable here — put the real URL in it."
+        required: true
+        type: string
+        default: |
+          Усі секонд-хенди Львова на одній карті 🧥
+
+          Адреси, години роботи — і скільки днів минуло від останнього завозу в кожному магазині.
+
+          Безкоштовно, без реєстрації → https://www.lvivsecondhand.com
+      dry_run:
+        description: "Check config only — run the pre-flights and stop before posting"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+env:
+  SITE: https://www.lvivsecondhand.com
+
+jobs:
+  post:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # Exit 0, not 1: an unconfigured repo should be a no-op, not a red run.
+      # TG_CHANNEL is read from `vars` first because a channel handle is not a
+      # credential — it is public by definition, and worker/wrangler.toml
+      # already keeps OWNER_ID as a plain var for the same reason. The secrets
+      # fallback is for a private channel, whose numeric id is worth hiding.
+      - name: Check the channel is configured
+        id: guard
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN || secrets.TELEGRAM_BOT_TOKEN }}
+          CHANNEL: ${{ vars.TG_CHANNEL || secrets.TG_CHANNEL }}
+        run: |
+          if [ -z "$BOT_TOKEN" ] || [ -z "$CHANNEL" ]; then
+            echo "::notice::BOT_TOKEN / TG_CHANNEL not set — skipping the channel post. See docs/TELEGRAM_CHANNEL.md."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Telegram fetches the URL itself, exactly like Meta, so the same reasoning
+      # applies: verify the file the API will actually fetch, not the one in this
+      # checkout. A caller that commits its image in an earlier job of the same
+      # run is checked out at the SHA that triggered the run, which predates that
+      # commit — testing `-f "$IMG"` locally would fail for a file that is live.
+      - name: Pre-flight — image is committed and publicly reachable
+        if: steps.guard.outputs.ready == 'true' && inputs.image != ''
+        env:
+          IMG: ${{ inputs.image }}
+        run: |
+          # Path containment first: this value can arrive from a caller workflow
+          # and it becomes a public URL below.
+          case "$IMG" in
+            *..*) echo "::error::image path $IMG contains '..' — refusing."; exit 1 ;;
+          esac
+          case "$IMG" in
+            marketing/*) ;;
+            *) echo "::error::$IMG is outside marketing/."; exit 1 ;;
+          esac
+
+          URL="$SITE/$IMG"
+          CODE=$(curl -s -o /tmp/tg-probe.bin -w '%{http_code}' -L "$URL")
+          if [ "$CODE" != "200" ]; then
+            echo "::error::$URL returned HTTP $CODE. Telegram fetches this URL itself, so it must be live first (Pages may lag a commit by a minute)."
+            exit 1
+          fi
+
+          # Unlike Instagram, Telegram accepts PNG as happily as JPEG, so there
+          # is no format gate here — only the size one. sendPhoto by URL caps at
+          # 5 MB, and its rejection names a limit without naming which file blew
+          # it, so the check is worth making here where the path is in hand.
+          SIZE=$(wc -c < /tmp/tg-probe.bin)
+          if [ "$SIZE" -ge 5242880 ]; then
+            echo "::error::$URL is $SIZE bytes. Telegram's sendPhoto caps URL-fetched photos at 5 MB — render a smaller image."
+            exit 1
+          fi
+          echo "IMAGE_URL=$URL" >> "$GITHUB_ENV"
+          echo "Image OK: $URL (${SIZE} bytes)"
+
+      # The failure this catches is THE setup mistake: a bot that is a member of
+      # the channel but not an administrator. Telegram accepts the token, resolves
+      # the chat, and then refuses the post with "not enough rights" — at post
+      # time, on a real schedule. Checking the right up front turns that into a
+      # legible error on a dry run.
+      - name: Pre-flight — token, channel, and post rights
+        if: steps.guard.outputs.ready == 'true'
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN || secrets.TELEGRAM_BOT_TOKEN }}
+          CHANNEL: ${{ vars.TG_CHANNEL || secrets.TG_CHANNEL }}
+        run: |
+          API="https://api.telegram.org/bot$BOT_TOKEN"
+
+          ME=$(curl -s "$API/getMe")
+          if [ "$(echo "$ME" | jq -r '.ok // false')" != "true" ]; then
+            echo "::error::Telegram rejected BOT_TOKEN: $(echo "$ME" | jq -c '{error_code, description}' 2>/dev/null || echo "$ME")"
+            exit 1
+          fi
+          BOT_ID=$(echo "$ME" | jq -r '.result.id')
+          echo "Token valid — bot @$(echo "$ME" | jq -r '.result.username')."
+
+          CHAT=$(curl -sG "$API/getChat" --data-urlencode "chat_id=$CHANNEL")
+          if [ "$(echo "$CHAT" | jq -r '.ok // false')" != "true" ]; then
+            echo "::error::Cannot resolve channel '$CHANNEL': $(echo "$CHAT" | jq -c '{error_code, description}' 2>/dev/null || echo "$CHAT")"
+            echo "::error::A public channel is addressed as @handle; a private one by its -100… id. The bot must already be a member. See docs/TELEGRAM_CHANNEL.md."
+            exit 1
+          fi
+          TITLE=$(echo "$CHAT" | jq -r '.result.title // empty')
+          USERNAME=$(echo "$CHAT" | jq -r '.result.username // empty')
+          echo "Channel resolved: ${TITLE:-$CHANNEL}${USERNAME:+ (@$USERNAME)}"
+          echo "CHANNEL_USERNAME=$USERNAME" >> "$GITHUB_ENV"
+
+          MEMBER=$(curl -sG "$API/getChatMember" --data-urlencode "chat_id=$CHANNEL" --data-urlencode "user_id=$BOT_ID")
+          STATUS=$(echo "$MEMBER" | jq -r '.result.status // empty')
+          CAN_POST=$(echo "$MEMBER" | jq -r '.result.can_post_messages // false')
+          if [ "$STATUS" != "administrator" ] && [ "$STATUS" != "creator" ]; then
+            echo "::error::The bot is '${STATUS:-not a member}' in this channel, not an administrator, so it cannot post. Channel → Administrators → Add admin → the bot."
+            exit 1
+          fi
+          if [ "$STATUS" = "administrator" ] && [ "$CAN_POST" != "true" ]; then
+            echo "::error::The bot is an administrator but its 'Post messages' right is off. Turn it on in the channel's admin settings."
+            exit 1
+          fi
+          echo "Post rights confirmed."
+
+      # Without this a dry run ends green with no output, which reads exactly
+      # like a successful post — the one confusion this feature must not create.
+      - name: Dry run — report and stop
+        if: steps.guard.outputs.ready == 'true' && inputs.dry_run == true
+        run: |
+          {
+            echo "### Dry run — nothing was posted"
+            echo ""
+            echo "Pre-flights passed: the image is reachable, the token is valid, and the bot can post to the channel."
+            echo "Re-run with **dry_run unchecked** to publish."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice::Dry run complete — config is good, nothing posted."
+
+      - name: Post to the channel
+        if: steps.guard.outputs.ready == 'true' && inputs.dry_run != true
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN || secrets.TELEGRAM_BOT_TOKEN }}
+          CHANNEL: ${{ vars.TG_CHANNEL || secrets.TG_CHANNEL }}
+          CAPTION: ${{ inputs.caption }}
+          IMG: ${{ inputs.image }}
+        run: |
+          API="https://api.telegram.org/bot$BOT_TOKEN"
+
+          # Counted with jq, not ${#CAPTION}: the caption is Ukrainian, and the
+          # shell's idea of a character depends on the runner's locale while
+          # jq's is always codepoints. The threshold is 1000 rather than
+          # Telegram's actual 1024 because Telegram counts UTF-16 units, where
+          # an emoji outside the BMP counts twice — the margin covers the gap
+          # without needing to reimplement its counting.
+          LEN=$(jq -rn --arg c "$CAPTION" '$c | length')
+
+          send() {
+            curl -s -X POST "$API/$1" -H 'Content-Type: application/json' -d "$2"
+          }
+          check() {
+            if [ "$(echo "$1" | jq -r '.ok // false')" != "true" ]; then
+              echo "::error::Telegram rejected $2: $(echo "$1" | jq -c '{error_code, description}' 2>/dev/null || echo "$1")"
+              exit 1
+            fi
+          }
+
+          if [ -z "$IMG" ]; then
+            if [ "$LEN" -gt 4096 ]; then
+              echo "::error::Text post is $LEN characters; Telegram's limit is 4096."
+              exit 1
+            fi
+            RESP=$(send sendMessage "$(jq -nc --arg c "$CHANNEL" --arg t "$CAPTION" '{chat_id:$c, text:$t}')")
+            check "$RESP" "the text post"
+            MSG_ID=$(echo "$RESP" | jq -r '.result.message_id')
+          elif [ "$LEN" -le 1000 ]; then
+            RESP=$(send sendPhoto "$(jq -nc --arg c "$CHANNEL" --arg p "$IMAGE_URL" --arg cap "$CAPTION" '{chat_id:$c, photo:$p, caption:$cap}')")
+            check "$RESP" "the photo"
+            MSG_ID=$(echo "$RESP" | jq -r '.result.message_id')
+          else
+            # Too long for a photo caption. Truncating would drop the URL, which
+            # is the whole point of posting here, so the photo goes up bare and
+            # the full text follows as a reply — nothing is lost and the two stay
+            # visually joined in the channel.
+            RESP=$(send sendPhoto "$(jq -nc --arg c "$CHANNEL" --arg p "$IMAGE_URL" '{chat_id:$c, photo:$p}')")
+            check "$RESP" "the photo"
+            MSG_ID=$(echo "$RESP" | jq -r '.result.message_id')
+            RESP2=$(send sendMessage "$(jq -nc --arg c "$CHANNEL" --arg t "$CAPTION" --argjson r "$MSG_ID" '{chat_id:$c, text:$t, reply_to_message_id:$r}')")
+            check "$RESP2" "the caption follow-up"
+            echo "::notice::Caption was $LEN characters — posted as a reply under the photo."
+          fi
+
+          if [ -n "$CHANNEL_USERNAME" ]; then
+            LINK="https://t.me/$CHANNEL_USERNAME/$MSG_ID"
+          else
+            LINK="message $MSG_ID"
+          fi
+          echo "::notice::Posted to the Telegram channel: $LINK"
+          {
+            echo "### Posted to the Telegram channel"
+            echo ""
+            echo "- **Image:** \`${IMG:-none (text only)}\`"
+            echo "- **Post:** $LINK"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ Setup lives in **[`docs/INSTAGRAM.md`](docs/INSTAGRAM.md)**. Two things that wil
 
 Images must be **JPEG** — the API rejects PNG with a generic container error that never mentions the format.
 
+**Beyond Instagram.** A channel-by-channel brainstorm — Telegram channel, short video, Facebook groups, what to skip, and what to build so it stays automatic — is in **[`docs/SOCIAL_MEDIA.md`](docs/SOCIAL_MEDIA.md)**.
+
 ### Paid ads on Instagram — you approve, then it posts
 
 A store buying a flash deal now also queues an **Instagram advertisement**. It is queued, never posted: the only route from a completed payment to the public feed is you tapping approve.
@@ -689,6 +691,8 @@ PWA (прогресивний веб-додаток) для пошуку та в
 Решта — вручну: **Actions → Post to Instagram → Run workflow**. Позначка **`dry_run`** проганяє перевірки й зупиняється перед публікацією — зручно після зміни секрета, щоб перевірка налаштувань не коштувала справжнього допису.
 
 Налаштування — у **[`docs/INSTAGRAM.md`](docs/INSTAGRAM.md)**. Два підводні камені: використовується шлях **Instagram Login** (`graph.instagram.com`), а не Facebook Login — вони несумісні, і більшість інструкцій в інтернеті описують саме інший; і **токен діє 60 днів**, а дізнатися залишок цим шляхом неможливо, тому щотижневий `instagram-token-check.yml` пише власнику в Telegram, щойно токен перестає працювати.
+
+**Далі за межами Instagram.** Розбір каналів — Telegram-канал, короткі відео, групи у Facebook, від чого свідомо відмовляємось і що варто автоматизувати — у **[`docs/SOCIAL_MEDIA.md`](docs/SOCIAL_MEDIA.md)**.
 
 Зображення мають бути у форматі **JPEG** — PNG API відхиляє.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ No app store, no install required to use it in a browser — but adding it to yo
 - 🔗 **Link to a store** — copy a direct `?store=<id>` link that opens straight on that store
 - 💬 **Telegram bot** — [@Secondhandlvivbot](https://t.me/Secondhandlvivbot): a tap-through menu plus `/today`, `/day` (any weekday), `/rare` and `/cheap`
 - 📸 **Instagram** — [@secondhandlvivbot](https://www.instagram.com/secondhandlvivbot/): which stores have gone longest since a restock, posted automatically every Monday
+- 📢 **Telegram channel** — the same posts, mirrored where the links are actually clickable and a post can be forwarded
 - 📣 **Store promotions** — a shop owner can promote their own store from inside the app; every paid placement is labelled
 - ⚡ **Flash deals** — a store can run a short paid sale (3h / 24h) with a live countdown banner and toast; follow a store on Telegram to hear the moment one goes live
 - ✏️ **Suggest a correction** — send a fix via Telegram; a moderator reviews it, or a trusted contributor's own edit publishes instantly
@@ -260,6 +261,12 @@ The app is **free for shoppers and always will be**. It is funded by the shops i
 
 Anything else is posted by hand: **Actions → Post to Instagram → Run workflow**, picking one of the images in `marketing/instagram/`. Tick **`dry_run`** to run the pre-flights and stop before posting — use it after changing a secret, so verifying a config change doesn't cost a real post.
 
+**Everything automatic goes to both surfaces.** The Monday ranking and the Thursday store-of-the-week are each posted to Instagram *and* mirrored to the Telegram channel, from the same image and the same caption, by [`telegram-channel-post.yml`](.github/workflows/telegram-channel-post.yml). Each surface is a separate job, so an expired Instagram token cannot stop the channel post and a misconfigured channel cannot stop the Instagram one.
+
+The channel is where the links actually work — an Instagram caption's `?store=…` is dead text, and on Telegram it is a tap. Setup is three steps (create it, make the bot an administrator, set one `TG_CHANNEL` variable) and lives in **[`docs/TELEGRAM_CHANNEL.md`](docs/TELEGRAM_CHANNEL.md)**. Until that variable is set the mirror jobs no-op green, so nothing here is waiting on it.
+
+**Paid ads are deliberately not mirrored.** A store buys an Instagram advertisement, and the approval you tap approves that one post — putting a second, unapproved copy of buyer-written text in a public channel is not something anyone bought.
+
 ### For maintainers
 
 | Piece | What it is |
@@ -268,6 +275,8 @@ Anything else is posted by hand: **Actions → Post to Instagram → Run workflo
 | `tools/social/avatar.mjs` | Profile photo, 3 variants, drawn from `favicon.svg`'s vector geometry |
 | `.github/workflows/instagram-post.yml` | Publishes one image. `workflow_dispatch` + `workflow_call`; no-ops without secrets |
 | `.github/workflows/instagram-token-check.yml` | Weekly token check that **messages the owner on Telegram** when it breaks |
+| `.github/workflows/telegram-channel-post.yml` | Posts one image + caption to the Telegram channel. Same inputs as the Instagram poster; no-ops without `TG_CHANNEL` |
+| `tools/social/pick-feature.mjs` | Chooses the week's store to feature — skips paid and thin-data stores, rotates through the rest |
 
 Setup lives in **[`docs/INSTAGRAM.md`](docs/INSTAGRAM.md)**. Two things that will bite otherwise:
 
@@ -328,15 +337,18 @@ A missing `BOT_TOKEN`/`OWNER_ID` **fails the run**, deliberately: this workflow'
 
 ### Featuring a store without claiming it paid
 
-Not every store post is an ad. `Feature a store on Instagram (not an ad)`
+Not every store post is an ad. `Feature a store (not an ad)`
 (`.github/workflows/instagram-feature.yml`) renders a card for any store on the
-map and posts it — with **no** sponsorship claim on it.
+map and posts it — to Instagram and the Telegram channel — with **no**
+sponsorship claim on it.
+
+It runs **every Thursday on its own**, and that is the store-of-the-week slot.
 
 The differences from the paid template are deliberate:
 
 | | Paid ad | Feature |
 | --- | --- | --- |
-| Trigger | a completed payment | you, typing a store id |
+| Trigger | a completed payment | the weekly schedule, or you typing a store id |
 | Says | `РЕКЛАМА · SPONSORED`, `Розміщення оплачене магазином` | `Не реклама. Магазин не платив за це розміщення.` |
 | Look | dark green ground, acid slab | paper ground, green ink |
 | Copy | the store's own offer line, buyer-supplied | nothing but `stores.json` fields |
@@ -352,11 +364,32 @@ be bought, and no sentence can be put in a shop's mouth. A store with neither a
 restock day nor a cycle gets no schedule claim at all rather than a
 plausible-sounding guess.
 
-`publish` is **false by default** — the first run renders, commits and sends the
-card to Telegram to look at; run it again with `publish` ticked to post that same
-committed file. There is no approval queue here because there is nothing to
-approve against: a payment triggers an ad, but a person triggers a feature, and
-adding a token endpoint would guard a decision that was never automatic.
+**Which store** a scheduled run picks is decided by
+[`tools/social/pick-feature.mjs`](tools/social/pick-feature.mjs), re-evaluated
+against `stores.json` every week rather than kept in a rotation list someone has
+to maintain. It refuses two kinds of store outright:
+
+- **A store currently paying for placement.** The card says "Не реклама — магазин
+  не платив за це розміщення", which for an advertiser is still literally true
+  (they bought a pin, not this post) — and that is exactly what makes it the
+  wrong sentence to print, because a reader cannot tell the difference. Both the
+  static `promo` field and the live `/promos` set are checked.
+- **A store whose card would be mostly blanks** — no address, no restock claim,
+  or hours nobody has surveyed. Not rejected forever; just until a field agent
+  fills it in.
+
+The rest rotate: never-featured first, then least-recently-featured, tracked in
+`marketing/instagram/features/history.json`. When nothing qualifies, the run
+posts nothing rather than a weak card. Today that leaves **80 of 126** stores
+eligible.
+
+On a **manual** run `publish` is still **false by default** — it renders, commits
+and sends the card to Telegram for you to look at; run it again with `publish`
+ticked to post that same committed file. A scheduled run publishes on its own and
+sends you the card as it goes out, because a slot that needs a human tap is not a
+slot. That is safe here for a reason that does not hold for ads: there is **no
+text input**, so no scheduled run can put a sentence in a shop's mouth. Comment
+out the `schedule:` block to stop it.
 
 ### Why approval links carry a token, not the admin key
 
@@ -525,6 +558,7 @@ PWA (прогресивний веб-додаток) для пошуку та в
 - ✅ Позначення магазинів як **відвіданих**
 - 🔔 **Сповіщення про завезення** — стежте за магазином і дізнавайтеся про завіз того ж ранку. Через push там, де браузер це вміє; де не вміє (iOS без встановленого застосунку) та сама кнопка пропонує Telegram, тож сповіщення доступні на будь-якому пристрої
 - 📸 **Instagram** — [@secondhandlvivbot](https://www.instagram.com/secondhandlvivbot/): хто найдовше без завозу, автоматично щопонеділка
+- 📢 **Telegram-канал** — ті самі дописи, але там, де посилання клікабельні, а допис можна переслати
 - ➕ **Додавання**, ✏️ **редагування** та 🗑️ **видалення/приховування** магазинів
 - 🤝 **Поділитися картою** та **внести** доповнення/зміни для всіх
 - 🔗 **Посилання на магазин** — скопіюйте пряме посилання `?store=<id>`, що одразу відкриває цей магазин
@@ -689,6 +723,12 @@ PWA (прогресивний веб-додаток) для пошуку та в
 **Щотижневий пост із цінами — автоматичний.** `.github/workflows/deals-image.yml` щопонеділка перебудовує `marketing/deals-this-week.jpg` за тим самим рейтингом `/cheap`, що й бот, комітить його (далі GitHub Pages віддає його за сталою адресою) і викликає `instagram-post.yml`, щоб опублікувати з підписом, згенерованим із рейтингу саме цього тижня. Публікується лише тоді, коли рейтинг **змінився**.
 
 Решта — вручну: **Actions → Post to Instagram → Run workflow**. Позначка **`dry_run`** проганяє перевірки й зупиняється перед публікацією — зручно після зміни секрета, щоб перевірка налаштувань не коштувала справжнього допису.
+
+**Автоматичні дописи йдуть на обидві платформи.** Щопонеділковий рейтинг і щочетверговий «магазин тижня» публікуються в Instagram **і** дублюються в Telegram-канал — те саме зображення, той самий підпис — через [`telegram-channel-post.yml`](.github/workflows/telegram-channel-post.yml). Кожна платформа — окреме завдання, тож прострочений токен Instagram не зупиняє допис у каналі, і навпаки.
+
+Саме в каналі посилання працюють: `?store=…` в підписі Instagram — мертвий текст, а в Telegram — дотик. Налаштування (створити канал, зробити бота адміністратором, задати змінну `TG_CHANNEL`) — у **[`docs/TELEGRAM_CHANNEL.md`](docs/TELEGRAM_CHANNEL.md)**. Доки змінної немає, дублювання просто не виконується — зелено й без помилок.
+
+**Платну рекламу свідомо не дублюємо.** Магазин купує рекламу в Instagram, і ваше підтвердження стосується саме того допису.
 
 Налаштування — у **[`docs/INSTAGRAM.md`](docs/INSTAGRAM.md)**. Два підводні камені: використовується шлях **Instagram Login** (`graph.instagram.com`), а не Facebook Login — вони несумісні, і більшість інструкцій в інтернеті описують саме інший; і **токен діє 60 днів**, а дізнатися залишок цим шляхом неможливо, тому щотижневий `instagram-token-check.yml` пише власнику в Telegram, щойно токен перестає працювати.
 

--- a/docs/SOCIAL_MEDIA.md
+++ b/docs/SOCIAL_MEDIA.md
@@ -1,0 +1,317 @@
+# Social media — where to expand next
+
+A brainstorm, not a commitment. Today the project publishes **one image a week to
+one platform**. This doc lays out what else is worth doing, what it would cost,
+what to build so it stays cheap, and what to deliberately skip.
+
+Instagram's own setup and mechanics stay in [`INSTAGRAM.md`](INSTAGRAM.md); paid
+store placements stay in [`ADVERTISING.md`](ADVERTISING.md). This is the layer
+above both: which channels, which content, in what order.
+
+---
+
+## 1. Where we actually are
+
+| | Status |
+| --- | --- |
+| Instagram [@secondhandlvivbot](https://www.instagram.com/secondhandlvivbot/) | One automatic post/week (Monday deals ranking), plus ~12 evergreen images posted by hand |
+| Telegram **bot** | A product, not a channel — reaches people who already found us |
+| Web push | Built, opt-in, same problem: existing users only |
+| Facebook / TikTok / Threads / YouTube | Nothing |
+| Video of any kind | Nothing |
+| Owned audience off-platform | None (no email list, no channel) |
+
+**The bottleneck is not content.** `stores.json` generates content endlessly —
+126 stores, restock cycles, per-store hours, a live "longest since restock"
+ranking. The bottleneck is **distribution and format**:
+
+1. **A static feed post is close to invisible now.** Instagram's discovery surface
+   is video and shares. A 1080×1350 JPEG reaches the followers we already have,
+   which is the audience we are trying to grow. It is a retention format doing a
+   job it cannot do.
+2. **The audience for a Lviv second-hand map is not on Instagram hashtags.** It is
+   in Telegram city channels, Facebook barahoLka/секонд groups, and university
+   chats. We are publishing where it is convenient, not where they are.
+3. **Every post is one-directional.** Nothing we publish asks anyone for anything,
+   so nothing compounds. No shares loop, no UGC loop, no referral loop.
+
+---
+
+## 2. The thesis
+
+> **Post the data, not opinions about the data.**
+
+The unfair advantage is a dataset nobody else in Lviv has: which store restocked
+when, which is furthest into its cycle, who opens tomorrow at nine. That converts
+into content that is *true this week and different next week* — which is exactly
+what an algorithm rewards and what a person forwards to a friend.
+
+Two corollaries that should govern every decision below:
+
+- **If a post can't be regenerated from data, it costs owner time forever.** Prefer
+  formats a script can re-render. This is already the house style (`deals-image.mjs`
+  reads the live ranking; `promo.mjs` reads live store counts) — extend it.
+- **Never bake a price into an image.** Existing rule, and it holds across every new
+  channel: per-kg rates differ per store and move with the exchange rate. Days
+  since restock is the durable number.
+
+---
+
+## 3. Channel expansion, ranked
+
+### A. Telegram **channel** — do this first
+
+A public broadcast channel (distinct from the bot), e.g. `@lvivsecondhand`.
+
+**Why it is the highest-return move here.** Ukraine's default social layer is
+Telegram, not Instagram. Three concrete advantages over IG for this product:
+
+- **Links are clickable.** Every Instagram post is a dead end — "link in bio" is a
+  tax we pay on every single post. A channel post links straight to
+  `?store=s10`. This alone probably doubles conversion per view.
+- **Forwarding is the growth mechanism** and it carries attribution back to the
+  channel. Someone forwarding "Bomba has gone 6 days" into a friends' chat *is* the
+  distribution.
+- **Cross-promotion is a normal, cheap transaction.** Lviv city channels sell or swap
+  posts. There is no Instagram equivalent at that price.
+
+**Cost to build: near zero.** The Worker already holds `BOT_TOKEN` and already calls
+`sendPhoto`/`sendMessage`. Posting to a channel is the same call with the channel's
+id as `chat_id`, after adding the bot as a channel admin. Everything currently going
+to Instagram can mirror there for one extra HTTP call.
+
+**What it carries:** the Monday ranking; "who restocks tomorrow" (daily, one line,
+no image needed); new stores as they land; flash deals (already broadcast to bot
+subscribers — the channel is the public, forwardable version).
+
+**Watch out:** a channel that posts more than ~1×/day gets muted. Daily restock
+line + Monday ranking is about right; hold everything else.
+
+### B. Short video — the only real discovery surface
+
+Reels / TikTok / Shorts are one asset shown in three places. Two production routes,
+and they answer different questions:
+
+**B1. Programmatic video — no filming.** The generators already rasterize HTML
+through Playwright. Playwright can also record a screencast, so an animated version
+of the existing templates (the ranking counting up, the price tag falling, pins
+dropping onto the map one per store) is a **new script, not a new pipeline** —
+`tools/social/reel.mjs`, maybe a day of work. Ceiling is real but limited: motion
+graphics perform far below footage of actual things.
+
+**B2. Field video — the actual advantage, and it is already staffed.** The field
+agent visits ~40 stores a week (see [`FIELD_AGENT.md`](FIELD_AGENT.md)). Every one of
+those visits is standing inside a second-hand shop on restock day. A 10-second
+vertical clip — the rail, the crowd at the door at opening, the tag, the street
+outside — is content nobody else can produce, and it costs the visit that is
+already happening.
+
+This is the single biggest unlock in this document. It needs three things that are
+not code: the agent's consent to film, each store's permission, and a phone-shot
+standard low enough that it actually happens (vertical, 10s, no talking required).
+Add a "clip" checkbox and an upload step to the `/visit` flow and it becomes part
+of the existing survey rather than an extra chore. **Pay per usable clip**, same
+shape as the existing per-visit rate.
+
+**Format ideas that survive without a presenter:** silent B-roll + on-screen
+Ukrainian text + trending audio; "day 1 vs day 6 of the same rail"; the door at
+10:00 on restock day; three stores in 15 seconds.
+
+**Watch out:** filming people in shops needs the store's OK — get it during the
+survey, and never film customers' faces. A store that says no is still a store on
+the map; do not let filming leak into the free-listing relationship.
+
+### C. Facebook — the Page is free, the Groups are the point
+
+- **A Page** costs almost nothing: Instagram cross-posts to it natively. Do it for
+  completeness and for the older half of the audience, expect little.
+- **Groups are where the shoppers actually are.** Lviv барахолка / секонд-хенд /
+  «Львів оголошення» groups have real, active, exactly-right audiences.
+
+**Groups must be posted by a human, occasionally, in a helpful register** — "made a
+free map of every second-hand in Lviv with restock days, no ads, no signup" once
+per group, then answer questions in comments. **Never automate this.** Automated
+group posting gets the account banned and the project labelled spam in the one
+community that matters most.
+
+### D. Threads — cheap side-effect, unproven
+
+Same Meta account, the caption already exists, the text is short. Worth ~zero
+effort as a mirror of the Telegram channel's text posts. Do not build anything for
+it; if a cross-post is not close to free, skip it.
+
+### E. Deliberately skipping (for now)
+
+| Channel | Why not |
+| --- | --- |
+| **YouTube long-form** | Production cost is an order of magnitude above the rest for an audience that is not searching for this |
+| **Pinterest** | Wrong geography, wrong intent — thrift content there is US/UK styling, not "which Lviv shop restocked" |
+| **X / Twitter** | Negligible Ukrainian local-commerce audience |
+| **Reddit** | One good `r/lviv` post is worth making; it is not a channel to maintain |
+| **Paid ads (Meta)** | Not until organic proves a message converts. Buying reach for an unproven post is how budgets disappear |
+
+### F. Not social, but competes for the same hours
+
+Worth naming so the comparison is honest — these may beat channels D–E:
+
+- **Google Maps / local SEO.** People search "секонд хенд Львів" on Maps with the
+  highest intent that exists anywhere in this funnel. A Google Business Profile plus
+  per-store pages that already exist (`/store/*`) is likely a better hour than Threads.
+- **Paid placement in a big Lviv Telegram channel.** Cheap, instant, and measurable
+  with a `?src=` link. Probably the fastest way to find out whether the product's
+  pitch lands at all.
+- **University chats (УКУ, ЛНУ, Політехніка).** The exact demographic, reachable in
+  a way that costs nothing but a well-worded message to an admin.
+
+---
+
+## 4. Content pillars
+
+Five recurring slots. Each names what generates it, so the calendar is a build list
+rather than a wish list.
+
+| # | Pillar | Source | Cadence | Exists? |
+| --- | --- | --- | --- | --- |
+| 1 | **The cycle** — who has gone longest without a restock | `deals-image.mjs` | Monday | ✅ automatic |
+| 2 | **Store of the week** — one shop, hours, restock day, honestly labelled not-an-ad | `store-feature.mjs` + `instagram-feature.yml` | Thursday | ⚠️ built, unscheduled |
+| 3 | **What's new on the map** — stores added since last time | *(new)* diff of `stores.json` | Monthly | ❌ |
+| 4 | **Restock tomorrow** — one line, who to be at when they open | `restockDay` / `restockDates` | Daily, Telegram only | ❌ |
+| 5 | **How the cycle works** — education: why day 6 is cheaper than day 1, per-kg vs per-item | evergreen, written once | Every ~2 weeks | ❌ |
+
+Plus two loops that are not slots but changes in posture:
+
+- **6. Find of the week (UGC).** Ask for what people found — repost with credit.
+  This is the cheapest growth mechanism available and the only one that makes
+  followers do the work. Needs nothing but a call to action and a repost habit.
+- **7. Behind the scenes.** The agent job posting, a survey being filled in, the
+  map growing. Doubles as recruitment (`/apply` already exists) and is the kind of
+  post that makes a project look alive rather than automated.
+
+### Twenty posts already sitting in the data
+
+The point of the thesis in §2 is that this list writes itself. All of these are
+queries against files already in the repo:
+
+1. The Monday ranking (live).
+2. "Only these N shops are open on Sunday." — `hours`
+3. "Restocking tomorrow: …" — `restockDay`
+4. "8 chains, 49 independents — and the independents restock a day sooner on average (8.4 vs 9.6)." — `brand` + `cycle`
+5. "Every shop within 10 minutes of Rynok." — `lat`/`lng`
+6. "Sold by weight, not by item: N shops." — `pricing`
+7. "Opens at 9 — the five earliest doors in the city."
+8. "The map just passed 130 stores." — milestone from the count
+9. "Newly added this month: …" — git diff of `stores.json`
+10. "The longest-cycle shop in Lviv restocks every N days." — `cycle`
+11. "Three shops on one street." — address clustering
+12. "Day 1 vs day 6 on the same rail." — video
+13. "What our field agent does in a day." — `FIELD_AGENT.md`
+14. "How to read a second-hand price cycle." — explainer
+15. "Per-kilo, explained — why we never print the rate." — explainer
+16. "The map at night" — the store-owner pitch (`stories.mjs` already renders it)
+17. "No account, no tracking, free." — `promo.mjs` post 4
+18. "Found something good? Show us." — UGC prompt
+19. "Own a shop? You're already on the map, free." — owner acquisition
+20. "Flash deal, 3 hours left." — the live flash-deal path
+
+---
+
+## 5. What to build so this stays cheap
+
+Ordered by return per hour. Everything here matches the existing pattern: a script
+in `tools/social/`, a workflow that runs it, output committed and served by Pages.
+
+| Build | What it does | Rough size |
+| --- | --- | --- |
+| **`telegram-channel-post.yml`** | Mirrors any image we publish to the Telegram channel via `sendPhoto`. Reuses `BOT_TOKEN`. | Hours |
+| **Schedule `instagram-feature.yml`** | Store-of-the-week actually goes out weekly instead of on demand, picking a store that has not been featured recently | Hours |
+| **`?src=` on every posted link + pass-through in the Worker** | Per-channel attribution against the existing `store_open` metric. Without this the whole exercise is unmeasurable | Hours |
+| **`restock-tomorrow` job** | Daily one-liner to the channel from `restockDay`/`restockDates` | Half a day |
+| **`captions.mjs`** | One place for caption templates + hashtag sets per channel, so captions stop being retyped per post | Half a day |
+| **`whats-new.mjs`** | Renders "added this month" from a `stores.json` diff | Half a day |
+| **`reel.mjs`** | Playwright screencast → MP4 from the existing HTML templates | ~A day |
+| **Clip upload in `/visit`** | The field agent submits a 10s vertical clip with the survey; clips land somewhere the owner can review | ~A day, plus policy |
+
+**Do the attribution one early.** Everything else is guesswork without it, and it is
+the smallest item on the list.
+
+---
+
+## 6. Measuring it
+
+One number per channel, checked monthly. Not impressions — impressions are the
+metric that makes a dead account look alive.
+
+| Channel | The number that matters |
+| --- | --- |
+| Telegram channel | Subscribers, and forwards per post |
+| Instagram | Saves + shares (not likes), profile→link taps |
+| Video | Watch-through, then follows per 1k views |
+| Facebook groups | Comments and clicks per post, not reach |
+| All | `store_open` events tagged with `?src=` — the only cross-channel truth |
+
+The Worker already records `store_open`; adding a source tag makes the map's own
+analytics the scoreboard for social, which is better than any platform's dashboard
+because it counts the thing we actually want (someone looking at a shop).
+
+**A blunt kill rule:** any channel that has not produced measurable link taps after
+8 weeks of honest effort gets dropped, not "improved". The list in §3E is already
+long; it should stay long.
+
+---
+
+## 7. Guardrails
+
+- **Paid placements are always labelled** — `Реклама / Sponsored`, on every surface
+  including new ones. The app promises shoppers this; a new channel does not get an
+  exemption. Store features that are *not* paid must keep saying so, as
+  `store-feature.mjs` already does.
+- **No prices in images.** Days since restock, never ₴/kg. (See §2.)
+- **Don't repost an unchanged ranking.** `deals-image.yml` already refuses; keep that
+  rule when the same content mirrors to new channels.
+- **Never automate group or DM posting.** Bans, and worse, reputation.
+- **Store photos need the store's permission**, gathered during the visit.
+- **Token expiry is the standing failure mode.** Every new API channel needs the same
+  treatment as `instagram-token-check.yml`: an automated check that turns a silent
+  outage into a Telegram message.
+- **Ukrainian first.** Captions in Ukrainian; English only where the audience is
+  clearly not local.
+- **One voice.** The existing register — plain, factual, slightly dry, no hype, no
+  emoji spam. It is why the map reads as trustworthy; it should survive TikTok.
+
+---
+
+## 8. Sequence
+
+**First 30 days — cheap and mostly automatic**
+1. Open the Telegram channel; mirror the Monday post; add the daily restock line.
+2. Add `?src=` and the Worker pass-through so everything after this is measurable.
+3. Schedule store-of-the-week.
+4. Post once, by hand, in three Facebook groups and once in `r/lviv`. Watch what happens.
+
+**Days 30–60 — find out whether video works**
+5. `reel.mjs`, and ship 4–6 programmatic videos to Reels + TikTok.
+6. Settle the filming policy with the agent and the stores; collect the first clips.
+7. Start the UGC ask ("find of the week") on every channel.
+
+**Days 60–90 — commit or cut**
+8. Compare `src`-tagged store opens per channel; drop whatever produced nothing.
+9. If video worked, make the field clip a paid, standard part of every visit.
+10. Only then consider paid placement — in a Lviv Telegram channel, not on Meta.
+
+---
+
+## 9. Open questions for the owner
+
+These decide the shape of the above and cannot be answered from the repo:
+
+1. **Who makes video, and is anyone willing to be on camera?** A face outperforms
+   motion graphics by a wide margin, and it is a personal decision, not a tactical one.
+2. **Can the field agent film, and will stores agree?** This is the difference between
+   plan B1 and plan B2 — between decent and unmatched.
+3. **How many hours a week does this get?** The channel list scales down cleanly; the
+   §8 sequence assumes a few hours weekly, not a full-time content operation.
+4. **Any budget for cross-promotion?** A few hundred ₴ in the right Lviv Telegram
+   channel likely beats every organic hour in this document, and answers "does the
+   pitch land" in a week.
+5. **Is the account brand or person?** `@secondhandlvivbot` reads as a utility. A
+   named human account grows faster and carries a cost — it cannot be handed off.

--- a/docs/SOCIAL_MEDIA.md
+++ b/docs/SOCIAL_MEDIA.md
@@ -1,8 +1,12 @@
 # Social media — where to expand next
 
-A brainstorm, not a commitment. Today the project publishes **one image a week to
-one platform**. This doc lays out what else is worth doing, what it would cost,
-what to build so it stays cheap, and what to deliberately skip.
+A brainstorm, not a commitment. This doc lays out what is worth doing, what it
+would cost, what to build so it stays cheap, and what to deliberately skip.
+
+> **Shipped since this was written:** the Telegram channel mirror (§3A) and the
+> weekly store-of-the-week slot (pillar 2). Setup for the channel is in
+> [`TELEGRAM_CHANNEL.md`](TELEGRAM_CHANNEL.md). The rest of this document is
+> still a proposal.
 
 Instagram's own setup and mechanics stay in [`INSTAGRAM.md`](INSTAGRAM.md); paid
 store placements stay in [`ADVERTISING.md`](ADVERTISING.md). This is the layer
@@ -14,7 +18,8 @@ above both: which channels, which content, in what order.
 
 | | Status |
 | --- | --- |
-| Instagram [@secondhandlvivbot](https://www.instagram.com/secondhandlvivbot/) | One automatic post/week (Monday deals ranking), plus ~12 evergreen images posted by hand |
+| Instagram [@secondhandlvivbot](https://www.instagram.com/secondhandlvivbot/) | Two automatic posts/week (Monday deals ranking, Thursday store of the week), plus ~12 evergreen images posted by hand |
+| Telegram **channel** | ✅ Built — both automatic posts mirror to it. Needs one `TG_CHANNEL` variable to go live |
 | Telegram **bot** | A product, not a channel — reaches people who already found us |
 | Web push | Built, opt-in, same problem: existing users only |
 | Facebook / TikTok / Threads / YouTube | Nothing |
@@ -28,7 +33,7 @@ ranking. The bottleneck is **distribution and format**:
 1. **A static feed post is close to invisible now.** Instagram's discovery surface
    is video and shares. A 1080×1350 JPEG reaches the followers we already have,
    which is the audience we are trying to grow. It is a retention format doing a
-   job it cannot do.
+   job it cannot do. (The channel mirror fixes the *link* problem, not this one.)
 2. **The audience for a Lviv second-hand map is not on Instagram hashtags.** It is
    in Telegram city channels, Facebook barahoLka/секонд groups, and university
    chats. We are publishing where it is convenient, not where they are.
@@ -59,7 +64,7 @@ Two corollaries that should govern every decision below:
 
 ## 3. Channel expansion, ranked
 
-### A. Telegram **channel** — do this first
+### A. Telegram **channel** — ✅ built
 
 A public broadcast channel (distinct from the bot), e.g. `@lvivsecondhand`.
 
@@ -75,14 +80,17 @@ Telegram, not Instagram. Three concrete advantages over IG for this product:
 - **Cross-promotion is a normal, cheap transaction.** Lviv city channels sell or swap
   posts. There is no Instagram equivalent at that price.
 
-**Cost to build: near zero.** The Worker already holds `BOT_TOKEN` and already calls
-`sendPhoto`/`sendMessage`. Posting to a channel is the same call with the channel's
-id as `chat_id`, after adding the bot as a channel admin. Everything currently going
-to Instagram can mirror there for one extra HTTP call.
+**Cost to build: near zero, and now spent.** `telegram-channel-post.yml` takes the
+same inputs as the Instagram poster, so the Monday and Thursday pipelines each mirror
+with one extra `uses:` job. It no-ops green until `TG_CHANNEL` is set —
+[`TELEGRAM_CHANNEL.md`](TELEGRAM_CHANNEL.md) is the three-step setup.
 
-**What it carries:** the Monday ranking; "who restocks tomorrow" (daily, one line,
-no image needed); new stores as they land; flash deals (already broadcast to bot
-subscribers — the channel is the public, forwardable version).
+**What it carries today:** the Monday ranking and the Thursday store feature.
+**Not yet wired:** "who restocks tomorrow" (daily, one line, no image needed — the
+poster already accepts an empty `image` for exactly this), new stores as they land,
+and flash deals (already broadcast to bot subscribers; the channel would be the
+public, forwardable version). Paid ads are deliberately excluded — a store bought an
+Instagram post, and the approval covers that one post.
 
 **Watch out:** a channel that posts more than ~1×/day gets muted. Daily restock
 line + Monday ranking is about right; hold everything else.
@@ -173,9 +181,9 @@ rather than a wish list.
 | # | Pillar | Source | Cadence | Exists? |
 | --- | --- | --- | --- | --- |
 | 1 | **The cycle** — who has gone longest without a restock | `deals-image.mjs` | Monday | ✅ automatic |
-| 2 | **Store of the week** — one shop, hours, restock day, honestly labelled not-an-ad | `store-feature.mjs` + `instagram-feature.yml` | Thursday | ⚠️ built, unscheduled |
+| 2 | **Store of the week** — one shop, hours, restock day, honestly labelled not-an-ad | `store-feature.mjs` + `pick-feature.mjs` + `instagram-feature.yml` | Thursday | ✅ automatic |
 | 3 | **What's new on the map** — stores added since last time | *(new)* diff of `stores.json` | Monthly | ❌ |
-| 4 | **Restock tomorrow** — one line, who to be at when they open | `restockDay` / `restockDates` | Daily, Telegram only | ❌ |
+| 4 | **Restock tomorrow** — one line, who to be at when they open | `restockDay` / `restockDates` | Daily, Telegram only | ⚠️ poster ready, job not written |
 | 5 | **How the cycle works** — education: why day 6 is cheaper than day 1, per-kg vs per-item | evergreen, written once | Every ~2 weeks | ❌ |
 
 Plus two loops that are not slots but changes in posture:
@@ -222,8 +230,8 @@ in `tools/social/`, a workflow that runs it, output committed and served by Page
 
 | Build | What it does | Rough size |
 | --- | --- | --- |
-| **`telegram-channel-post.yml`** | Mirrors any image we publish to the Telegram channel via `sendPhoto`. Reuses `BOT_TOKEN`. | Hours |
-| **Schedule `instagram-feature.yml`** | Store-of-the-week actually goes out weekly instead of on demand, picking a store that has not been featured recently | Hours |
+| ✅ **`telegram-channel-post.yml`** | Mirrors any image we publish to the Telegram channel via `sendPhoto`. Reuses `BOT_TOKEN`. | Done |
+| ✅ **Schedule `instagram-feature.yml`** | Store-of-the-week goes out weekly, picking a store that is not paid-for, not thin, and not recently featured | Done |
 | **`?src=` on every posted link + pass-through in the Worker** | Per-channel attribution against the existing `store_open` metric. Without this the whole exercise is unmeasurable | Hours |
 | **`restock-tomorrow` job** | Daily one-liner to the channel from `restockDay`/`restockDates` | Half a day |
 | **`captions.mjs`** | One place for caption templates + hashtag sets per channel, so captions stop being retyped per post | Half a day |
@@ -283,9 +291,10 @@ long; it should stay long.
 ## 8. Sequence
 
 **First 30 days — cheap and mostly automatic**
-1. Open the Telegram channel; mirror the Monday post; add the daily restock line.
+1. ✅ Mirror the Monday post to a channel. **Left to do:** open the channel and set
+   `TG_CHANNEL` — the code is inert until then — and add the daily restock line.
 2. Add `?src=` and the Worker pass-through so everything after this is measurable.
-3. Schedule store-of-the-week.
+3. ✅ Schedule store-of-the-week.
 4. Post once, by hand, in three Facebook groups and once in `r/lviv`. Watch what happens.
 
 **Days 30–60 — find out whether video works**

--- a/docs/TELEGRAM_CHANNEL.md
+++ b/docs/TELEGRAM_CHANNEL.md
@@ -1,0 +1,132 @@
+# The Telegram channel
+
+The public channel is the second place everything gets posted, and — for a map
+of shops in one city — probably the more important of the two.
+
+Setup is three steps and about five minutes; nothing posts until you finish
+them, and an unconfigured repo produces no failed runs.
+
+Instagram's setup lives in [`INSTAGRAM.md`](INSTAGRAM.md). The strategy behind
+having a channel at all is in [`SOCIAL_MEDIA.md`](SOCIAL_MEDIA.md).
+
+---
+
+## Why a channel, when the bot already exists
+
+They reach different people. The **bot** talks to shoppers who already found the
+project; the **channel** is the surface those people can forward. Three things
+it does that Instagram cannot:
+
+- **Links work.** A channel post's `https://www.lvivsecondhand.com/?store=s10`
+  is tappable. On Instagram it is dead text, which is why every post there pays
+  the "link in bio" tax.
+- **Forwarding carries attribution.** Someone forwarding the week's ranking into
+  a friends' chat brings the channel name with it. That is the growth mechanism.
+- **Cross-promotion is a normal transaction.** Lviv city channels swap or sell
+  posts to each other; there is no equivalent at that price on Instagram.
+
+It is also cheaper to operate. No 60-day token to refresh, no container/publish
+dance, no JPEG-only rule — one `sendPhoto` call with the `BOT_TOKEN` this repo
+already holds.
+
+---
+
+## One-time setup
+
+### 1. Create the channel
+
+Telegram → **New Channel**. Make it **public** and give it a handle
+(`@lvivsecondhand` or similar). A private channel works too, but then nothing
+can be forwarded into public view, which is most of the point.
+
+Use `marketing/instagram/avatar-*.png` as the photo — the same avatar as
+Instagram, so the two read as one project.
+
+### 2. Add the bot as an administrator
+
+Channel → **Administrators → Add administrator** → search for your bot
+(`@Secondhandlvivbot`) → grant **Post messages**.
+
+This is the step that gets skipped, because adding the bot as a *member* looks
+like it worked. It does not: Telegram accepts the token, resolves the channel,
+and then refuses the post with `not enough rights` — at posting time, on a
+schedule, where nobody is watching. The workflow pre-flights it (see below) so
+that failure surfaces on demand instead.
+
+### 3. Tell the repo where to post
+
+**Settings → Secrets and variables → Actions → Variables → New repository
+variable**, named `TG_CHANNEL`, value `@yourhandle`.
+
+A **variable**, not a secret: a public channel handle is public by definition,
+and this repo already keeps `OWNER_ID` as a plain var in `worker/wrangler.toml`
+for the same reason. Duplicating public values into secrets is how this project
+twice ended up with two names for one value, each holding something different.
+
+If you made the channel private, put its numeric `-100…` id in a **secret**
+called `TG_CHANNEL` instead — the workflow reads the variable first and falls
+back to the secret.
+
+`BOT_TOKEN` is already set from the bot's own deployment; nothing new is needed.
+
+### 4. Check it without posting
+
+**Actions → Post to the Telegram channel → Run workflow**, tick **`dry_run`**.
+
+It resolves the channel, confirms the bot is an administrator with posting
+rights, and confirms the image URL is live — then stops. Green means the next
+scheduled post will work.
+
+---
+
+## What posts automatically
+
+| When | What | Workflow |
+| --- | --- | --- |
+| Mondays ~07:00 Kyiv | The week's "longest since a restock" ranking — **only when the ranking actually moved** | `deals-image.yml` → `telegram-channel-post.yml` |
+| Thursdays ~13:00 Kyiv | Store of the week — one shop, chosen by `pick-feature.mjs`, labelled *not an ad* | `instagram-feature.yml` → `telegram-channel-post.yml` |
+
+Both mirror what goes to Instagram, from the same image and the same caption.
+Each surface is its own job, so an expired Instagram token cannot stop the
+channel post, and a misconfigured channel cannot stop the Instagram post.
+
+Anything else goes out by hand: **Actions → Post to the Telegram channel → Run
+workflow**, with an image path and a caption. Leave `image` empty to post text
+only.
+
+**Paid store ads are deliberately not mirrored here.** A store buys an
+*Instagram* advertisement, and the approval you tap in Telegram approves that
+one post. Posting it to the channel as well would deliver something nobody
+bought and would put a second, unapproved copy of buyer-written text in public.
+If it should become part of the product, sell it as part of the product.
+
+---
+
+## Cadence
+
+A channel that posts more than about once a day gets muted, and a muted channel
+is worse than a small one. The two automatic slots above are roughly right; add
+a third only when you have something people would forward.
+
+---
+
+## Things that will bite
+
+**The bot must be an administrator, not a member.** See step 2. The pre-flight
+names this exact failure, so run a `dry_run` after any change to the channel's
+admin list.
+
+**Captions over 1024 characters.** Telegram's photo-caption limit is far shorter
+than Instagram's 2200. Rather than truncate — which would drop the URL at the
+end, the whole reason for posting here — the workflow posts the photo bare and
+puts the full text in a reply underneath. The current captions are ~400–600
+characters, so this is a guard, not a routine path.
+
+**Nothing is retracted by deleting the file.** A post is live the moment the API
+returns; removing the committed image later leaves the post in place with a
+broken picture. Delete the post in Telegram.
+
+**No `parse_mode`.** Captions can carry store-supplied fragments, and the same
+rule the Worker's notifications follow applies here: without `parse_mode`, no
+text can be made to render as markup and no post can be broken by an unbalanced
+asterisk in a shop's name. Bare URLs still auto-link, so nothing is lost.

--- a/tools/social/README.md
+++ b/tools/social/README.md
@@ -31,6 +31,7 @@ its bundled browser.
 | `npm run avatar` | `marketing/instagram/avatar-*.png` (1080×1080) + `avatar-preview.png` | **Instagram profile photo**, 3 variants, drawn from `favicon.svg`'s vector geometry rather than upscaling the app icon. Tuned for the circle crop: the hanger scales ~46%→60% of the width so it fills the circle instead of floating in a square with dead corners, and stroke weight rides the transform so it stays legible at 32px. `avatar-preview.png` shows each circle-cropped at 320/110/32px on light and dark feeds — the only view that settles the choice. |
 | `npm run ad` | `marketing/instagram/ads/<id>.jpg` (1080x1350) | **One paid store advertisement.** Reads `AD_STORE_ID`, `AD_TEXT`, `AD_TIER` from the environment. Carries the mandatory `РЕКЛАМА · SPONSORED` mark — the app promises shoppers that "paid placements are always labelled", so that is not a styling choice. Buyer text is HTML-escaped and capped at 120 chars; the name and address come from `stores.json`, so an advertiser cannot invent an address. Normally invoked by `instagram-ad.yml`, not by hand. |
 | `npm run stories` | `marketing/instagram/story-*.jpg` (4 files, 1080x1350) | **Four posts that argue from a point of view** rather than listing features: the shopper (the falling tag), the store owner (the map at night), the field-agent job (the survey card it produces), and running a flash deal (the countdown). Each gets its own visual treatment on purpose - one template recoloured four ways reads as one advertiser talking four times. Prices are parsed out of `worker.js` and `index.html`, never retyped, and no per-kilogram figure appears anywhere. |
+| `npm run pick-feature` | *(prints a store id)* | **Chooses the week's store to feature** for the scheduled run of `instagram-feature.yml`. Not an image generator — it prints one id on stdout and its reasoning on stderr, and prints nothing when no store qualifies, which the workflow reads as "skip this week". Refuses stores that are currently **paying** for placement (the card's "Не реклама" line is unreadable as anything but a claim about the shop) and stores whose card would be mostly blanks; rotates the rest never-featured-first via `marketing/instagram/features/history.json`. Set `PROMOS_URL=` empty to skip the live promo lookup. |
 | `npm run promo` | `marketing/instagram/*.jpg` (8 files) | **Instagram posts advertising the app itself** — 4 messages (coverage, the price-cycle idea, restock alerts, free/no-account) × 2 sizes (1080×1080 square, 1080×1350 portrait). Emitted as **JPEG**, not PNG — Instagram's publishing API accepts JPEG only. Every post ends on the site URL. Override with `PROMO_URL=…`. |
 
 ### Notes on the Instagram set
@@ -44,6 +45,13 @@ its bundled browser.
   `line-height:.94`, and a class outranks a bare element selector, so an `h1`
   rule is silently ignored. Uppercase Cyrillic (Й, Ї) needs more leading than
   that Latin-tuned default or the diacritics clip into the line above.
+
+Everything the automatic pipelines post to Instagram is also mirrored to the
+Telegram channel by
+[`.github/workflows/telegram-channel-post.yml`](../../.github/workflows/telegram-channel-post.yml),
+which takes the same `image` + `caption` inputs — see
+[`docs/TELEGRAM_CHANNEL.md`](../../docs/TELEGRAM_CHANNEL.md). It no-ops until the
+channel is configured.
 
 Posting the Instagram set is manual by default; [`.github/workflows/instagram-post.yml`](../../.github/workflows/instagram-post.yml) can publish one via the Meta Graph API once the account is set up for it — see [`docs/INSTAGRAM.md`](../../docs/INSTAGRAM.md). It is `workflow_dispatch`-only and no-ops without the secrets, so it never fires on its own.
 

--- a/tools/social/package.json
+++ b/tools/social/package.json
@@ -15,7 +15,8 @@
     "promo": "node promo.mjs",
     "avatar": "node avatar.mjs",
     "stories": "node stories.mjs",
-    "ad": "node ad-image.mjs"
+    "ad": "node ad-image.mjs",
+    "pick-feature": "node pick-feature.mjs"
   },
   "dependencies": {
     "playwright": "^1.48.0",

--- a/tools/social/pick-feature.mjs
+++ b/tools/social/pick-feature.mjs
@@ -1,0 +1,128 @@
+// Picks which store to feature this week, for the scheduled run of
+// instagram-feature.yml. Prints the chosen id on stdout and its reasoning on
+// stderr; prints nothing at all when no store qualifies, which the workflow
+// reads as "skip this week" rather than as a failure.
+//
+// WHY A PICKER RATHER THAN A LIST
+// A hand-kept rotation list goes stale the moment a store is added, closes, or
+// buys a promotion. Every rule below is re-evaluated from stores.json on the
+// morning it runs, so the rotation follows the data instead of a file someone
+// has to remember to edit.
+//
+// THE THREE RULES, IN THE ORDER THEY MATTER
+//
+// 1. Never feature a store that is currently PAYING for placement. The card
+//    store-feature.mjs renders says "Не реклама — магазин не платив за це
+//    розміщення". For an advertiser that sentence is still literally true (they
+//    bought a pin, not this post), which is exactly what makes it the wrong
+//    sentence to print: a reader cannot tell the difference, and the ambiguity
+//    resolves in the direction that flatters us. Both promo sources are checked
+//    — the static `promo` field in stores.json and the live self-fulfilled set
+//    at /promos — because a store can be paying through either.
+//
+// 2. Never feature a store whose card would be mostly blanks. The whole claim of
+//    a feature post is "here is a real shop you can walk to on a day worth
+//    going" — so an address, a restock claim, and real opening hours are all
+//    required. A store missing any of them is not rejected forever, just until
+//    a field agent fills it in.
+//
+// 3. Prefer a store never featured before, oldest-featured first after that.
+//    History is marketing/instagram/features/history.json, not the committed
+//    .jpg files and not `git log`: the workflow checks out at depth 1, so the
+//    commit dates those files would need are not in the clone.
+//
+// Inputs (all optional):
+//   FEATURE_HISTORY   path to history.json
+//   PROMOS_URL        live promo endpoint; set empty to skip the network call
+//
+// Run: node pick-feature.mjs
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../..');
+
+const HISTORY = process.env.FEATURE_HISTORY
+  ? resolve(repoRoot, process.env.FEATURE_HISTORY)
+  : resolve(repoRoot, 'marketing/instagram/features/history.json');
+
+// Same worker the app itself reads /promos from (index.html's METRICS_URL).
+const PROMOS_URL = process.env.PROMOS_URL === undefined
+  ? 'https://lviv-metrics.lshanalytic.workers.dev/promos'
+  : process.env.PROMOS_URL;
+
+const say = (...a) => console.error(...a);
+
+const stores = JSON.parse(readFileSync(resolve(repoRoot, 'stores.json'), 'utf8'));
+
+// Same activeness test deals-image.mjs uses, so "currently promoted" means the
+// same thing in both places.
+const activePromo = (s) =>
+  s.promo && (!s.promo.until || new Date(s.promo.until + 'T23:59:59') >= new Date());
+
+const DAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+// A day is known if it names hours or says closed — "?" is the unknown marker
+// stores.json uses for a store nobody has surveyed yet.
+const knownHours = (s) =>
+  s.hours ? DAYS.filter((d) => s.hours[d] && s.hours[d] !== '?').length : 0;
+
+// Mirrors store-feature.mjs's restockLine(): it prints a day, else an interval,
+// else no claim at all. "No claim at all" is the case worth skipping.
+const hasRestockClaim = (s) => Boolean(s.restockDay) || Number(s.cycle) >= 1;
+
+let livePromos = {};
+if (PROMOS_URL) {
+  try {
+    const res = await fetch(PROMOS_URL, { signal: AbortSignal.timeout(8000) });
+    if (res.ok) livePromos = await res.json();
+    else say(`note: ${PROMOS_URL} returned HTTP ${res.status} — using stores.json promos only.`);
+  } catch (e) {
+    // Non-fatal by design. Rule 1 is a judgement call about optics, not a
+    // correctness gate, and a marketing post should not be blocked by a
+    // transient fetch failure — but say so out loud rather than silently.
+    say(`note: could not read live promos (${e.message}) — using stores.json promos only.`);
+  }
+}
+
+const rejected = { watermark: 0, promoted: 0, thin: 0 };
+const eligible = stores.filter((s) => {
+  if (s.watermark) { rejected.watermark++; return false; }
+  if (activePromo(s) || livePromos[s.id]) { rejected.promoted++; return false; }
+  if (!s.name || !s.address || !hasRestockClaim(s) || knownHours(s) < 5) { rejected.thin++; return false; }
+  return true;
+});
+
+say(`${stores.length} stores → ${eligible.length} eligible ` +
+    `(skipped ${rejected.watermark} placeholder, ${rejected.promoted} currently promoted, ${rejected.thin} too thin).`);
+
+if (!eligible.length) {
+  say('Nothing qualifies this week — printing no id so the run skips rather than posting a weak card.');
+  process.exit(0);
+}
+
+let history = {};
+if (existsSync(HISTORY)) {
+  try {
+    history = JSON.parse(readFileSync(HISTORY, 'utf8'));
+  } catch (e) {
+    // A corrupt history file must not silently restart the rotation from the
+    // top — that would re-feature the same handful of stores forever.
+    throw new Error(`${HISTORY} is not valid JSON (${e.message}); fix or delete it.`);
+  }
+}
+
+// Never-featured first (history has no entry), then least-recently-featured.
+// `id` breaks every tie so the same input always picks the same store — a
+// re-run of a failed week posts the store that week was meant to post.
+eligible.sort((a, b) => {
+  const ta = history[a.id] || '';
+  const tb = history[b.id] || '';
+  if (ta !== tb) return ta < tb ? -1 : 1;
+  return a.id < b.id ? -1 : 1;
+});
+
+const pick = eligible[0];
+const last = history[pick.id];
+say(`Picked ${pick.id} — ${pick.name} (${last ? `last featured ${last}` : 'never featured'}).`);
+process.stdout.write(pick.id);


### PR DESCRIPTION
Two commits: a social-media expansion brainstorm, then the first two items off its build list.

## 1. The channel mirror (`telegram-channel-post.yml`)

Takes **deliberately identical inputs** to `instagram-post.yml` (`image`, `caption`, `dry_run`), so a pipeline that already posts to Instagram mirrors with one extra `uses:` job instead of a second caption format. Both automatic pipelines now do:

| When | What | Goes to |
| --- | --- | --- |
| Mondays | Deals ranking, only when it moved | Instagram + channel |
| Thursdays | Store of the week | Instagram + channel |

Each surface is its own job, so an expired Instagram token can't stop the channel post and a misconfigured channel can't stop the Instagram one.

**Why the channel earns it:** a caption's `?store=…` deep link is dead text on Instagram and a tap on Telegram. It's also cheaper to run — no 60-day token, no container/publish dance, no JPEG-only rule, just `sendPhoto` with the `BOT_TOKEN` the repo already holds.

**Pre-flights**, because a post that fails silently at 07:00 on a Monday is worse than one that never ran:
- The image URL is checked against Pages, not the checkout — for a caller that commits its image in an earlier job, the checkout predates that commit (the bug `instagram-feature.yml` already hit).
- The bot is checked to be a channel **administrator with post rights**, which is *the* setup mistake: adding it as a member looks like it worked, and Telegram only says `not enough rights` at posting time.
- No `parse_mode`, matching the Worker's rule, so no shop's name can break a post; bare URLs still auto-link.
- A caption over Telegram's 1024-char photo limit posts the photo bare with the full text as a reply, rather than truncating away the URL that is the point of posting here.

`TG_CHANNEL` is a repo **variable**, not a secret — a public handle is not a credential, and this repo has twice been bitten by duplicating a public value into a secret. Absent it every mirror job no-ops green, so nothing here is waiting on setup.

## 2. Store-of-the-week runs itself (`instagram-feature.yml` + `pick-feature.mjs`)

The workflow was built but only ever ran on demand. It now has a Thursday schedule — which means a machine chooses the shop, and that is what the picker guards:

- **Refuses a store currently paying for placement.** The card's "Не реклама — магазин не платив за це розміщення" is still literally true for an advertiser (they bought a pin, not this post), and that is exactly what makes it the wrong sentence to print to a reader who cannot tell. Both the static `promo` field and the live `/promos` set are checked.
- **Refuses a store whose card would be mostly blanks** — no address, no restock claim, or unsurveyed hours. Not forever; just until a field agent fills it in.
- Rotates the rest never-featured-first via `features/history.json` — used instead of `git log` because the workflow checks out at depth 1.
- Nothing qualifying means **no post**, not a weak one. 80 of 126 stores are eligible today.

A scheduled run publishes on its own and sends the owner the card as it goes out. That's safe here for a reason that does not hold for ads: this workflow has **no text input**, so no scheduled run can put a sentence in a shop's mouth. Manual runs keep `publish:false` and the preview round-trip. **Paid ads are deliberately not mirrored** — a store bought an Instagram post, and the approval covers that one post.

## 3. `docs/SOCIAL_MEDIA.md` (first commit)

The brainstorm the above came from: honest inventory, channels ranked with an explicit skip list, five content pillars mapped to the generator that makes each, twenty post ideas that are queries against data already in the repo, `?src=` measurement with an 8-week kill rule, guardrails, and a 30/60/90 sequence. Updated in the second commit to mark what shipped.

## Verification

- All five CI scripts pass locally, plus `node --check` on both Workers.
- Every `run:` block in the touched workflows shell-parses under `bash -n`.
- The poster's post step was **executed verbatim against a stubbed Telegram API** through all three branches (short caption → `sendPhoto`; empty image → `sendMessage`; 1200-char caption → photo + reply) and a rejection, which exits 1 with Telegram's own message.
- The picker was run against live `/promos`, a populated history file, and a corrupt one (exits 1 rather than silently restarting the rotation).
- The picked store (`c10`) renders a correct card and caption end to end.

## Not in scope here

The daily "who restocks tomorrow" line — the poster already accepts an empty `image` for it, but it's a new content generator rather than a mirror, and a third daily slot risks the muting that kills channels. Flagged as next in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gz9PPbPRjgz5dbWsr9jpvn