### PR TITLE
Let a seller close a sold listing: /my, /sold, and the ✅ Продано button

### DIFF
--- a/docs/MARKET.md
+++ b/docs/MARKET.md
@@ -187,10 +187,32 @@ three weeks ago, gets no reply, and stops trusting the feed.
 
 - **30-day expiry.** The bot deletes the channel post and marks it `expired`.
 - **Day 25: «Ще актуально?»** — one tap to extend 30 more days or close it.
-- **`/sold`** closes a listing immediately; the bot edits the post to
-  ~~struck-through~~ with «ПРОДАНО» and removes it a day later, so a buyer
-  mid-conversation sees what happened.
-- **`/my`** lists the seller's active items with close buttons.
+- **`/sold`** (also the `✅ Продано` keyboard button) closes a listing
+  immediately: the bot prefixes the channel caption with «🔴 ПРОДАНО» and the
+  sweep removes the post a day later, so a buyer mid-conversation sees what
+  happened instead of finding a hole.
+- **`/my`** lists the seller's own listings — pending, live and just-sold —
+  with their status.
+
+Two things came out differently from the sketch above, both on purpose:
+
+**A prefix, not strikethrough.** Strikethrough needs `parse_mode`, and the
+caption carries seller-written text. Letting a seller's title render as markup
+is the one thing this repo consistently refuses, so «🔴 ПРОДАНО» goes on as a
+plain first line.
+
+**The card is rebuilt, not re-read.** The `sold:` tap arrives on the picker
+message in the bot chat, which has no caption, and a bot cannot fetch a message
+it did not just send. So the new caption is rebuilt from the row the status
+call returns — which is why `/api/listing/status` hands back the whole row and
+not just an ok.
+
+Ownership is checked in the bot, not the Worker: `/api/listing/status` is a
+Worker-to-Worker call that the owner's approval uses too, so before a `sold:`
+tap changes anything the bot confirms the id is in the tapping user's own
+`/api/listing/mine` list and still `live`. A guessed id from a stranger, or a
+second tap on something already closed, gets «Це оголошення не ваше або вже
+закрите» and writes nothing.
 
 ## Anti-abuse
 
@@ -274,7 +296,8 @@ a plausible quarter:
 5. Одяг, взуття та дрібні речі, які можна принести в руках
    (спортінвентар — так; меблі, техніка, авто — ні).
 6. Заборонено: репліки як оригінал, нові речі.
