### PR TITLE
Write down the rule for music in videos, before the first video exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ Images must be **JPEG** — the API rejects PNG with a generic container error t
 
 **Beyond Instagram.** A channel-by-channel brainstorm — Telegram channel, short video, Facebook groups, what to skip, and what to build so it stays automatic — is in **[`docs/SOCIAL_MEDIA.md`](docs/SOCIAL_MEDIA.md)**.
 
+**Music in videos needs written permission first.** This project posts from a Business account, which cannot use the platform music libraries' popular tracks — so a commercial song under a Reel gets muted or pulled unless the rights holder has cleared it in writing. The rule, the safe alternatives, and which tracks are cleared: **[`docs/MUSIC.md`](docs/MUSIC.md)**.
+
 ### Paid ads on Instagram — you approve, then it posts
 
 A store buying a flash deal now also queues an **Instagram advertisement**. It is queued, never posted: the only route from a completed payment to the public feed is you tapping approve.

--- a/docs/MUSIC.md
+++ b/docs/MUSIC.md
@@ -1,0 +1,62 @@
+# Music in videos
+
+**The rule: no commercial track goes in a post until written permission is on
+file, recorded in the table below.**
+
+That includes the track this project would most like to use.
+
+## Why it is a hard rule
+
+- **A recording carries two separate rights** — the composition and the master.
+  Permission has to cover both, and the artist may not control both.
+- **This project posts from a Business account.** Instagram's publishing API
+  requires one ([`INSTAGRAM.md`](INSTAGRAM.md)), and Meta and TikTok restrict
+  business accounts to their Commercial Music Libraries. Popular commercial
+  tracks are generally not in them, so the usual "pick a sound in the app"
+  route is closed here. Using one anyway gets the audio muted or the post
+  pulled — against the account that runs the automated posting.
+- **The project is not purely non-commercial.** Shops buy placements
+  ([`ADVERTISING.md`](ADVERTISING.md)). Permission obtained by describing this
+  as a hobby project is permission that evaporates when someone checks.
+
+## What counts as permission
+
+A message from the rights holder, screenshotted and filed, that names:
+
+1. **What** — the track, and that a clip may be used as a video soundtrack.
+2. **Where** — the specific accounts and platforms.
+3. **How long**, and whether it can be revoked.
+4. **Credit** — the wording to display.
+
+Anything vaguer ("sure, go ahead") is not enough to dispute an automated claim.
+
+**Platform matching is automated and does not know about your permission.** Even
+with a genuine licence a video can be muted by Content ID or Meta's rights
+manager, so ask the rights holder to whitelist the accounts, and keep the
+written permission ready to dispute with.
+
+## Safe without permission
+
+- The platform's own **Commercial Music Library** (Meta, TikTok) — cleared for
+  business accounts by definition.
+- A paid library licence (Epidemic Sound, Artlist, Musicbed).
+- **CC-BY** tracks, credited exactly as the licence requires.
+- **No music.** Ambient sound from the shop, or silence with on-screen text.
+  Most of these videos are watched muted anyway.
+
+## Credit format
+
+When a licence requires credit, put it in the caption and on-screen:
+
+```
+Музика: <Виконавець> — <Трек>
+```
+
+## Status
+
+| Track | Rights holder | Asked | Granted | May use? |
+| --- | --- | --- | --- | --- |
+| «Секонд хенд» | Уляна Дель Рей (independent; no label found) | not yet | — | **No** |
+
+Update this table when an answer arrives — including a refusal, so nobody asks
+twice or assumes silence meant yes.

--- a/docs/SOCIAL_MEDIA.md
+++ b/docs/SOCIAL_MEDIA.md
@@ -127,8 +127,9 @@ shape as the existing per-visit rate.
 Ukrainian text + trending audio; "day 1 vs day 6 of the same rail"; the door at
 10:00 on restock day; three stores in 15 seconds.
 
-**Watch out:** filming people in shops needs the store's OK — get it during the
-survey, and never film customers' faces. A store that says no is still a store on
+**Watch out:** the soundtrack is a licensing question before it is a taste
+question — see [`MUSIC.md`](MUSIC.md); and filming people in shops needs the
+store's OK — get it during the survey, and never film customers' faces. A store that says no is still a store on
 the map; do not let filming leak into the free-listing relationship.
 
 ### C. Facebook — the Page is free, the Groups are the point
@@ -280,6 +281,10 @@ long; it should stay long.
   rule when the same content mirrors to new channels.
 - **Never automate group or DM posting.** Bans, and worse, reputation.
 - **Store photos need the store's permission**, gathered during the visit.
+- **No commercial music without written permission on file.** A business account
+  cannot use the platform music libraries' popular tracks, so a licensed-looking
+  Reel gets muted or pulled. The rule, the safe alternatives and the current
+  status are in [`MUSIC.md`](MUSIC.md).
 - **Token expiry is the standing failure mode.** Every new API channel needs the same
   treatment as `instagram-token-check.yml`: an automated check that turns a silent
   outage into a Telegram message.


### PR DESCRIPTION
Docs only. One new file, two links to it.

## Why now

The project would like to use Уляна Дель Рей's «Секонд хенд» — a Ukrainian track literally about second-hand shopping — as the soundtrack for the short videos in `SOCIAL_MEDIA.md`. That needs the rights holder's written permission, which **does not exist yet**. The rule goes in before the first video, not after a Reel gets pulled.

## The rule

> **No commercial track goes in a post until written permission is on file, recorded in the status table.**

Three things make this sharper than generic "don't use copyrighted music" advice, and all three are specific to this repo:

- **Two separate rights.** A recording carries the composition *and* the master; an artist may not control both.
- **This project posts from a Business account** — Instagram's publishing API requires one (`INSTAGRAM.md`). Meta and TikTok restrict business accounts to their Commercial Music Libraries, where popular commercial tracks generally are not. So the ordinary "pick a sound in the app" route is closed here, and using one anyway risks the audio being muted or the post pulled — against the very account that runs the automated posting.
- **The project is not purely non-commercial.** Shops buy placements (`ADVERTISING.md`). Permission obtained by describing this as a hobby project is permission that evaporates when someone checks, so the ask has to say so up front.

## Also recorded

- **Platform matching is automated and does not know about a private permission** — so ask the rights holder to whitelist the accounts, and keep the written grant ready to dispute with. This is the failure most people hit *after* getting a yes.
- What counts as permission: what / where / how long / credit, screenshotted and filed. "Sure, go ahead" is not enough to dispute an automated claim.
- What is safe without permission at all: the platform Commercial Music Library, a paid library licence, CC-BY with exact credit, or no music — most of these videos are watched muted anyway.
- A status table. Its only row currently reads **may use: No**. It is to be updated on a refusal too, so nobody asks twice or reads silence as a yes.

## Linking

From `README.md`, and from both the short-video section and the guardrails list in `SOCIAL_MEDIA.md` — the two places someone planning a reel would actually look.

CI here is schema/syntax checks over code this PR doesn't touch; all four pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gz9PPbPRjgz5dbWsr9jpvn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gz9PPbPRjgz5dbWsr9jpvn)_