### PR TITLE
Mirror every approved listing to Instagram

### DIFF
--- a/.github/workflows/market-listing-ig.yml
+++ b/.github/workflows/market-listing-ig.yml
@@ -1,0 +1,229 @@
+name: Mirror a listing to Instagram
+
+# Posts one approved барахолка listing to Instagram, as its own post.
+#
+# WHY THIS RUNS HERE AND NOT IN THE BOT
+# The bot approves the listing and posts it to the channel itself — that part
+# needs no runner. Instagram needs two things a Cloudflare Worker cannot give
+# it: a headless browser (the card is rendered, see below) and a PUBLIC image
+# URL for Meta to fetch, which GitHub Pages already serves for anything
+# committed. So the bot sends a repository_dispatch carrying the listing id and
+# nothing else, and this workflow re-reads the listing from the metrics Worker.
+# The id is all it is given and all it needs; nothing in the payload is trusted.
+#
+# WHY A RENDERED CARD RATHER THAN THE SELLER'S PHOTO
+# Instagram accepts 4:5 to 1.91:1 and rejects everything else with a generic
+# container error. A phone photo is routinely 9:16, so posting raw photos would
+# fail on roughly every second listing, opaquely. The card also carries the
+# price, size and district — captions are not clickable on Instagram, so what a
+# reader needs has to be inside the image. See tools/social/listing-card.mjs.
+#
+# TWO GATES, BOTH IN THE DATA
+#   status = live — a pending or rejected listing is never mirrored. The owner's
+#     approval is what makes it live, so the human gate is the same one.
+#   ig_ok = 1     — set only by the /sell wizard, which tells the seller their
+#     listing goes to Instagram before they publish. A listing whose seller was
+#     never told cannot be mirrored no matter who triggers this.
+#
+# Unconfigured is a no-op, not a failure: without BOT_TOKEN or ADMIN_KEY this
+# exits green, same as every other pipeline here.
+
+on:
+  repository_dispatch:
+    types: [listing_to_instagram]
+  workflow_dispatch:
+    inputs:
+      listing_id:
+        description: "Listing id (the 8-character id from the approval message)"
+        required: true
+        type: string
+      dry_run:
+        description: "Render and commit the card, but do not post it"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+# Every run commits and pushes. Queued, never cancelled: two listings approved
+# a minute apart are two posts, and dropping one would silently lose it.
+concurrency:
+  group: market-listing-ig
+  cancel-in-progress: false
+
+env:
+  SITE: https://www.lvivsecondhand.com
+  METRICS: https://lviv-metrics.lshanalytic.workers.dev
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    outputs:
+      ready: ${{ steps.fetch.outputs.ready }}
+      image: ${{ steps.render.outputs.image }}
+      caption: ${{ steps.render.outputs.caption }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      # Fetch first, install later: a listing that turns out not to qualify
+      # should cost seconds, not a Chromium download. Same ordering as
+      # instagram-feature.yml's picker.
+      - name: Read the listing and its photo
+        id: fetch
+        env:
+          # Via env, never interpolated into the script body — a value pasted
+          # into `run:` as ${{ }} is substituted before bash parses it.
+          GIVEN: ${{ inputs.listing_id }}
+          DISPATCHED: ${{ github.event.client_payload.listing_id }}
+          ADMIN_KEY: ${{ secrets.ADMIN_KEY }}
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN || secrets.TELEGRAM_BOT_TOKEN }}
+        run: |
+          echo "ready=false" >> "$GITHUB_OUTPUT"
+          ID="${GIVEN:-$DISPATCHED}"
+          if [ -z "$ID" ]; then
+            echo "::error::No listing id given."
+            exit 1
+          fi
+          # Shape check before the id reaches a URL or a file path. Ids are
+          # crypto.randomUUID().slice(0,8) — hex and dashes, nothing else.
+          case "$ID" in
+            ''|*[!a-f0-9-]*) echo "::error::listing id '$ID' is not a plain hex id."; exit 1 ;;
+          esac
+          if [ ${#ID} -gt 36 ]; then echo "::error::listing id is too long."; exit 1; fi
+
+          if [ -z "$ADMIN_KEY" ] || [ -z "$BOT_TOKEN" ]; then
+            echo "::notice::ADMIN_KEY or BOT_TOKEN not set — skipping the Instagram mirror."
+            exit 0
+          fi
+
+          ROW=$(curl -s -X POST "$METRICS/api/listing/get" \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -nc --arg id "$ID" --arg k "$ADMIN_KEY" '{id:$id, key:$k}')" || echo '{}')
+          if [ "$(echo "$ROW" | jq -r '.ok // false')" != "true" ]; then
+            echo "::error::The metrics Worker did not return listing $ID: $(echo "$ROW" | jq -c '.reason // .')"
+            exit 1
+          fi
+          L=$(echo "$ROW" | jq -c '.listing')
+
+          # The two gates. Both are refusals, not errors: an owner re-running
+          # this by hand on a rejected listing should be told no, not handed a
+          # red run.
+          STATUS=$(echo "$L" | jq -r '.status // empty')
+          IG_OK=$(echo "$L" | jq -r '.ig_ok // 0')
+          if [ "$STATUS" != "live" ]; then
+            echo "::notice::Listing $ID is '$STATUS', not live — not mirroring."
+            exit 0
+          fi
+          if [ "$IG_OK" != "1" ]; then
+            echo "::notice::Listing $ID has no ig_ok — its seller was never told it would go to Instagram. Not mirroring."
+            exit 0
+          fi
+
+          FILE_ID=$(echo "$L" | jq -r '.photo_ids' | jq -r '.[0] // empty')
+          if [ -z "$FILE_ID" ]; then
+            echo "::error::Listing $ID has no photo."
+            exit 1
+          fi
+
+          # Two calls: getFile resolves a path, then the file is fetched from
+          # Telegram's file host. Both URLs embed the bot token, so neither is
+          # ever echoed — only the resolved path and the byte count are.
+          FP=$(curl -s "https://api.telegram.org/bot$BOT_TOKEN/getFile" \
+                 -d "file_id=$FILE_ID" | jq -r '.result.file_path // empty')
+          if [ -z "$FP" ]; then
+            echo "::error::Telegram would not resolve the listing's photo. The file_id may have expired."
+            exit 1
+          fi
+          curl -s -o /tmp/listing-photo.jpg "https://api.telegram.org/file/bot$BOT_TOKEN/$FP"
+          MAGIC=$(od -An -N3 -tx1 /tmp/listing-photo.jpg | tr -d ' \n')
+          if [ "$MAGIC" != "ffd8ff" ]; then
+            echo "::error::What Telegram returned for $FP is not a JPEG (first bytes: ${MAGIC:-none})."
+            exit 1
+          fi
+          echo "Photo: $FP ($(wc -c < /tmp/listing-photo.jpg) bytes, JPEG confirmed)"
+
+          # The row goes to the renderer as JSON, through the environment file
+          # rather than an output, so no part of a seller's title is ever
+          # substituted into a shell command line.
+          {
+            echo 'LISTING_JSON<<LISTING_JSON_EOF'
+            echo "$L"
+            echo 'LISTING_JSON_EOF'
+          } >> "$GITHUB_ENV"
+          echo "LISTING_ID=$ID" >> "$GITHUB_ENV"
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install deps + Chromium
+        if: steps.fetch.outputs.ready == 'true'
+        working-directory: tools/social
+        run: |
+          npm install
+          npx playwright install --with-deps chromium
+
+      - name: Render the card and its caption
+        id: render
+        if: steps.fetch.outputs.ready == 'true'
+        env:
+          LISTING_PHOTO: /tmp/listing-photo.jpg
+        run: |
+          IMG="marketing/instagram/market/${LISTING_ID}.jpg"
+          CAP="marketing/instagram/market/${LISTING_ID}.txt"
+          (cd tools/social && LISTING_OUT="$IMG" node listing-card.mjs)
+          if [ ! -f "$IMG" ] || [ ! -f "$CAP" ]; then
+            echo "::error::the renderer did not produce $IMG and $CAP."
+            exit 1
+          fi
+          echo "image=$IMG" >> "$GITHUB_OUTPUT"
+          {
+            echo 'caption<<LISTING_CAPTION_EOF'
+            cat "$CAP"
+            echo 'LISTING_CAPTION_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      # Committed because Meta fetches the image over HTTP at publish time and
+      # GitHub Pages serves the repo root — committing IS how it gets a public
+      # URL. Same mechanism the ad, deals and feature pipelines rely on.
+      - name: Commit the card
+        if: steps.fetch.outputs.ready == 'true'
+        env:
+          IMG: ${{ steps.render.outputs.image }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$IMG" "${IMG%.jpg}.txt"
+          if git diff --cached --quiet; then
+            echo "Card is unchanged since the last run — nothing to commit."
+          else
+            git commit -m "Listing card for $LISTING_ID [skip ci]"
+            # One retry: listings can be approved in bursts, and another
+            # pipeline (deals, features) may have pushed since checkout.
+            git push || { git pull --rebase && git push; }
+          fi
+
+      - name: Wait for Pages to serve it
+        if: steps.fetch.outputs.ready == 'true'
+        env:
+          IMG: ${{ steps.render.outputs.image }}
+        run: |
+          URL="$SITE/$IMG"
+          for i in $(seq 1 30); do
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -L "$URL" || true)
+            [ "$CODE" = "200" ] && { echo "Live: $URL"; exit 0; }
+            sleep 10
+          done
+          echo "::error::$URL did not become reachable within 5 minutes."
+          exit 1
+
+  publish:
+    needs: render
+    if: needs.render.outputs.ready == 'true' && inputs.dry_run != true
+    uses: ./.github/workflows/instagram-post.yml
+    secrets: inherit
+    with:
+      image: ${{ needs.render.outputs.image }}
+      caption: ${{ needs.render.outputs.caption }}

--- a/docs/MARKET.md
+++ b/docs/MARKET.md
@@ -130,7 +130,7 @@ and a listing with a photo and a price is already useful.
 | 5 | Розмір | buttons: XS S M L XL / «Пропустити» | — |
 | 6 | Стан | buttons: 10/10 … 6/10 / «Пропустити» | — |
 | 7 | Район і як забрати | free text / «Пропустити» | — |
-| 8 | Підтвердження | preview + «Опублікувати» | ✅ |
+| 8 | Підтвердження | preview + «Опублікувати» — and the line naming both surfaces (see [Instagram](#instagram--every-listing-mirrored)) | ✅ |
 
 `/cancel` exits at any step, and the hint repeats at every step — the bot
 already does this everywhere else.
@@ -214,6 +214,56 @@ tap changes anything the bot confirms the id is in the tapping user's own
 second tap on something already closed, gets «Це оголошення не ваше або вже
 закрите» and writes nothing.
 
+## Instagram — every listing mirrored
+
+Every approved listing also becomes its own Instagram post. Instagram cannot
+*be* the market — captions carry no clickable link, so nobody can tap through
+to a seller — but it is where people who have never heard of the channel are,
+and every card says where the market is in text they can retype.
+
+**The seller is told before they publish, not after.** The confirm step names
+both surfaces outright: «Після перевірки воно з'явиться в каналі та в Instagram
+(@secondhandlvivbot) — з фото, ціною і вашим @username». Instagram is a public
+feed outside Telegram and outside our control once posted; publishing there on
+the strength of «з'явиться в каналі» would be publishing something the seller
+did not agree to. That consent is recorded on the row as `ig_ok = 1`, written
+once at creation by the wizard that showed the line — so a listing made before
+the wizard said anything can never be mirrored, however the code later changes.
+
+**Two gates, both in the data**, checked by the workflow rather than assumed:
+
+| Gate | Meaning |
+| --- | --- |
+| `status = live` | The owner approved it. Same human gate as the channel post. |
+| `ig_ok = 1` | Its seller was told it goes to Instagram. |
+
+**A rendered card, not the raw photo.** Three reasons, each sufficient:
+Instagram accepts 4:5 to 1.91:1 and rejects everything else with a generic
+container error — a phone photo is routinely 9:16, so raw photos would fail on
+roughly every second listing, opaquely. A photo alone states no price, size or
+district, and the caption is not clickable, so what a reader needs has to be
+inside the image. And item photos sit in a feed of map posts: the frame, the
+channel handle and «Оголошення користувача · ми не беремо участі в угоді» are
+what tell a reader whose post this is. The photo itself is never cropped to
+fit — it is contained over a blurred copy of itself, because cropping a garment
+someone is trying to sell is the one failure that costs them the sale.
+
+**How it runs.** The bot approves and posts to the channel itself, then sends a
+`repository_dispatch` carrying the listing id and nothing else;
+`.github/workflows/market-listing-ig.yml` re-reads the listing from the metrics
+Worker, downloads the photo from Telegram, renders the card
+(`tools/social/listing-card.mjs`), commits it — GitHub Pages serving the repo
+root is how it gets the public URL Meta insists on fetching — and hands it to
+the existing `instagram-post.yml`. Instagram is deliberately last and
+best-effort: the channel is where the market lives, and a GitHub outage must
+not cost a listing its publication.
+
+**Known limit.** Instagram's publishing API allows 50 posts per rolling 24
+hours. Since there is no cap on listings, a day with more than fifty approvals
+would see the surplus fail in the workflow — the channel posts still go out,
+and the failures show as red runs. Not worth a retry queue at this size; worth
+knowing before it is.
+
 ## Anti-abuse
 
 Per the decision above, there is **no cap on how many listings a seller posts
@@ -260,12 +310,16 @@ CREATE TABLE IF NOT EXISTS listings (
   status          TEXT NOT NULL,   -- pending | live | sold | expired | rejected
   channel_msg_id  INTEGER,
   created_at      TEXT NOT NULL,
-  expires_at      TEXT NOT NULL
+  expires_at      TEXT NOT NULL,
+  nudged_at       TEXT,            -- set when the day-25 "ще актуально?" was sent
+  ig_ok           INTEGER          -- 1 = the seller was told it goes to Instagram
 );
 ```
 
 Photos are stored as Telegram `file_id`s, not re-hosted: Telegram keeps them,
-and the bot can re-send by id indefinitely.
+and the bot can re-send by id indefinitely. The Instagram mirror is the one
+thing that needs the bytes rather than the id, and it fetches them at post
+time from Telegram — nothing here re-hosts a seller's photo.
 
 ## What already exists and gets reused
 
@@ -289,6 +343,7 @@ a plausible quarter:
 📌 Барахолка Львів — правила
 
 1. Оголошення публікує лише бот: @Secondhandlvivbot → /sell
+   Схвалене оголошення йде в канал і в Instagram.
 2. Ми НЕ беремо участі в оплаті й НЕ гарантуємо угоди.
    Зустрічайтеся в людних місцях. Перевіряйте річ до оплати.
 3. Одна річ — одне оголошення. Скільки завгодно оголошень.

--- a/docs/SOCIAL_MEDIA.md
+++ b/docs/SOCIAL_MEDIA.md
@@ -19,8 +19,8 @@ above both: which channels, which content, in what order.
 
 | | Status |
 | --- | --- |
-| Instagram [@secondhandlvivbot](https://www.instagram.com/secondhandlvivbot/) | Two automatic posts/week (Monday deals ranking, Thursday store of the week), plus ~12 evergreen images posted by hand |
-| Telegram **channel** | ✅ **Live** at [@Lviv_Secondhand](https://t.me/Lviv_Secondhand) — two mirrored posts plus a channel-only daily restock line |
+| Instagram [@secondhandlvivbot](https://www.instagram.com/secondhandlvivbot/) | Two automatic posts/week (Monday deals ranking, Thursday store of the week), plus ~12 evergreen images posted by hand — **and now one post per approved барахолка listing** ([MARKET.md](MARKET.md#instagram--every-listing-mirrored)) |
+| Telegram **channel** | ✅ **Live** at [@Lviv_Secondhand](https://t.me/Lviv_Secondhand) — two mirrored posts, a channel-only daily restock line, and the барахолка |
 | Telegram **bot** | A product, not a channel — reaches people who already found us |
 | Web push | Built, opt-in, same problem: existing users only |
 | Facebook / TikTok / Threads / YouTube | Nothing |
@@ -96,6 +96,25 @@ that one post.
 
 **Watch out:** a channel that posts more than ~1×/day gets muted. Daily restock
 line + Monday ranking is about right; hold everything else.
+
+**The барахолка deliberately breaks that rule, on both surfaces.** Every
+approved listing is a channel post and now an Instagram post too
+([MARKET.md](MARKET.md#instagram--every-listing-mirrored)), and there is no cap
+on listings — that was decided outright. So the volume guidance above no longer
+holds for the channel, and the Instagram feed now mixes the map's own data
+posts with strangers' jackets. Both are real costs, taken knowingly, and both
+are measurable rather than matters of opinion:
+
+- **Channel:** subscriber count and the mute rate. If growth flattens or
+  reverses in a week where listings spiked, listings are the cause.
+- **Instagram:** saves and profile→link taps *on the map posts*, before and
+  after. Item posts earn less engagement than data posts, and Instagram ranks
+  an account partly on its recent average — so the risk is not that listings
+  underperform, it is that they drag the Monday ranking down with them.
+
+If either moves the wrong way, the fix is not to stop mirroring: it is to batch
+listings into one digest post per week and keep the per-item posts on the
+channel, where they cost nothing.
 
 ### B. Short video — the only real discovery surface
 

--- a/scripts/check-wiring.mjs
+++ b/scripts/check-wiring.mjs
@@ -39,6 +39,12 @@
 //      cheapText() reported days since the restock anchor without reducing
 //      modulo the cycle, inverting its own "longest since a restock" list.
 //
+//   8. Every repository_dispatch a Worker sends has a workflow listening.
+//      A Worker's dispatch returns 204 whether or not anything is subscribed:
+//      GitHub accepts the event and drops it. So a renamed event_type — or a
+//      workflow that never shipped — looks exactly like success from inside
+//      the Worker, and the feature silently does nothing forever.
+//
 // Exit code 1 on any violation.
 
 import fs from 'node:fs';
@@ -306,6 +312,32 @@ const errors = [];
       console.log('bot ranking: day-in-cycle, reduced modulo the cycle');
     }
   }
+}
+
+// ── 8 · every dispatched event_type has a listener ───────────────────────────
+{
+  // The Workers send repository_dispatch events to drive workflows they cannot
+  // run themselves (a map patch, an Instagram mirror). GitHub answers 204 for
+  // an event nobody listens for, so this mismatch is invisible at runtime.
+  const sent = new Set();
+  for (const [file, src] of [['worker/worker.js', worker], ['telegram-bot/worker.js', bot]]) {
+    for (const m of src.matchAll(/event_type:\s*'([^']+)'/g)) sent.add(`${m[1]}\u0000${file}`);
+  }
+  const listening = new Set();
+  for (const f of fs.readdirSync('.github/workflows')) {
+    const y = fs.readFileSync(`.github/workflows/${f}`, 'utf8');
+    // `types: [a, b]` under repository_dispatch. Read as text rather than
+    // parsed: check-workflows.mjs already proves these files are valid YAML.
+    const block = /repository_dispatch:\s*\n\s*types:\s*\[([^\]]*)\]/.exec(y);
+    if (block) for (const t of block[1].split(',')) listening.add(t.trim());
+  }
+  for (const entry of sent) {
+    const [type, file] = entry.split('\u0000');
+    if (!listening.has(type)) {
+      errors.push(`${file} dispatches event_type "${type}" but no workflow listens for it — GitHub would accept and drop it.`);
+    }
+  }
+  console.log(`dispatches: ${sent.size} sent, ${listening.size} listened for`);
 }
 
 if (errors.length) {

--- a/telegram-bot/worker.js
+++ b/telegram-bot/worker.js
@@ -3117,6 +3117,29 @@ function sellCard(d, username) {
   ].filter((x) => x !== null).join('\n');
 }
 
+// Asks GitHub to mirror one approved listing to Instagram
+// (.github/workflows/market-listing-ig.yml). Same repository_dispatch
+// mechanism as dispatchMapPatch, and deliberately the same shape: rendering a
+// 1080×1350 card needs a headless browser, which a Worker does not have, and
+// Instagram's API will only fetch a public URL, which GitHub Pages already
+// serves. The workflow re-reads the listing from the metrics Worker rather than
+// trusting anything in this payload — the id is all it needs, and all it gets.
+async function dispatchListingToInstagram(env, listingId) {
+  if (!env.GH_PAT) throw new Error('GH_PAT not configured');
+  const res = await fetch('https://api.github.com/repos/anonymouspartner/lviv-secondhand/dispatches', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${env.GH_PAT}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'lviv-secondhand-bot',
+    },
+    body: JSON.stringify({ event_type: 'listing_to_instagram', client_payload: { listing_id: listingId } }),
+  });
+  if (res.status !== 204) throw new Error(`dispatch failed: ${res.status}`);
+}
+
 // Every state change goes through the metrics Worker, which owns the table.
 async function sellApi(env, path, payload) {
   const res = await metricsFetch(env, path, {
@@ -3248,7 +3271,11 @@ async function handleSellFlow(env, c, msg, ctx) {
     await putSellSession(env, uid, session);
     const uname = (ctx.from && ctx.from.username) || '';
     await tg(env, 'sendPhoto', { chat_id: chatId, photo: d.photos[0], caption: sellCard(d, uname) });
-    await say(env, chatId, `Так виглядатиме оголошення. Публікуємо?\n\nПісля перевірки воно з’явиться в каналі.` + SELL_CANCEL_HINT, sellKb([[SELL_PUBLISH]]));
+    // Says both surfaces, here, where the seller is deciding — not in a rule
+    // post they will not read. Instagram is a public feed outside Telegram and
+    // outside our control once posted, so publishing there on the strength of
+    // "з’явиться в каналі" would be publishing something they did not agree to.
+    await say(env, chatId, `Так виглядатиме оголошення. Публікуємо?\n\nПісля перевірки воно з’явиться <b>в каналі та в Instagram</b> (@secondhandlvivbot) — з фото, ціною і вашим @${esc((ctx.from && ctx.from.username) || '')}.` + SELL_CANCEL_HINT, sellKb([[SELL_PUBLISH]]));
     return true;
   }
 
@@ -3259,6 +3286,10 @@ async function handleSellFlow(env, c, msg, ctx) {
       seller_id: String(uid), seller_username: uname, category: d.category,
       title: d.title, price_uah: d.price, size: d.size || null,
       condition: d.condition || null, area: d.area || null, photo_ids: d.photos,
+      // The seller saw the Instagram line one step ago. Stored on the row, so
+      // the mirror can tell a listing whose seller was told from one made
+      // before the wizard said anything.
+      ig_ok: 1,
     });
     if (!out || !out.ok) {
       // Never claim it was submitted when the call did not happen — the whole
@@ -3342,6 +3373,17 @@ async function handleSellCallback(env, c, cq) {
     const out = await sellApi(env, '/api/listing/status', { id, status: 'live', channel_msg_id: msgId });
     if (out && out.ok && out.listing) {
       await tg(env, 'sendMessage', { chat_id: out.listing.seller_id, text: `✅ Ваше оголошення опубліковано: ${out.listing.title}\n\nПродали — надішліть /sold.` });
+    }
+    // Instagram last, and only after the channel post is recorded: the channel
+    // is where the market actually lives, and a GitHub outage must not cost a
+    // listing its publication. Gated on ig_ok, which is set only by a wizard
+    // that showed the seller the Instagram line.
+    if (out && out.ok && out.listing && out.listing.ig_ok === 1) {
+      try {
+        await dispatchListingToInstagram(env, id);
+      } catch (e) {
+        await tg(env, 'sendMessage', { chat_id: c.ownerId, text: `📸 #${id} у каналі, але дзеркало в Instagram не запустилося (${String(e && e.message || e).slice(0, 80)}).\n\nЗапустіть вручну: Actions → Mirror a listing to Instagram.` });
+      }
     }
     await tg(env, 'editMessageReplyMarkup', { chat_id: cq.message.chat.id, message_id: cq.message.message_id, reply_markup: { inline_keyboard: [] } });
     return true;

--- a/tools/social/listing-card.mjs
+++ b/tools/social/listing-card.mjs
@@ -1,0 +1,195 @@
+// Renders one барахолка listing as a 1080×1350 Instagram card.
+//
+// WHY A RENDERED CARD RATHER THAN THE SELLER'S PHOTO
+// Three reasons, and each one alone would be enough:
+//
+//   * Aspect ratio. Instagram's publishing API accepts 4:5 to 1.91:1 and
+//     rejects anything else with a generic container error that names no
+//     cause. A phone photo is routinely 9:16 — every second listing would
+//     fail, opaquely. A fixed 1080×1350 frame makes that impossible.
+//   * The facts. A photo alone says nothing about price, size or where to
+//     collect it, and Instagram captions are not clickable — so whatever a
+//     reader needs has to be *in the image*.
+//   * Whose post this is. Item photos sit in a feed of map posts. The frame,
+//     the disclosure line and the channel handle are what tell a reader they
+//     are looking at somebody's jacket rather than at our data.
+//
+// The photo is never cropped to fit: it is contained inside the frame over a
+// blurred copy of itself. Cropping a garment someone is trying to sell is the
+// one failure mode that costs them the sale.
+//
+// NO FREE TEXT BEYOND THE WIZARD'S FIELDS. Everything on the card is either
+// fixed chrome or a field of the listing row, and the row was validated by the
+// metrics Worker before it ever became live. Same rule as store-feature.mjs.
+//
+// Inputs (env):
+//   LISTING_JSON    required — the listing row, as JSON
+//   LISTING_PHOTO   required — path to the seller's photo, already downloaded
+//   LISTING_OUT     optional — output path (default marketing/instagram/market/<id>.jpg)
+//
+// Writes the .jpg and a .txt caption beside it, and prints both paths.
+import { chromium } from 'playwright';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { C, CSS } from './brand.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../..');
+
+const W = 1080, H = 1350;
+const PHOTO_H = 920;
+const CHANNEL = 't.me/Lviv_Secondhand';
+
+const raw = process.env.LISTING_JSON;
+if (!raw) throw new Error('LISTING_JSON is required');
+const L = JSON.parse(raw);
+if (!L || typeof L.id !== 'string') throw new Error('LISTING_JSON has no id');
+
+const photoPath = process.env.LISTING_PHOTO;
+if (!photoPath) throw new Error('LISTING_PHOTO is required');
+
+// The same seven categories the bot offers and the Worker validates. Unknown
+// codes get no tag rather than an invented one.
+const CATEGORIES = {
+  women:       { label: 'Жіноче',    tag: '#жіноче' },
+  men:         { label: 'Чоловіче',  tag: '#чоловіче' },
+  shoes:       { label: 'Взуття',    tag: '#взуття' },
+  kids:        { label: 'Дитяче',    tag: '#дитяче' },
+  accessories: { label: 'Аксесуари', tag: '#аксесуари' },
+  sport:       { label: 'Спорт',     tag: '#спорт' },
+  other:       { label: 'Інше',      tag: '#інше' },
+};
+const cat = CATEGORIES[L.category] || null;
+
+const esc = (s) => String(s == null ? '' : s)
+  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+
+const title = String(L.title || '').trim();
+const price = Number(L.price_uah);
+if (!title || !Number.isFinite(price)) throw new Error(`listing ${L.id} has no title or price`);
+
+// Optional fields vanish when absent rather than printing «не вказано» — the
+// same rule the channel card follows.
+const spec = [
+  L.size ? `Розмір ${L.size}` : null,
+  L.condition ? `Стан ${L.condition}` : null,
+].filter(Boolean).join(' · ');
+
+// A long title at a fixed size wraps into the disclosure line. Ramp it, and let
+// the overflow assertion below catch anything the ramp does not.
+const titleSize = title.length <= 22 ? 62 : title.length <= 38 ? 50 : 42;
+
+const photo = 'data:image/jpeg;base64,' + readFileSync(resolve(process.cwd(), photoPath)).toString('base64');
+
+const page_html = `<!doctype html><html lang="uk"><head><meta charset="utf-8"><style>
+  ${CSS}
+  html,body{width:${W}px;height:${H}px;overflow:hidden;}
+  .card{width:${W}px;height:${H}px;display:flex;flex-direction:column;
+    background:${C.paper};color:${C.ink};}
+  /* The photo, whole. .fill is the same image blown up and blurred behind it,
+     so a portrait photo fills 1080px of width without a garment losing its
+     sleeves to a centre crop. */
+  .photo{position:relative;width:${W}px;height:${PHOTO_H}px;overflow:hidden;background:${C.ink};}
+  .photo .fill{position:absolute;inset:-60px;background-image:url('${photo}');
+    background-size:cover;background-position:center;filter:blur(38px) brightness(.55);}
+  .photo img{position:relative;width:100%;height:100%;object-fit:contain;}
+  /* Price as a slab on the photo: the one number a scroller stops for. */
+  .price{position:absolute;left:0;bottom:34px;background:${C.acid};color:${C.ink};
+    font-size:56px;padding:14px 30px 14px 40px;border-radius:0 6px 6px 0;}
+  .tag{position:absolute;right:34px;top:34px;background:rgba(13,44,26,.82);color:${C.paper};
+    font-size:22px;letter-spacing:.12em;padding:10px 18px;border-radius:4px;}
+  .info{flex:1;display:flex;flex-direction:column;padding:38px 56px 34px;gap:14px;}
+  .t{font-size:${titleSize}px;line-height:1.08;color:${C.ink};}
+  .s{font-size:27px;color:${C.ink2};}
+  .a{font-size:27px;color:${C.ink2};}
+  .who{margin-top:auto;font-size:31px;color:${C.green};}
+  .foot{display:flex;justify-content:space-between;align-items:baseline;gap:20px;
+    border-top:1px solid ${C.line};padding-top:18px;}
+  .foot .url{font-size:29px;letter-spacing:.02em;color:${C.green};}
+  /* Listings share a feed with the map's own posts and with paid store ads.
+     An unlabelled post is ambiguous rather than neutral, so it is labelled. */
+  .foot .dis{font-size:19px;color:${C.ink2};opacity:.85;text-align:right;}
+</style></head><body>
+  <div class="card">
+    <div class="photo">
+      <div class="fill"></div>
+      <img src="${photo}" alt="">
+      ${cat ? `<div class="tag display">${esc(cat.label)}</div>` : ''}
+      <div class="price display">${Math.round(price)} ₴</div>
+    </div>
+    <div class="info">
+      <div class="t display">${esc(title)}</div>
+      ${spec ? `<div class="s body">${esc(spec)}</div>` : ''}
+      ${L.area ? `<div class="a body">📍 ${esc(L.area)}</div>` : ''}
+      <div class="who body">Пишіть @${esc(L.seller_username)} у Telegram</div>
+      <div class="foot">
+        <span class="url display">${CHANNEL}</span>
+        <span class="dis body">Оголошення користувача.<br>Ми не беремо участі в угоді.</span>
+      </div>
+    </div>
+  </div>
+</body></html>`;
+
+const out = process.env.LISTING_OUT
+  ? resolve(repoRoot, process.env.LISTING_OUT)
+  : resolve(repoRoot, `marketing/instagram/market/${L.id}.jpg`);
+mkdirSync(dirname(out), { recursive: true });
+
+const browser = await chromium.launch({ executablePath: process.env.CHROMIUM_PATH || undefined });
+const page = await browser.newPage({ viewport: { width: W, height: H }, deviceScaleFactor: 1 });
+await page.setContent(page_html, { waitUntil: 'networkidle' });
+
+// Same assertion store-feature.mjs makes, and for the same reason: the
+// screenshot crops silently, so a title one line too long would produce a
+// plausible card with the disclosure line missing. Text boxes are inflated by
+// 0.2em first — Oswald's Cyrillic diacritics (Й, Ї, Є) paint above the em box.
+const overflow = await page.evaluate(() => {
+  const info = document.querySelector('.info');
+  const box = info.getBoundingClientRect();
+  const bad = [];
+  if (info.scrollHeight > info.clientHeight + 1) {
+    bad.push(`the text block is ${info.scrollHeight - info.clientHeight}px taller than the space under the photo`);
+  }
+  for (const el of document.querySelectorAll('.info .t, .info .s, .info .a, .info .who, .foot .url, .foot .dis')) {
+    const r = el.getBoundingClientRect();
+    const pad = parseFloat(getComputedStyle(el).fontSize) * 0.2;
+    const label = (el.textContent || '').trim().slice(0, 40);
+    if (r.top - pad < box.top || r.bottom + pad > box.bottom) bad.push(`"${label}" reaches the edge of the text block`);
+    if (r.left < box.left - 1 || r.right > box.right + 1) bad.push(`"${label}" reaches the left/right edge`);
+  }
+  return bad;
+});
+if (overflow.length) {
+  await browser.close();
+  throw new Error(`layout does not fit for listing ${L.id}:\n  - ` + overflow.join('\n  - '));
+}
+
+// JPEG only — Instagram's publishing API rejects PNG.
+writeFileSync(out, await page.locator('.card').screenshot({ type: 'jpeg', quality: 90 }));
+await browser.close();
+
+// Instagram captions are not clickable, so the caption's job is to say where
+// the market is in text a reader can retype, and to carry the same disclosure
+// the card does — a caption is what gets read when the image is scrolled past.
+const caption = [
+  title,
+  `${Math.round(price)} ₴`,
+  spec || null,
+  L.area ? `📍 ${L.area}` : null,
+  '',
+  `Пишіть @${L.seller_username} у Telegram.`,
+  '',
+  `Уся барахолка — ${CHANNEL}`,
+  'Оголошення користувача · ми не беремо участі в угоді й не гарантуємо її.',
+  '',
+  ['#барахолка', '#секондхендльвів', '#львів', cat ? cat.tag : null, '#lviv', '#thrifted', '#вінтаж']
+    .filter(Boolean).join(' '),
+].filter((l) => l !== null).join('\n');
+
+const capPath = out.replace(/\.jpg$/, '.txt');
+writeFileSync(capPath, caption + '\n');
+
+console.log(out.replace(repoRoot + '/', ''));
+console.log(capPath.replace(repoRoot + '/', ''));

--- a/tools/social/package.json
+++ b/tools/social/package.json
@@ -17,7 +17,8 @@
     "stories": "node stories.mjs",
     "ad": "node ad-image.mjs",
     "pick-feature": "node pick-feature.mjs",
-    "restock-tomorrow": "node restock-tomorrow.mjs"
+    "restock-tomorrow": "node restock-tomorrow.mjs",
+    "listing-card": "node listing-card.mjs"
   },
   "dependencies": {
     "playwright": "^1.48.0",

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -184,7 +184,7 @@ async function ensureSchema(env) {
   // a Worker fetching another Worker on the same zone by its public URL gets
   // 404 / error 1042.
   await env.DB.prepare(
-    "CREATE TABLE IF NOT EXISTS listings (id TEXT PRIMARY KEY, seller_id TEXT NOT NULL, seller_username TEXT NOT NULL, category TEXT NOT NULL, title TEXT NOT NULL, price_uah INTEGER NOT NULL, size TEXT, condition TEXT, area TEXT, photo_ids TEXT NOT NULL, status TEXT NOT NULL, channel_msg_id INTEGER, created_at TEXT NOT NULL, expires_at TEXT NOT NULL, nudged_at TEXT)"
+    "CREATE TABLE IF NOT EXISTS listings (id TEXT PRIMARY KEY, seller_id TEXT NOT NULL, seller_username TEXT NOT NULL, category TEXT NOT NULL, title TEXT NOT NULL, price_uah INTEGER NOT NULL, size TEXT, condition TEXT, area TEXT, photo_ids TEXT NOT NULL, status TEXT NOT NULL, channel_msg_id INTEGER, created_at TEXT NOT NULL, expires_at TEXT NOT NULL, nudged_at TEXT, ig_ok INTEGER)"
   ).run();
   // The sweep runs every five minutes and asks exactly one question — which
   // live listings are due — so it gets the index that answers it. Without this
@@ -197,6 +197,12 @@ async function ensureSchema(env) {
   // must, and it throws harmlessly once the column is there. Same shape as the
   // promos.cust_id migration.
   try { await env.DB.prepare('ALTER TABLE events ADD COLUMN src TEXT').run(); } catch {}
+  // `ig_ok` records that the seller was told, at the moment they published,
+  // that the listing also goes to Instagram. It is deliberately a stored fact
+  // rather than a config flag: rows created before the wizard said so have no
+  // 1 in this column and can never be mirrored, however the code later
+  // changes. Same migration shape as events.src above.
+  try { await env.DB.prepare('ALTER TABLE listings ADD COLUMN ig_ok INTEGER').run(); } catch {}
   _schemaReady = true;
 }
 
@@ -2107,13 +2113,17 @@ export default {
       }
       await ensureSchema(env);
       const id = crypto.randomUUID().slice(0, 8);
+      // Only the caller that actually showed the seller the Instagram line can
+      // set this, and it is written once at creation — nothing downstream can
+      // turn a listing into an Instagram post after the fact.
+      const igOk = b.ig_ok === true || b.ig_ok === 1 ? 1 : 0;
       await env.DB.prepare(
-        'INSERT INTO listings (id, seller_id, seller_username, category, title, price_uah, size, condition, area, photo_ids, status, created_at, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+        'INSERT INTO listings (id, seller_id, seller_username, category, title, price_uah, size, condition, area, photo_ids, status, created_at, expires_at, ig_ok) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
       ).bind(
         id, b.seller_id, cleanText(b.seller_username, 32), b.category,
         cleanText(b.title, 60), Math.round(price),
         cleanText(b.size, 12) || null, cleanText(b.condition, 12) || null, cleanText(b.area, 60) || null,
-        JSON.stringify(photos), 'pending', kyivDateStr(), isoDaysFromNow(LISTING_TTL_DAYS)
+        JSON.stringify(photos), 'pending', kyivDateStr(), isoDaysFromNow(LISTING_TTL_DAYS), igOk
       ).run();
       return json({ ok: true, id }, 200, origin);
     }
@@ -2143,6 +2153,20 @@ export default {
       await env.DB.prepare('UPDATE listings SET status = ?, channel_msg_id = ?, expires_at = ? WHERE id = ?')
         .bind(status, msgId, expires, id).run();
       return json({ ok: true, id, status, listing: { ...row, status, channel_msg_id: msgId, expires_at: expires } }, 200, origin);
+    }
+
+    // ── Барахолка: one listing, by id ─────────────────────────────────────
+    // For the Instagram mirror, which runs in GitHub Actions rather than in a
+    // Worker and so has no service binding — it authenticates with ADMIN_KEY
+    // like every other caller here. Read-only on purpose: the workflow renders
+    // and posts, it never changes a listing's state.
+    if (url.pathname === '/api/listing/get') {
+      if (!env.ADMIN_KEY || (body && body.key) !== env.ADMIN_KEY) return json({ ok: false }, 401, origin);
+      if (typeof (body && body.id) !== 'string') return json({ ok: false, reason: 'bad_request' }, 400, origin);
+      await ensureSchema(env);
+      const row = await env.DB.prepare('SELECT * FROM listings WHERE id = ?').bind(body.id).first();
+      if (!row) return json({ ok: false, reason: 'not_found' }, 404, origin);
+      return json({ ok: true, listing: row }, 200, origin);
     }
 
     // ── Барахолка: one seller's listings, for /my ──────────────────────────


### PR DESCRIPTION
The барахолка lived only in Telegram, which reaches people who already found us. Every approved listing now also becomes its own Instagram post.

## What the seller agrees to

The confirm step names both surfaces **before** they publish: «Після перевірки воно з'явиться **в каналі та в Instagram** (@secondhandlvivbot) — з фото, ціною і вашим @username».

Instagram is a public feed outside Telegram and outside our control once posted; publishing there on the strength of «з'явиться в каналі» would be publishing something the seller did not agree to. That consent is stored on the row as `ig_ok`, written once at creation by the wizard that showed the line — so a listing made before the wizard said anything can never be mirrored, however the code later changes.

Two gates, both checked in the data by the workflow rather than assumed:

| Gate | Meaning |
| --- | --- |
| `status = live` | The owner approved it — the same human gate as the channel post |
| `ig_ok = 1` | Its seller was told it goes to Instagram |

## A rendered card, not the raw photo

Three reasons, each sufficient on its own:

- **Aspect ratio.** Instagram accepts 4:5 to 1.91:1 and rejects everything else with a generic container error naming no cause. A phone photo is routinely 9:16, so raw photos would fail on roughly every second listing, opaquely.
- **The facts.** A photo alone states no price, size or district, and Instagram captions are not clickable — so what a reader needs has to be *inside the image*.
- **Whose post this is.** Item photos sit in a feed of map posts. The frame, the channel handle and «Оголошення користувача · ми не беремо участі в угоді» are what tell a reader they are looking at somebody's jacket rather than at our data.

The photo is never cropped to fit: it is contained over a blurred copy of itself. Cropping a garment someone is trying to sell is the one failure mode that costs them the sale.

## How it runs

The bot approves and posts to the channel itself, then sends a `repository_dispatch` carrying the listing id and nothing else. `market-listing-ig.yml` re-reads the row from the metrics Worker, fetches the photo from Telegram, renders the card, commits it (Pages serving the repo root is how Meta gets a URL to fetch) and hands off to the existing `instagram-post.yml`. A Worker has neither a headless browser nor a public image host, which is why this is a workflow at all.

Instagram is deliberately last and best-effort: the channel is where the market lives, and a GitHub outage must not cost a listing its publication — the owner is told instead.

## New CI check

`check-wiring` gains an eighth check: every `repository_dispatch` a Worker sends has a workflow listening for it. GitHub answers `204` for an event nobody subscribes to, so a renamed `event_type` looks exactly like success from inside the Worker and the feature silently does nothing forever. Verified against both a typo'd and a plausibly-renamed event type.

## Verification

**Renderer**, six listings: tall/wide/square photos, a 60-character title, a listing with no optional fields at all, an unknown category, and one whose title, username and district are full of HTML and a `<script>` tag (rendered as text). The layout assertion is `store-feature.mjs`'s, because the screenshot crops silently.

**Bot, end to end** (KV, metrics Worker, Telegram and GitHub stubbed): the create call carries `ig_ok`, an approved told listing dispatches exactly one event with the right payload, a not-told one dispatches none, and with GitHub returning 500 the channel post and the seller's confirmation still stand while the owner is told the mirror did not start.

**SQL** against real SQLite: DDL, migration and the 14-column INSERT, in both a database that predates `ig_ok` and a fresh one.

Local CI green: `validate-stores`, `check-inline-js`, `check-wiring`, `check-workflows`, `check-init-data`, `node --check` on both Workers.

## Known limit

Instagram's publishing API allows 50 posts per rolling 24 hours. With no cap on listings, a day with more than fifty approvals would see the surplus fail in the workflow — the channel posts still go out. Documented rather than queued; not worth a retry queue at this size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gz9PPbPRjgz5dbWsr9jpvn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gz9PPbPRjgz5dbWsr9jpvn)_