### PR TITLE
Settle the market's scope, and put the listings table in the right Worker

### DIFF
--- a/docs/MARKET.md
+++ b/docs/MARKET.md
@@ -94,12 +94,27 @@ That is mostly good (a store feature gaining a comment thread is fine) but it
 is a change to the map channel's character, and it brings its own moderation
 surface. It can be switched off again, but not selectively per post.
 
+## Scope — what may be listed
+
+**Clothing, footwear, and small items a person can carry to a meetup by hand.**
+Sports equipment is explicitly in; furniture, appliances, vehicles and anything
+needing a van are out.
+
+The rule is deliberately about **size and handover**, not about a category
+list. A category list has to be extended every time someone lists something
+nobody thought of, and each extension is a moderation argument. "Could you
+carry it to the meeting point?" answers every one of those without a
+discussion, and it follows from the fact that we run no shipping and take no
+part in the handover.
+
 ## Categories
 
-Six. Every extra category splits a small market into emptier rooms.
+Seven, and the last one is a catch-all rather than a room of its own. Every
+extra category splits a small market into emptier shelves, so the long tail
+goes in `Інше` instead of earning its own entry.
 
 `👗 Жіноче` · `👔 Чоловіче` · `👟 Взуття` · `🧸 Дитяче` · `🎒 Аксесуари` ·
-`🏠 Дім і текстиль`
+`⚽ Спорт` · `📦 Інше`
 
 ## The `/sell` flow
 
@@ -191,10 +206,22 @@ With no rate limit, the gate carries the whole load. A seller can queue fifty
 items in an evening; they simply arrive as fifty approvals to tap. Batch
 approve/reject is the obvious thing to build first if that happens.
 
-## Data
+## Data — and whose database it is
 
-One table. The repo's `check-wiring.mjs` fails CI on a D1 table written to but
-never created, so it goes in `ensureSchema()` with the rest.
+**The bot Worker has no D1 binding.** It has KV (`VISITS`) for sessions and a
+**service binding** to the metrics Worker (`METRICS`), which owns the database.
+So the table lives in `worker/` and the bot reaches it through
+`metricsFetch()`, exactly as the flash-deal subscriptions, edit claim/resolve
+and the leaderboard already do.
+
+This is not a stylistic preference. A Worker cannot fetch another Worker on the
+same zone by its public URL — Cloudflare answers 404 with `error code: 1042` —
+and this repo has already been bitten by it once, which is why `check-wiring.mjs`
+fails CI on exactly that pattern. An earlier draft of this document said "one
+new D1 table" without saying whose, which would have led straight into it.
+
+One table, in the metrics Worker's `ensureSchema()`, since `check-wiring.mjs`
+also fails CI on a D1 table written to but never created.
 
 ```sql
 CREATE TABLE IF NOT EXISTS listings (
@@ -229,7 +256,10 @@ a plausible quarter:
 - **Reply keyboards and a universal `/cancel`.**
 - **Owner-gated inline callbacks** (`handleAgentCallback`).
 - **The scheduled sweep** in the metrics Worker, which already runs every five
-  minutes — expiry and the day-25 nudge are another query on it.
+  minutes — expiry and the day-25 nudge are another query on it, and it lives
+  in the same Worker as the table.
+- **`metricsFetch()`**, the bot's service-binding helper, with the strict
+  variant that refuses to let an unreachable Worker look like an empty result.
 
 ## Rules — the pinned post
 
@@ -239,10 +269,12 @@ a plausible quarter:
 1. Оголошення публікує лише бот: @Secondhandlvivbot → /sell
 2. Ми НЕ беремо участі в оплаті й НЕ гарантуємо угоди.
    Зустрічайтеся в людних місцях. Перевіряйте річ до оплати.
-3. Одна річ — одне оголошення. До 5 активних.
+3. Одна річ — одне оголошення. Скільки завгодно оголошень.
 4. Тільки вживане, для себе. Не для магазинів і не оптом.
-5. Заборонено: репліки як оригінал, нові речі, не одяг/взуття/дім.
-6. Продали — /sold. Через 30 днів оголошення зникає саме.
+5. Одяг, взуття та дрібні речі, які можна принести в руках
+   (спортінвентар — так; меблі, техніка, авто — ні).
+6. Заборонено: репліки як оригінал, нові речі.
+7. Продали — /sold. Через 30 днів оголошення зникає саме.
 
 Питання по речі — у коментарях під нею.
 ```


### PR DESCRIPTION
Spec corrections to `docs/MARKET.md` before any of the market gets built. Two matter, one is cleanup.

## 1. Scope is a size rule, not a category list

**Clothing, footwear, and small items a person can carry to a meetup by hand.** Sports equipment explicitly in; furniture, appliances, vehicles out.

A category list has to be extended every time someone lists something nobody anticipated, and each extension is a moderation argument. *"Could you carry it to the meeting point?"* answers all of them at once — and it follows directly from the fact that we run no shipping and take no part in the handover.

Categories go to **seven**, the last a catch-all (`📦 Інше`), so the long tail lands there rather than earning its own empty shelf.

## 2. The listings table was going to be built in the wrong Worker

The earlier draft said "one new D1 table" without saying *whose*. **The bot Worker has no D1 binding** — it has KV for sessions and a service binding (`METRICS`) to the metrics Worker, which owns the database.

Building it as the draft implied would have walked straight into a failure this repo has already hit: a Worker cannot fetch another Worker on the same zone by its public URL — Cloudflare answers 404 with `error code: 1042` — which is exactly why `check-wiring.mjs` fails CI on that pattern.

So the table lives in `worker/`, and the bot reaches it through `metricsFetch()`, as the flash-deal subscriptions, edit claim/resolve and the leaderboard already do. The scheduled sweep that expiry rides is in that same Worker, next to the table.

## 3. Cleanup the no-limits change left behind

The pinned rules had a duplicated list number, and rule 3 still promised «До 5 активних» after the caps were removed. It now reads «скільки завгодно», which is what was actually decided.

## Settled, for the record

| Decision | Answer |
| --- | --- |
| Build it | Yes |
| Collector | Existing `@Secondhandlvivbot`, `/sell` |
| Venue | Existing `@Lviv_Secondhand` |
| Second bot | No |
| Payments | None |
| Volume limits | None |
| Scope | Clothes + carryable small items |

All four CI scripts pass. Next: the listings store in `worker/`, then the `/sell` wizard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gz9PPbPRjgz5dbWsr9jpvn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gz9PPbPRjgz5dbWsr9jpvn)_