### PR TITLE
Move the daily restock line to 14:00 UTC, off the Kyiv-midnight edge

### DIFF
--- a/.github/workflows/restock-tomorrow.yml
+++ b/.github/workflows/restock-tomorrow.yml
@@ -3,6 +3,20 @@ name: Daily restock line
 # Posts "who restocks tomorrow" to the Telegram channel, every evening Kyiv
 # time — early enough to plan the next morning around it.
 #
+# WHY 14:00 UTC AND NOT 17:00, WHICH IS WHAT 20:00 KYIV WOULD SUGGEST
+# GitHub does not run scheduled workflows on time. Measured on this repo:
+# refresh-pages.yml (cron 03:17) has fired between 07:44 and 08:45 — 4h27m to
+# 5h28m late — and this workflow's first scheduled run was 1h51m late. So the
+# cron is not a delivery time, it is the earliest possible one, with a tail of
+# several hours behind it.
+#
+# 14:00 UTC puts the whole observed range between roughly 17:00 and 21:30 Kyiv.
+# The previous 16:00 landed at 20:50 on its first run, but at the slow end of
+# that range it would cross Kyiv midnight — and that does not merely make the
+# post late, it makes it WRONG: restock-tomorrow.mjs computes "tomorrow" from
+# the actual run time, so a run at 00:30 announces the day after next and the
+# intervening day is never announced at all.
+#
 # WHY THIS IS THE ONE POST THAT EARNS A DAILY SLOT
 # The bot already answers "today" on demand. What a broadcast can do that a
 # command cannot is arrive BEFORE you need it: a restock is worth knowing the
@@ -24,7 +38,7 @@ name: Daily restock line
 
 on:
   schedule:
-    - cron: "0 16 * * *" # Daily 16:00 UTC (~19:00 Europe/Kyiv)
+    - cron: "0 14 * * *" # Daily 14:00 UTC — see the delay note above
   workflow_dispatch:
     inputs:
       dry_run:

--- a/docs/TELEGRAM_CHANNEL.md
+++ b/docs/TELEGRAM_CHANNEL.md
@@ -88,7 +88,7 @@ scheduled post will work.
 | --- | --- | --- |
 | Mondays ~07:00 Kyiv | The week's "longest since a restock" ranking — **only when the ranking actually moved** | `deals-image.yml` → `telegram-channel-post.yml` |
 | Thursdays ~13:00 Kyiv | Store of the week — one shop, chosen by `pick-feature.mjs`, labelled *not an ad* | `instagram-feature.yml` → `telegram-channel-post.yml` |
-| Every evening ~19:00 Kyiv | **Who restocks tomorrow** — text only, and silent on days with nothing on record | `restock-tomorrow.yml` → `telegram-channel-post.yml` |
+| Every evening, ~17:00–21:30 Kyiv | **Who restocks tomorrow** — text only, and silent on days with nothing on record | `restock-tomorrow.yml` → `telegram-channel-post.yml` |
 
 The first two mirror what goes to Instagram, from the same image and the same
 caption. Each surface is its own job, so an expired Instagram token cannot stop
@@ -138,6 +138,13 @@ than Instagram's 2200. Rather than truncate — which would drop the URL at the
 end, the whole reason for posting here — the workflow posts the photo bare and
 puts the full text in a reply underneath. The current captions are ~400–600
 characters, so this is a guard, not a routine path.
+
+**A cron is the earliest possible time, not the delivery time.** GitHub runs
+scheduled workflows late — measured on this repo, between two and five and a
+half hours. That is why the daily line's cron is 14:00 UTC for an evening post
+rather than 17:00: the whole delay range has to land before Kyiv midnight,
+because a run after midnight announces the day after next and silently skips a
+day.
 
 **Nothing is retracted by deleting the file.** A post is live the moment the API
 returns; removing the committed image later leaves the post in place with a


### PR DESCRIPTION
One cron change, plus the reasoning written where it will be found.

## The problem

A cron on GitHub is the **earliest possible** run time, not the delivery time. Measured on this repo:

| Workflow | Cron | Actually fired | Late by |
| --- | --- | --- | --- |
| `refresh-pages.yml` | 03:17 | 07:44 – 08:45 (5 runs) | 4h27m – 5h28m |
| `restock-tomorrow.yml` | 16:00 | 17:50 (first run) | 1h51m |

At 16:00 UTC that spread reaches across Kyiv midnight. For this post, crossing midnight isn't merely late — it's **wrong**: `restock-tomorrow.mjs` computes "tomorrow" from the actual run time, so a run at 00:30 announces the day *after* next, and the day in between is never announced at all.

## The change

`0 16 * * *` → `0 14 * * *`. That puts the whole observed delay range between roughly **17:00 and 21:30 Kyiv** — still an evening post, midnight edge removed.

## Where the reasoning lives

In the **workflow header**, not just this PR: the next person to read that cron will wonder why an evening post fires at 14:00, and the answer isn't guessable from the file. `TELEGRAM_CHANNEL.md`'s schedule table now states a delivery *range* rather than a single time, and repeats the warning alongside its other failure modes.

## Timing of the change itself

Made at **05:10 UTC**, before either the old (16:00) or new (14:00) slot had come round today — so today's post fires once, at the new time, rather than being skipped or duplicated. Today is the first run with real content: Sunday evening announcing Monday's nine shops.

## Why a separate branch

`claude/social-media-marketing-brainstorm-bs7vxn` currently backs open PR #330 (the music-licensing doc), which is waiting on a decision. Bundling this time-sensitive fix behind that would have meant merging an undecided doc to ship a cron change. This one stands alone.

All four CI scripts pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gz9PPbPRjgz5dbWsr9jpvn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gz9PPbPRjgz5dbWsr9jpvn)_