### PR TITLE
Record the owner's fair-use decision on «Секонд хенд» as a decision, not a clearance

### DIFF
--- a/docs/MUSIC.md
+++ b/docs/MUSIC.md
@@ -3,7 +3,9 @@
 **The rule: no commercial track goes in a post until written permission is on
 file, recorded in the table below.**
 
-That includes the track this project would most like to use.
+That includes the track this project would most like to use. Any exception
+is a decision by the owner, recorded as such under Status below — it is not a
+clearance, and the difference matters.
 
 ## Why it is a hard rule
 
@@ -56,7 +58,27 @@ When a licence requires credit, put it in the caption and on-screen:
 
 | Track | Rights holder | Asked | Granted | May use? |
 | --- | --- | --- | --- | --- |
-| «Секонд хенд» | Уляна Дель Рей (independent; no label found) | not yet | — | **No** |
+| «Секонд хенд» | Уляна Дель Рей (independent; no label found) | not yet | — | **Owner's call** — see below |
 
 Update this table when an answer arrives — including a refusal, so nobody asks
 twice or assumes silence meant yes.
+
+### Exception on file
+
+**«Секонд хенд» — the owner asserts fair use for clips of 30 seconds or less.
+No licence on file. Recorded 2026-09-06.**
+
+Written down as what it is: a decision by the project owner, not a permission
+from the rights holder. The two are not interchangeable, and a reader a year
+from now needs to be able to tell which one this row is.
+
+Two things it does not change, both worth knowing if a post disappears:
+
+- **Platform audio matching is automated and does not evaluate fair use.** It
+  fingerprints a few seconds and matches regardless of clip length, so a video
+  can still be muted or removed — on the Business account that runs the
+  automated posting.
+- **A claim would be answered with the assertion above, not with a licence.**
+
+The band has not been asked. One message is what would turn this row into a
+clearance and make the point moot.


### PR DESCRIPTION
Docs only — one file, `docs/MUSIC.md`.

## What changed

The owner has decided to proceed on a fair-use judgement for clips of 30 seconds or less. That's their call, so the doc records it rather than arguing with it — but records it accurately.

**Status row:** `**No**` → `**Owner's call** — see below`

Not "No", which no longer reflects the project's intent. Not "Yes", which would imply a clearance that doesn't exist.

**New "Exception on file" section** states the assertion, that no licence is on file, and the date. A reader a year from now has to be able to tell an owner's decision apart from a rights holder's permission, and a bare "yes" in that column wouldn't let them.

It also notes the two things the decision doesn't change — operational, not argumentative, because whoever finds a post missing will want them written down:

- Platform audio matching is automated and fingerprints a few seconds **regardless of clip length**, so a video can still be muted or removed — on the Business account that runs the automated posting.
- A claim would be met with the assertion, not a licence.

**The top-line rule is unchanged** and remains the default. It now says outright that an exception is an owner decision recorded under Status, so the rule and the row don't contradict each other.

## Not changed

`SOCIAL_MEDIA.md` and `README.md` still point at `MUSIC.md` as the place where music decisions live, which is still true. No workflow or code touched.

All four CI scripts pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gz9PPbPRjgz5dbWsr9jpvn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gz9PPbPRjgz5dbWsr9jpvn)_