### PR TITLE
Tag arrivals with ?src= so the metrics can say which channel sends people

### DIFF
--- a/docs/SOCIAL_MEDIA.md
+++ b/docs/SOCIAL_MEDIA.md
@@ -235,7 +235,7 @@ in `tools/social/`, a workflow that runs it, output committed and served by Page
 | --- | --- | --- |
 | ✅ **`telegram-channel-post.yml`** | Mirrors any image we publish to the Telegram channel via `sendPhoto`. Reuses `BOT_TOKEN`. | Done |
 | ✅ **Schedule `instagram-feature.yml`** | Store-of-the-week goes out weekly, picking a store that is not paid-for, not thin, and not recently featured | Done |
-| **`?src=` on every posted link + pass-through in the Worker** | Per-channel attribution against the existing `store_open` metric. Without this the whole exercise is unmeasurable | Hours |
+| ✅ **`?src=` on posted links + pass-through in the Worker** | Per-channel attribution against the existing `store_open` metric. Built: the app reads `?src=`, keeps it for the tab, and attaches it to every beacon; the Worker stores it and `/stats` reports `storeOpensBySrc30`. Only the nightly restock line is tagged so far — see below | Done |
 | **`restock-tomorrow` job** | Daily one-liner to the channel from `restockDay`/`restockDates` | Half a day |
 | **`captions.mjs`** | One place for caption templates + hashtag sets per channel, so captions stop being retyped per post | Half a day |
 | **`whats-new.mjs`** | Renders "added this month" from a `stores.json` diff | Half a day |
@@ -258,11 +258,20 @@ metric that makes a dead account look alive.
 | Instagram | Saves + shares (not likes), profile→link taps |
 | Video | Watch-through, then follows per 1k views |
 | Facebook groups | Comments and clicks per post, not reach |
-| All | `store_open` events tagged with `?src=` — the only cross-channel truth |
+| All | `store_open` events tagged with `?src=` — the only cross-channel truth. Read it from `GET /stats` as `storeOpensBySrc30` |
 
 The Worker already records `store_open`; adding a source tag makes the map's own
 analytics the scoreboard for social, which is better than any platform's dashboard
 because it counts the thing we actually want (someone looking at a shop).
+
+**What is tagged, and what cannot be.** The nightly restock line is
+channel-only, so its link carries `src=tg` and every tap on it genuinely came
+from Telegram. The Monday ranking and Thursday store feature share one caption
+between Instagram and the channel, so a single tag would be a lie on one of
+them. Tagging those needs the tag applied per surface at post time rather than
+baked into the caption — worth doing, not done. Mitigating that slightly:
+an Instagram caption's URL is not clickable at all, so almost any tap on a
+shared link came from Telegram anyway.
 
 **A blunt kill rule:** any channel that has not produced measurable link taps after
 8 weeks of honest effort gets dropped, not "improved". The list in §3E is already
@@ -300,7 +309,7 @@ long; it should stay long.
 **First 30 days — cheap and mostly automatic**
 1. ✅ Mirror the Monday post to a channel, ✅ add the daily restock line,
    ✅ open the channel and set `TG_CHANNEL`. All three slots are running.
-2. Add `?src=` and the Worker pass-through so everything after this is measurable.
+2. ✅ Add `?src=` and the Worker pass-through. **Left to do:** tag the shared captions — see the caveat below.
 3. ✅ Schedule store-of-the-week.
 4. Post once, by hand, in three Facebook groups and once in `r/lviv`. Watch what happens.
 

