### PR TITLE
Check the right that actually grants pinning in a channel

### DIFF
--- a/.github/workflows/channel-rules.yml
+++ b/.github/workflows/channel-rules.yml
@@ -79,7 +79,8 @@ jobs:
             echo "::error::Cannot resolve $TG_CHANNEL: $(echo "$CHAT" | jq -c '.description // .')"
             exit 1
           fi
-          echo "Channel resolved: $(echo "$CHAT" | jq -r '.result.title') ($TG_CHANNEL)"
+          CHAT_TYPE=$(echo "$CHAT" | jq -r '.result.type // empty')
+          echo "Channel resolved: $(echo "$CHAT" | jq -r '.result.title') ($TG_CHANNEL, type $CHAT_TYPE)"
           # Reported, not enforced: without a linked discussion group there are
           # no comments under a post, which is why the rules name the seller.
           LINKED=$(echo "$CHAT" | jq -r '.result.linked_chat_id // empty')
@@ -89,16 +90,34 @@ jobs:
                  --data-urlencode "chat_id=$TG_CHANNEL" \
                  --data-urlencode "user_id=$(curl -s "$API/getMe" | jq -r '.result.id')")
           CAN_POST=$(echo "$ME" | jq -r '.result.can_post_messages // false')
-          CAN_PIN=$(echo "$ME" | jq -r '.result.can_pin_messages // false')
           if [ "$CAN_POST" != "true" ]; then
             echo "::error::@$NAME cannot post in $TG_CHANNEL. Make it an administrator with 'Post messages'."
             exit 1
           fi
+
+          # WHICH FIELD GRANTS PINNING DEPENDS ON THE CHAT TYPE, and getting this
+          # wrong reads as a missing permission that cannot be granted. The Bot
+          # API is explicit: can_pin_messages is "for groups and supergroups
+          # only", can_edit_messages is "True, if the administrator can edit
+          # messages of other users AND CAN PIN MESSAGES; for channels only",
+          # and pinChatMessage wants "the 'can_pin_messages' right or the
+          # 'can_edit_messages' right to pin messages in groups and channels
+          # respectively". So a channel admin never reports can_pin_messages at
+          # all — checking it sent the owner looking for a toggle Telegram does
+          # not show for channels, while the bot already had the right.
+          if [ "$CHAT_TYPE" = "channel" ]; then
+            PIN_FIELD="can_edit_messages"
+            PIN_LABEL="Edit Messages (which is what grants pinning in a channel)"
+          else
+            PIN_FIELD="can_pin_messages"
+            PIN_LABEL="Pin Messages"
+          fi
+          CAN_PIN=$(echo "$ME" | jq -r --arg f "$PIN_FIELD" '.result[$f] // false')
           if [ "$CAN_PIN" != "true" ]; then
-            echo "::error::@$NAME can post in $TG_CHANNEL but cannot pin. Grant 'Pin messages' in the channel's administrator settings and re-run — posting an unpinned copy would leave a stray message to delete."
+            echo "::error::@$NAME can post in $TG_CHANNEL but $PIN_FIELD is not set. Grant '$PIN_LABEL' in the administrator settings and re-run — posting an unpinned copy would leave a stray message to delete."
             exit 1
           fi
-          echo "Rights confirmed: post ✓ pin ✓"
+          echo "Rights confirmed: post ✓ pin ✓ (via $PIN_FIELD)"
 
           if [ "$DRY_RUN" = "true" ]; then
             {

--- a/docs/MARKET.md
+++ b/docs/MARKET.md
@@ -343,6 +343,13 @@ Posted and pinned by `.github/workflows/channel-rules.yml`, which reads the
 block below rather than a copy — so the pinned post and this document cannot
 drift. Re-run it after editing the block.
 
+Pinning in a **channel** is granted by `can_edit_messages`, not
+`can_pin_messages`: the Bot API says the latter is "for groups and supergroups
+only", and describes the former as "can edit messages of other users **and can
+pin messages**; for channels only". A channel admin therefore never reports
+`can_pin_messages`, and a pre-flight that checks it refuses every channel while
+telling the owner to grant a right Telegram does not offer for channels.
+
 The last line names the seller rather than the comments, because the channel
 has **no linked discussion group**: there are no comments under a channel post
 until one is linked, and the seller's `@username` is the only contact by


### PR DESCRIPTION
The rules pre-flight refused with `@Secondhandlvivbot can post in @Lviv_Secondhand but cannot pin` on a bot that **already had the right**, and sent the owner looking for a toggle Telegram does not show for channels.

## The bug

`can_pin_messages` is, in the Bot API's own words, *"for groups and supergroups only"* — a channel administrator never reports it, so the check was `false` whatever the settings said.

What grants pinning in a channel is `can_edit_messages`: *"True, if the administrator can edit messages of other users **and can pin messages**; for channels only"*. `pinChatMessage` says it outright: *"the bot must be an administrator with the 'can_pin_messages' right or the 'can_edit_messages' right to pin messages in **groups and channels respectively**"*.

## The fix

The field is chosen by the chat type `getChat` reports, and the failure message names the right by the label Telegram actually shows for that chat type — "Edit Messages (which is what grants pinning in a channel)" rather than a "Pin messages" toggle that isn't there. The success line says which field was consulted, so anyone reading a future refusal can tell whether it's this bug again.

## Verification

Against the three real `getChatMember` shapes:

| Case | Field checked | Result |
| --- | --- | --- |
| Channel admin, post + edit + delete | `can_edit_messages` | ✅ passes |
| Channel admin, post but no edit | `can_edit_messages` | ❌ correctly refused |
| Supergroup admin with pin | `can_pin_messages` | ✅ passes |

The old check returns `false` for the first of those — which is the whole bug.

Local CI green: `validate-stores`, `check-inline-js`, `check-wiring`, `check-workflows`, `check-init-data`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gz9PPbPRjgz5dbWsr9jpvn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gz9PPbPRjgz5dbWsr9jpvn)_