-7. Продали — /sold. Через 30 днів оголошення зникає саме.
+7. Продали — кнопка «✅ Продано» або /sold.
+   Свої оголошення — /my. Через 30 днів зникає саме.
 
 Питання по речі — у коментарях під нею.
 ```

--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -242,6 +242,12 @@ function helpText() {
     '/day — pick any weekday · обрати будь-який день тижня',
     '/rare — stores that restock every 14+ days · рідко оновлювані магазини',
     '/cheap — longest since a restock · найдовше без завозу',
+    '',
+    '🏷 <b>Барахолка · Flea market</b> — продати свою річ у каналі',
+    '/sell — put an item up for sale · виставити річ на продаж',
+    '/my — your listings · ваші оголошення',
+    '/sold — close a listing you sold · закрити продане',
+    '',
     '/submit — add your store (for owners) · додати свій магазин',
     '/job — vacancy: field agent · вакансії: польовий агент',
     '/feedback — tell the maintainer something · залишити відгук',
@@ -453,6 +459,7 @@ const MENU_RARE = '🐢 Рідко оновлюють';
 const MENU_ADD = '➕ Додати магазин';
 const MENU_FEEDBACK = '💬 Залишити відгук';
 const MENU_SELL = '🏷 Продати річ';
+const MENU_SOLD = '✅ Продано';
 const MENU_HELP = '❓ Довідка';
 const MENU_BACK = '⬅️ Назад';
 // Extra row, appended only for the owner/agents (see mainMenuMarkupFor) — the
@@ -468,8 +475,8 @@ function kbMarkup(rows) {
 const MAIN_MENU_MARKUP = kbMarkup([
   [MENU_DAY, MENU_CHEAP],
   [MENU_RARE, MENU_ADD],
-  [MENU_SELL, MENU_FEEDBACK],
-  [MENU_HELP],
+  [MENU_SELL, MENU_SOLD],
+  [MENU_FEEDBACK, MENU_HELP],
 ]);
 // isOwner/isAgent gate real access everywhere these menus are actually used
 // (handleVisit's command router) — this only controls whether the button is
@@ -483,8 +490,8 @@ function mainMenuMarkupFor(isOwner, isAgent) {
   return kbMarkup([
     [MENU_DAY, MENU_CHEAP],
     [MENU_RARE, MENU_ADD],
-    [MENU_SELL, MENU_FEEDBACK],
-    [MENU_HELP],
+    [MENU_SELL, MENU_SOLD],
+    [MENU_FEEDBACK, MENU_HELP],
     extra,
   ]);
 }
@@ -3333,6 +3340,114 @@ async function handleSellCallback(env, c, cq) {
   return true;
 }
 
+// /my and /sold — a seller's own listings, and closing one.
+//
+// Both read through the metrics Worker, which is also where ownership is
+// established: the callback data carries a listing id, and anyone can craft
+// one, so /sold verifies the id is in the tapping user's OWN list before it
+// changes anything. The status endpoint deliberately does not check ownership
+// — it is a Worker-to-Worker call and the owner's approval uses it too — so
+// the check has to live here.
+async function sellMine(env, uid) {
+  const out = await sellApi(env, '/api/listing/mine', { seller_id: String(uid) });
+  return (out && out.ok && Array.isArray(out.listings)) ? out.listings : null;
+}
+
+async function handleMyListings(env, c, ctx) {
+  if (!c.enabled) return false;
+  const text = ctx.text;
+  if (text !== '/my' && text !== '/mine') return false;
+  const rows = await sellMine(env, ctx.userId);
+  if (rows === null) {
+    // Never invent an empty list from a failed call — an unreachable Worker
+    // must not read as "you have nothing".
+    await say(env, ctx.chatId, '⚠️ Не вдалося отримати ваші оголошення. Спробуйте за хвилину.');
+    return true;
+  }
+  if (!rows.length) {
+    await say(env, ctx.chatId, 'У вас немає активних оголошень.\n\nДодати — /sell');
+    return true;
+  }
+  const label = { pending: '⏳ на перевірці', live: '🟢 в каналі', sold: '✅ продано' };
+  const list = rows.map((r) => `• ${esc(r.title)} — ${r.price_uah} ₴ · ${label[r.status] || r.status}`).join('\n');
+  await say(env, ctx.chatId, `<b>Ваші оголошення</b>\n\n${list}\n\nПродали — ${MENU_SOLD} або /sold`);
+  return true;
+}
+
+async function handleSoldFlow(env, c, ctx) {
+  if (!c.enabled) return false;
+  const text = ctx.text;
+  if (text !== '/sold' && text !== MENU_SOLD) return false;
+  const rows = await sellMine(env, ctx.userId);
+  if (rows === null) {
+    await say(env, ctx.chatId, '⚠️ Не вдалося отримати ваші оголошення. Спробуйте за хвилину.');
+    return true;
+  }
+  const live = rows.filter((r) => r.status === 'live');
+  if (!live.length) {
+    await say(env, ctx.chatId, 'Немає опублікованих оголошень, які можна закрити.');
+    return true;
+  }
+  await tg(env, 'sendMessage', {
+    chat_id: ctx.chatId,
+    text: 'Що продали?',
+    reply_markup: { inline_keyboard: live.slice(0, 20).map((r) => [{ text: `${r.title} — ${r.price_uah} ₴`, callback_data: `sold:${r.id}` }]) },
+  });
+  return true;
+}
+
+// Seller taps one of their own listings in the /sold picker.
+async function handleSoldCallback(env, c, cq) {
+  const data = (cq && cq.data) || '';
+  if (!data.startsWith('sold:')) return false;
+  const id = data.slice(5);
+  const uid = cq.from && cq.from.id;
+  await tg(env, 'answerCallbackQuery', { callback_query_id: cq.id });
+
+  // Ownership: the id must be in this user's own list. Without this, anyone
+  // who guessed an id could close someone else's listing.
+  const rows = await sellMine(env, uid);
+  const mine = (rows || []).find((r) => r.id === id && r.status === 'live');
+  if (!mine) {
+    await tg(env, 'sendMessage', { chat_id: cq.message.chat.id, text: 'Це оголошення не ваше або вже закрите.' });
+    return true;
+  }
+
+  const out = await sellApi(env, '/api/listing/status', { id, status: 'sold' });
+  if (!out || !out.ok) {
+    await tg(env, 'sendMessage', { chat_id: cq.message.chat.id, text: '⚠️ Не вдалося закрити. Спробуйте ще раз.' });
+    return true;
+  }
+  // Mark the channel post rather than deleting it now: a buyer mid-conversation
+  // should see what happened instead of finding a hole. The sweep removes it a
+  // day later.
+  //
+  // The card is rebuilt from the row the status call just returned, not read
+  // off cq.message — the tapped message is the /sold picker in THIS chat, which
+  // has no caption at all, so reading it would replace a full card with a bare
+  // title. Bots cannot fetch a message they did not just send, so rebuilding is
+  // the only way to keep the price, size and district on the post.
+  //
+  // A prefix, not strikethrough. Strikethrough needs parse_mode, and this
+  // caption carries seller-written text — the one thing this repo consistently
+  // refuses to let render as markup.
+  const row = (out && out.listing) || null;
+  const body = row
+    ? sellCard({ category: row.category, title: row.title, size: row.size,
+                 condition: row.condition, price: row.price_uah, area: row.area },
+               row.seller_username || (cq.from && cq.from.username) || '')
+    : mine.title;
+  if (mine.channel_msg_id && env.TG_CHANNEL) {
+    await tg(env, 'editMessageCaption', {
+      chat_id: env.TG_CHANNEL,
+      message_id: mine.channel_msg_id,
+      caption: `🔴 ПРОДАНО\n\n${body}`,
+    }).catch(() => {});
+  }
+  await tg(env, 'sendMessage', { chat_id: cq.message.chat.id, text: `✅ Закрито: ${mine.title}\n\nДопис зникне з каналу завтра.` });
+  return true;
+}
+
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
@@ -3389,8 +3504,10 @@ export default {
     if (update.callback_query) {
       // sell:* is claimed here first; handleAgentCallback owns the bounty
       // prefixes and would otherwise treat an unknown payload as malformed.
-      ctx.waitUntil(handleSellCallback(env, c, update.callback_query).then((done) => {
-        if (!done) return handleAgentCallback(env, c, update.callback_query, origin);
+      ctx.waitUntil(handleSellCallback(env, c, update.callback_query).then(async (done) => {
+        if (done) return;
+        if (await handleSoldCallback(env, c, update.callback_query)) return;
+        return handleAgentCallback(env, c, update.callback_query, origin);
       }).catch(() => {}));
       return ok();
     }
@@ -3433,6 +3550,8 @@ export default {
     // answer must never be mistaken for a listing title.
     try {
       if (await handleSellFlow(env, c, msg, mctx)) return ok();
+      if (await handleMyListings(env, c, mctx)) return ok();
+      if (await handleSoldFlow(env, c, mctx)) return ok();
     } catch (e) {}
 
     // General feedback (Feature 7). Only needs BOT_TOKEN + VISITS, not the

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -205,6 +205,7 @@ async function ensureSchema(env) {
 // data and the clock. Nothing here touches money — there is none in the design.
 const LISTING_TTL_DAYS = 30;   // a listing removes itself after this
 const LISTING_NUDGE_DAYS = 25; // "ще актуально?" this many days in
+const LISTING_SOLD_GRACE_DAYS = 1; // a sold post lingers this long, marked, then goes
 const LISTING_STATUSES = new Set(['pending', 'live', 'sold', 'expired', 'rejected']);
 // Kept in step with the seven categories in docs/MARKET.md. Validated rather
 // than trusted: the value reaches a channel post, and an unbounded set would
@@ -822,8 +823,10 @@ async function sweepListings(env) {
   await ensureSchema(env);
   const today = kyivDateStr();
 
+  // Both 'live' (ran its 30 days) and 'sold' (grace period over): each needs
+  // the channel post gone, and only the message to the seller differs.
   const due = await env.DB.prepare(
-    "SELECT id, seller_id, title, channel_msg_id FROM listings WHERE status = 'live' AND expires_at <= ? LIMIT 50"
+    "SELECT id, seller_id, title, channel_msg_id, status FROM listings WHERE status IN ('live','sold') AND expires_at <= ? LIMIT 50"
   ).bind(today).all();
   for (const r of (due && due.results) || []) {
     if (r.channel_msg_id && env.BOT_TOKEN && env.TG_CHANNEL) {
@@ -833,11 +836,16 @@ async function sweepListings(env) {
         body: JSON.stringify({ chat_id: env.TG_CHANNEL, message_id: r.channel_msg_id }),
       }).catch(() => {});
     }
-    await env.DB.prepare("UPDATE listings SET status = 'expired' WHERE id = ?").bind(r.id).run();
+    const wasSold = r.status === 'sold';
+    // A sold row keeps its status — it is a record of a completed sale, not an
+    // expiry. Only a listing that timed out becomes 'expired'.
+    if (!wasSold) await env.DB.prepare("UPDATE listings SET status = 'expired' WHERE id = ?").bind(r.id).run();
     // No parse_mode: the title is seller-supplied.
-    await tgSend(env, r.seller_id,
-      `\u23f3 \u0412\u0430\u0448\u0435 \u043e\u0433\u043e\u043b\u043e\u0448\u0435\u043d\u043d\u044f \u0437\u043d\u044f\u0442\u043e \u0447\u0435\u0440\u0435\u0437 30 \u0434\u043d\u0456\u0432: ${r.title}\n\n\u0429\u0435 \u0430\u043a\u0442\u0443\u0430\u043b\u044c\u043d\u043e? \u041d\u0430\u0434\u0456\u0448\u043b\u0456\u0442\u044c /sell \u0449\u0435 \u0440\u0430\u0437.`
-    ).catch(() => {});
+    if (!wasSold) {
+      await tgSend(env, r.seller_id,
+        `\u23f3 \u0412\u0430\u0448\u0435 \u043e\u0433\u043e\u043b\u043e\u0448\u0435\u043d\u043d\u044f \u0437\u043d\u044f\u0442\u043e \u0447\u0435\u0440\u0435\u0437 30 \u0434\u043d\u0456\u0432: ${r.title}\n\n\u0429\u0435 \u0430\u043a\u0442\u0443\u0430\u043b\u044c\u043d\u043e? \u041d\u0430\u0434\u0456\u0448\u043b\u0456\u0442\u044c /sell \u0449\u0435 \u0440\u0430\u0437.`
+      ).catch(() => {});
+    }
   }
 
   const soon = await env.DB.prepare(
@@ -2126,7 +2134,12 @@ export default {
       const msgId = Number.isFinite(Number(body.channel_msg_id)) ? Number(body.channel_msg_id) : row.channel_msg_id;
       // Publishing restarts the clock: a listing that waited two days in the
       // approval queue should still get its full thirty days on the channel.
-      const expires = status === 'live' ? isoDaysFromNow(LISTING_TTL_DAYS) : row.expires_at;
+      // Selling shortens it instead — the post stays up one more day so a buyer
+      // mid-conversation sees "ПРОДАНО" rather than finding a hole, then the
+      // sweep removes it.
+      const expires = status === 'live' ? isoDaysFromNow(LISTING_TTL_DAYS)
+        : status === 'sold' ? isoDaysFromNow(LISTING_SOLD_GRACE_DAYS)
+        : row.expires_at;
       await env.DB.prepare('UPDATE listings SET status = ?, channel_msg_id = ?, expires_at = ? WHERE id = ?')
         .bind(status, msgId, expires, id).run();
       return json({ ok: true, id, status, listing: { ...row, status, channel_msg_id: msgId, expires_at: expires } }, 200, origin);
@@ -2138,7 +2151,7 @@ export default {
       if (typeof (body && body.seller_id) !== 'string') return json({ ok: false, reason: 'bad_request' }, 400, origin);
       await ensureSchema(env);
       const res = await env.DB.prepare(
-        "SELECT id, title, price_uah, status, expires_at, channel_msg_id FROM listings WHERE seller_id = ? AND status IN ('pending','live') ORDER BY created_at DESC LIMIT 50"
+        "SELECT id, title, price_uah, status, expires_at, channel_msg_id FROM listings WHERE seller_id = ? AND status IN ('pending','live','sold') ORDER BY created_at DESC LIMIT 50"
       ).bind(body.seller_id).all();
       return json({ ok: true, listings: (res && res.results) || [] }, 200, origin);
     }


### PR DESCRIPTION
Finishes the барахолка's seller side. Without this, a sold item sits in the channel for its full thirty days while buyers keep messaging a seller who is done — the single fastest way to make a flea-market feed feel dead.

## What a seller sees

- **`✅ Продано`** (new keyboard button) or **`/sold`** — an inline picker of their own *live* listings. Tapping one marks it sold, prefixes the channel caption with «🔴 ПРОДАНО», and the existing sweep removes the post a day later, so a buyer mid-conversation sees what happened instead of finding a hole.
- **`/my`** — everything they have pending, live or just-sold, with status.
- Both are now listed in `/help` under a Барахолка band.

## Three decisions worth naming

**Ownership is checked in the bot, not the Worker.** `/api/listing/status` is a Worker-to-Worker call that the owner's approval path uses too, so it cannot demand a seller id. Before a `sold:` tap changes anything, the bot confirms the id is in the tapping user's own `/api/listing/mine` list and still `live`. A guessed id from a stranger, or a second tap on something already closed, writes nothing.

**A prefix, not strikethrough** as the design sketch in `docs/MARKET.md` said. Strikethrough needs `parse_mode`, and this caption carries seller-written text — the one thing this repo consistently refuses to render as markup.

**The card is rebuilt, not re-read.** The `sold:` tap arrives on the picker message in the bot chat, which has no caption, and a bot cannot fetch a message it did not just send. Reading `cq.message.caption` would have replaced a full card with a bare title, so the new caption is rebuilt from the row `/api/listing/status` returns.

## Metrics Worker

- Selling shortens `expires_at` to the one-day grace rather than leaving the 30-day clock running.
- The sweep collects `sold` rows as well as `live` ones, and skips the expiry DM for them (the seller already knows).
- `/api/listing/mine` includes `sold`.

## Verification

Drove the real bot Worker end to end with KV, the metrics Worker and Telegram stubbed:

- a stranger's `sold:` tap on someone else's id → writes nothing, touches no channel post
- a second tap on an already-closed listing → refused
- a `pending` listing is never offered in the picker
- an unreachable metrics Worker says so rather than reading as "you have nothing"
- the rebuilt caption goes out with **no** `parse_mode`, price/size/district intact

The sweep's SQL is extracted from source and exercised against real SQLite (`node:sqlite`): sold posts go after the grace day, fresh ones stay, and sold rows keep their status rather than flipping to `expired`.

Local CI: `validate-stores`, `check-inline-js`, `check-wiring`, `check-workflows`, `check-init-data` and `node --check` on both Workers all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gz9PPbPRjgz5dbWsr9jpvn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gz9PPbPRjgz5dbWsr9jpvn)_