--- a/index.html
+++ b/index.html
@@ -3743,7 +3743,7 @@ if ('serviceWorker' in navigator) {
 // UPDATE CHECK — notify when a newer build is deployed, so nobody is stuck on
 // a cached version (no reinstall needed). Bump APP_VERSION on each deploy.
 // ─────────────────────────────────────────────
-const APP_VERSION = '2026-09-05.1';
+const APP_VERSION = '2026-09-06.1';
 
 // ─────────────────────────────────────────────
 // DONATIONS — points at a Stripe Payment Link (hosted checkout). No API keys
@@ -3785,10 +3785,36 @@ function initAnalytics(){
 // until METRICS_URL is set. Disclosed in privacy.html before it was enabled.
 // ─────────────────────────────────────────────
 const METRICS_URL = 'https://lviv-metrics.lshanalytic.workers.dev';
+// ?src=tg — which channel the visitor arrived from, read once and attached to
+// every beacon. Without it the metrics can say how many people came but not
+// where from, which is the only question that tells you where to spend the next
+// hour. Read before track() is defined below, because the once-per-open beacon
+// fires immediately after it.
+//
+// Kept for the tab, not the visit: someone who arrives from a channel post and
+// then browses six stores should credit all six to that channel, which is the
+// behaviour that makes store_open-by-src meaningful.
+//
+// Stripped from the URL afterwards, like ?store= and ?route=, so that a link
+// someone copies out of their address bar and forwards does not carry another
+// channel's attribution with it.
+let visitSrc = '';
+try {
+  const p = new URLSearchParams(location.search);
+  const raw = (p.get('src') || '').slice(0, 16).replace(/[^A-Za-z0-9_-]/g, '');
+  if (raw) {
+    sessionStorage.setItem('lviv_sh_src', raw);
+    p.delete('src');
+    const qs = p.toString();
+    history.replaceState(null, '', location.pathname + (qs ? '?' + qs : '') + location.hash);
+  }
+  visitSrc = sessionStorage.getItem('lviv_sh_src') || '';
+} catch(e) { /* private mode denies sessionStorage — attribution is optional, the app is not */ }
+
 function track(type, key){
   if (!METRICS_URL) return;
   try {
-    const body = JSON.stringify({ type, key: key == null ? '' : String(key), lang });
+    const body = JSON.stringify({ type, key: key == null ? '' : String(key), lang, src: visitSrc });
     if (navigator.sendBeacon) navigator.sendBeacon(METRICS_URL, body);
     else fetch(METRICS_URL, { method:'POST', body, keepalive:true }).catch(()=>{});
   } catch(e){ /* metrics must never break the app */ }

--- a/tools/social/restock-tomorrow.mjs
+++ b/tools/social/restock-tomorrow.mjs
@@ -77,7 +77,12 @@ if (!dated.length && !weekly.length) {
 
 // The map filters to exactly these shops. One tappable link beats one link per
 // store: a channel post is read on a phone, and fifteen links is a wall.
-const routeUrl = `${SITE}/?route=${[...dated, ...weekly].map((s) => s.id).join(',')}`;
+//
+// src=tg because this post is channel-only, so every tap on this link genuinely
+// came from Telegram — no other surface carries it. Captions that go to both
+// Instagram and the channel cannot be tagged this cleanly, which is why they
+// are not tagged yet.
+const routeUrl = `${SITE}/?route=${[...dated, ...weekly].map((s) => s.id).join(',')}&src=tg`;
 
 // Long enough to be complete on a normal day (the busiest fixed day has 14),
 // capped so an unusual day cannot turn the post into a scroll.

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -178,6 +178,11 @@ async function ensureSchema(env) {
   await env.DB.prepare(
     "CREATE TABLE IF NOT EXISTS events (id INTEGER PRIMARY KEY AUTOINCREMENT, day TEXT NOT NULL, type TEXT NOT NULL, key TEXT, lang TEXT)"
   ).run();
+  // `src` (where the visitor arrived from) was added after this table already
+  // existed in production, so CREATE TABLE above will not add it — an ALTER
+  // must, and it throws harmlessly once the column is there. Same shape as the
+  // promos.cust_id migration.
+  try { await env.DB.prepare('ALTER TABLE events ADD COLUMN src TEXT').run(); } catch {}
   _schemaReady = true;
 }
 
@@ -1595,11 +1600,19 @@ export default {
           const ev = await env.DB.prepare(
             'SELECT COUNT(*) AS n FROM events WHERE day >= ?'
           ).bind(ago(29)).first();
+          // The whole point of collecting src: which channel actually sends
+          // people to a shop. Only store_open counts here — a filter tap is not
+          // a visit to a store, and counting it would flatter whichever channel
+          // sends the most idle browsers.
+          const bySrc = await env.DB.prepare(
+            "SELECT src, COUNT(*) AS n FROM events WHERE day >= ? AND type = 'store_open' AND src IS NOT NULL GROUP BY src ORDER BY n DESC"
+          ).bind(ago(29)).all();
           return json({
             ok: true,
             today: d1, last7: d7, last30: d30, allTime: dAll,
             since: (first && first.d) || null,
             events30: (ev && ev.n) || 0,
+            storeOpensBySrc30: (bySrc && bySrc.results) || [],
             daily: (daily && daily.results) || [],
           }, 200, origin);
         } catch (e) {
@@ -2078,17 +2091,27 @@ export default {
     }
 
     // ── Usage metrics (root POST) ──
+    // Moved ahead of the insert below, which now names `src` — a column only
+    // ensureSchema's ALTER adds. It is guarded by _schemaReady so this costs one
+    // round trip per isolate, not one per beacon, and the later call in the
+    // visitor block is now a no-op rather than a second cost.
+    try { await ensureSchema(env); } catch {}
     const items = Array.isArray(body && body.events) ? body.events : [body];
     const day = new Date().toISOString().slice(0, 10);
     const rows = [];
     for (const e of items.slice(0, MAX_BATCH)) {
       if (!e || !TYPES.has(e.type)) continue;
-      rows.push({ type: e.type, key: clean(e.key, 40), lang: LANGS.has(e.lang) ? e.lang : null });
+      // src is attacker-controllable like every other field here, so it is
+      // length-capped and stripped to an id-safe alphabet rather than trusted —
+      // it ends up in a GROUP BY, and an unbounded label space is its own denial
+      // of service.
+      const src = clean(e.src, 16).replace(/[^A-Za-z0-9_-]/g, '');
+      rows.push({ type: e.type, key: clean(e.key, 40), lang: LANGS.has(e.lang) ? e.lang : null, src: src || null });
     }
     if (!rows.length) return new Response(null, { status: 204, headers: cors(origin) });
     try {
-      const stmt = env.DB.prepare('INSERT INTO events (day, type, key, lang) VALUES (?, ?, ?, ?)');
-      await env.DB.batch(rows.map((r) => stmt.bind(day, r.type, r.key, r.lang)));
+      const stmt = env.DB.prepare('INSERT INTO events (day, type, key, lang, src) VALUES (?, ?, ?, ?, ?)');
+      await env.DB.batch(rows.map((r) => stmt.bind(day, r.type, r.key, r.lang, r.src)));
     } catch {
       return new Response('db error', { status: 500, headers: cors(origin) });
     }


### PR DESCRIPTION
Three channels now publish and nothing could tell which of them sends anyone to a shop. The app counted arrivals; it couldn't count *where from* — the only version of that number that decides where to spend the next hour.

## The app

Reads `?src=` once per tab, keeps it in `sessionStorage`, attaches it to every beacon.

**Kept for the tab, not the page view**, deliberately: someone who arrives from a channel post and then opens six store pages should credit all six to that channel. That's what makes `store_open`-by-src mean anything.

**Stripped from the URL afterwards**, like `?store=` and `?route=` already are — so a link copied out of the address bar and forwarded doesn't carry someone else's attribution.

## The Worker

Stores it on `events` and reports it.

`src` is attacker-controllable like every other field on that endpoint, so it's **capped at 16 chars and stripped to an id-safe alphabet** before it reaches a `GROUP BY`. An unbounded label space is its own denial of service, independent of SQL injection — which bound parameters already handle.

`GET /stats` gains **`storeOpensBySrc30`**, counting `store_open` only: a filter tap isn't a visit to a store, and counting one would flatter whichever channel sends the most idle browsers.

**Migration note:** the column needed `ALTER TABLE`, not `CREATE TABLE`, since `events` already exists in production — same shape as the `promos.cust_id` migration. That forced `ensureSchema` ahead of the insert, which now names a column only the migration adds. It's guarded by `_schemaReady`, so the cost is one round trip per isolate, and the later call in the visitor block becomes a no-op.

## What's tagged, and what honestly can't be

Only the **nightly restock line** carries `src=tg` so far. It's channel-only, so every tap on its link genuinely came from Telegram.

The Monday ranking and Thursday feature **share one caption** between Instagram and the channel, so a single tag would be false on one of them. Doing it properly needs the tag applied per surface at post time. That's written down as not done rather than fudged. (Mitigating slightly: an Instagram caption's URL isn't clickable, so almost any tap on a shared link came from Telegram anyway.)

## Verification

Driven in a real browser (Playwright), not just diffed:

- `?src=tg` captured alongside `?route=c20,c22`; **both** stripped, leaving a clean URL.
- Both beacons carried it: `{"type":"action","key":"app_open","lang":"en","src":"tg"}` and the `tab`/`map` one.
- A second load in the same tab with **no** parameter still reported `src=tg`.
- No page errors.
- Sanitiser exercised against long strings, `'; DROP TABLE events;--`, path traversal, `<script>`, non-strings, and Cyrillic — all reduced to a safe token or `null`.

`APP_VERSION` → `2026-09-06.1`, since the service worker serves a cached `index.html` until it changes. All four CI scripts pass, plus `node --check` on both Workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gz9PPbPRjgz5dbWsr9jpvn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gz9PPbPRjgz5dbWsr9jpvn)_